### PR TITLE
feat: first-party Chrome subsystem skeleton (#4)

### DIFF
--- a/src/browser/common.rs
+++ b/src/browser/common.rs
@@ -1,0 +1,508 @@
+//! Cross-platform Chromium browser paths + identifiers for the first-party
+//! Chrome integration ("Claude in Chrome").
+//!
+//! The `ChromiumBrowser` enum enumerates every browser we know how to find on
+//! disk. Each browser has per-platform data paths (for extension detection)
+//! and per-platform native-messaging-host paths (for installing the native
+//! host manifest). Windows uses registry keys instead of file locations for
+//! native messaging discovery — those live here too.
+//!
+//! Mirrors `claude-code-bun/src/utils/claudeInChrome/common.ts` + `setupPortable.ts`.
+//!
+//! Nothing in this file performs I/O; detection and manifest install live in
+//! `setup.rs`. This keeps the table pure so tests can reason about it without
+//! touching the real filesystem.
+
+use std::path::PathBuf;
+
+/// Chromium-based browsers cc-rust knows how to find and talk to.
+///
+/// Ordered by popularity — callers that want "the first browser we can see"
+/// should iterate in [`BROWSER_DETECTION_ORDER`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ChromiumBrowser {
+    Chrome,
+    Brave,
+    Arc,
+    Chromium,
+    Edge,
+    Vivaldi,
+    Opera,
+}
+
+impl ChromiumBrowser {
+    /// Human-readable name (e.g. `"Google Chrome"`).
+    pub fn display_name(self) -> &'static str {
+        match self {
+            ChromiumBrowser::Chrome => "Google Chrome",
+            ChromiumBrowser::Brave => "Brave",
+            ChromiumBrowser::Arc => "Arc",
+            ChromiumBrowser::Chromium => "Chromium",
+            ChromiumBrowser::Edge => "Microsoft Edge",
+            ChromiumBrowser::Vivaldi => "Vivaldi",
+            ChromiumBrowser::Opera => "Opera",
+        }
+    }
+
+    /// Short identifier used in logs and config (e.g. `"chrome"`).
+    pub fn slug(self) -> &'static str {
+        match self {
+            ChromiumBrowser::Chrome => "chrome",
+            ChromiumBrowser::Brave => "brave",
+            ChromiumBrowser::Arc => "arc",
+            ChromiumBrowser::Chromium => "chromium",
+            ChromiumBrowser::Edge => "edge",
+            ChromiumBrowser::Vivaldi => "vivaldi",
+            ChromiumBrowser::Opera => "opera",
+        }
+    }
+}
+
+/// Iteration order for "first available browser" lookups. Mirrors
+/// the bun version's `BROWSER_DETECTION_ORDER`.
+pub const BROWSER_DETECTION_ORDER: &[ChromiumBrowser] = &[
+    ChromiumBrowser::Chrome,
+    ChromiumBrowser::Brave,
+    ChromiumBrowser::Arc,
+    ChromiumBrowser::Edge,
+    ChromiumBrowser::Chromium,
+    ChromiumBrowser::Vivaldi,
+    ChromiumBrowser::Opera,
+];
+
+// ---------------------------------------------------------------------------
+// Native host identifier + extension IDs
+// ---------------------------------------------------------------------------
+
+/// Native messaging host identifier written into the manifest `name` field.
+/// Must match the ID hard-coded in the Anthropic Chrome extension.
+pub const NATIVE_HOST_IDENTIFIER: &str = "com.anthropic.claude_code_browser_extension";
+
+/// Production extension ID (distributed via the Chrome Web Store).
+pub const PROD_EXTENSION_ID: &str = "fcoeoabgfenejglbffodgkkbkcdhcgfn";
+
+/// Development extension ID (internal Anthropic builds).
+pub const DEV_EXTENSION_ID: &str = "dihbgbndebgnbjfmelmegjepbnkhlgni";
+
+/// Anthropic-internal extension ID.
+pub const ANT_EXTENSION_ID: &str = "dngcpimnedloihjnnfngkgjoidhnaolf";
+
+/// Chrome Web Store URL for end users to install the extension.
+pub const CHROME_EXTENSION_URL: &str = "https://claude.ai/chrome";
+
+/// Reconnect URL the browser opens after native host install.
+pub const CHROME_RECONNECT_URL: &str = "https://clau.de/chrome/reconnect";
+
+/// Permissions management URL.
+pub const CHROME_PERMISSIONS_URL: &str = "https://clau.de/chrome/permissions";
+
+/// Extension IDs we look for when detecting installation.
+///
+/// Dev and Ant IDs are only returned when `USER_TYPE=ant` (internal builds),
+/// matching the bun behavior. End-user builds only match the prod ID.
+pub fn extension_ids() -> Vec<&'static str> {
+    if std::env::var("USER_TYPE").as_deref() == Ok("ant") {
+        vec![PROD_EXTENSION_ID, DEV_EXTENSION_ID, ANT_EXTENSION_ID]
+    } else {
+        vec![PROD_EXTENSION_ID]
+    }
+}
+
+/// MCP server name under which the first-party Chrome bridge registers its
+/// tools. Tools appear to the model as `mcp__claude-in-chrome__*`.
+pub const CLAUDE_IN_CHROME_MCP_SERVER_NAME: &str = "claude-in-chrome";
+
+// ---------------------------------------------------------------------------
+// Per-platform, per-browser config tables
+// ---------------------------------------------------------------------------
+
+/// Home-relative path segments for browser user data + native messaging.
+///
+/// Every field is used on *some* platform via the cfg-gated path helpers
+/// below, but the dead-code lint can only see one platform's usage at a
+/// time. Allowed explicitly so we don't have to carry per-field cfg attrs.
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
+struct BrowserConfig {
+    macos_app_bundle: &'static str,
+    macos_data: &'static [&'static str],
+    macos_native_messaging: &'static [&'static str],
+    linux_binaries: &'static [&'static str],
+    linux_data: &'static [&'static str],
+    linux_native_messaging: &'static [&'static str],
+    windows_data: &'static [&'static str],
+    windows_registry_key: &'static str,
+    /// Opera uses `AppData/Roaming` instead of `AppData/Local`.
+    windows_use_roaming: bool,
+}
+
+fn config_for(browser: ChromiumBrowser) -> BrowserConfig {
+    match browser {
+        ChromiumBrowser::Chrome => BrowserConfig {
+            macos_app_bundle: "Google Chrome",
+            macos_data: &["Library", "Application Support", "Google", "Chrome"],
+            macos_native_messaging: &[
+                "Library",
+                "Application Support",
+                "Google",
+                "Chrome",
+                "NativeMessagingHosts",
+            ],
+            linux_binaries: &["google-chrome", "google-chrome-stable"],
+            linux_data: &[".config", "google-chrome"],
+            linux_native_messaging: &[".config", "google-chrome", "NativeMessagingHosts"],
+            windows_data: &["Google", "Chrome", "User Data"],
+            windows_registry_key: r"Software\Google\Chrome\NativeMessagingHosts",
+            windows_use_roaming: false,
+        },
+        ChromiumBrowser::Brave => BrowserConfig {
+            macos_app_bundle: "Brave Browser",
+            macos_data: &[
+                "Library",
+                "Application Support",
+                "BraveSoftware",
+                "Brave-Browser",
+            ],
+            macos_native_messaging: &[
+                "Library",
+                "Application Support",
+                "BraveSoftware",
+                "Brave-Browser",
+                "NativeMessagingHosts",
+            ],
+            linux_binaries: &["brave-browser", "brave"],
+            linux_data: &[".config", "BraveSoftware", "Brave-Browser"],
+            linux_native_messaging: &[
+                ".config",
+                "BraveSoftware",
+                "Brave-Browser",
+                "NativeMessagingHosts",
+            ],
+            windows_data: &["BraveSoftware", "Brave-Browser", "User Data"],
+            windows_registry_key: r"Software\BraveSoftware\Brave-Browser\NativeMessagingHosts",
+            windows_use_roaming: false,
+        },
+        ChromiumBrowser::Arc => BrowserConfig {
+            macos_app_bundle: "Arc",
+            macos_data: &["Library", "Application Support", "Arc", "User Data"],
+            macos_native_messaging: &[
+                "Library",
+                "Application Support",
+                "Arc",
+                "User Data",
+                "NativeMessagingHosts",
+            ],
+            linux_binaries: &[],
+            linux_data: &[],
+            linux_native_messaging: &[],
+            windows_data: &["Arc", "User Data"],
+            windows_registry_key: r"Software\ArcBrowser\Arc\NativeMessagingHosts",
+            windows_use_roaming: false,
+        },
+        ChromiumBrowser::Chromium => BrowserConfig {
+            macos_app_bundle: "Chromium",
+            macos_data: &["Library", "Application Support", "Chromium"],
+            macos_native_messaging: &[
+                "Library",
+                "Application Support",
+                "Chromium",
+                "NativeMessagingHosts",
+            ],
+            linux_binaries: &["chromium", "chromium-browser"],
+            linux_data: &[".config", "chromium"],
+            linux_native_messaging: &[".config", "chromium", "NativeMessagingHosts"],
+            windows_data: &["Chromium", "User Data"],
+            windows_registry_key: r"Software\Chromium\NativeMessagingHosts",
+            windows_use_roaming: false,
+        },
+        ChromiumBrowser::Edge => BrowserConfig {
+            macos_app_bundle: "Microsoft Edge",
+            macos_data: &["Library", "Application Support", "Microsoft Edge"],
+            macos_native_messaging: &[
+                "Library",
+                "Application Support",
+                "Microsoft Edge",
+                "NativeMessagingHosts",
+            ],
+            linux_binaries: &["microsoft-edge", "microsoft-edge-stable"],
+            linux_data: &[".config", "microsoft-edge"],
+            linux_native_messaging: &[".config", "microsoft-edge", "NativeMessagingHosts"],
+            windows_data: &["Microsoft", "Edge", "User Data"],
+            windows_registry_key: r"Software\Microsoft\Edge\NativeMessagingHosts",
+            windows_use_roaming: false,
+        },
+        ChromiumBrowser::Vivaldi => BrowserConfig {
+            macos_app_bundle: "Vivaldi",
+            macos_data: &["Library", "Application Support", "Vivaldi"],
+            macos_native_messaging: &[
+                "Library",
+                "Application Support",
+                "Vivaldi",
+                "NativeMessagingHosts",
+            ],
+            linux_binaries: &["vivaldi", "vivaldi-stable"],
+            linux_data: &[".config", "vivaldi"],
+            linux_native_messaging: &[".config", "vivaldi", "NativeMessagingHosts"],
+            windows_data: &["Vivaldi", "User Data"],
+            windows_registry_key: r"Software\Vivaldi\NativeMessagingHosts",
+            windows_use_roaming: false,
+        },
+        ChromiumBrowser::Opera => BrowserConfig {
+            macos_app_bundle: "Opera",
+            macos_data: &[
+                "Library",
+                "Application Support",
+                "com.operasoftware.Opera",
+            ],
+            macos_native_messaging: &[
+                "Library",
+                "Application Support",
+                "com.operasoftware.Opera",
+                "NativeMessagingHosts",
+            ],
+            linux_binaries: &["opera"],
+            linux_data: &[".config", "opera"],
+            linux_native_messaging: &[".config", "opera", "NativeMessagingHosts"],
+            windows_data: &["Opera Software", "Opera Stable"],
+            windows_registry_key: r"Software\Opera Software\Opera Stable\NativeMessagingHosts",
+            windows_use_roaming: true,
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+/// A browser's on-disk user-data directory (where profiles and Extensions live).
+#[derive(Debug, Clone)]
+pub struct BrowserDataPath {
+    pub browser: ChromiumBrowser,
+    pub path: PathBuf,
+}
+
+/// A browser's native-messaging-hosts directory (where the manifest is written).
+#[derive(Debug, Clone)]
+pub struct NativeMessagingPath {
+    pub browser: ChromiumBrowser,
+    pub path: PathBuf,
+}
+
+/// A Windows registry key entry for native host discovery.
+#[derive(Debug, Clone)]
+pub struct WindowsRegistryKey {
+    pub browser: ChromiumBrowser,
+    /// Path under HKCU (without the `HKCU\\` prefix).
+    pub key: String,
+}
+
+fn home_dir() -> Option<PathBuf> {
+    dirs::home_dir()
+}
+
+#[cfg(target_os = "windows")]
+fn appdata_base(use_roaming: bool) -> Option<PathBuf> {
+    let home = home_dir()?;
+    if use_roaming {
+        Some(home.join("AppData").join("Roaming"))
+    } else {
+        Some(home.join("AppData").join("Local"))
+    }
+}
+
+/// Build the platform-appropriate user-data directory path for a single
+/// browser. Returns `None` if the browser isn't supported on this platform
+/// (e.g. Arc on Linux).
+pub fn data_path_for(browser: ChromiumBrowser) -> Option<PathBuf> {
+    let cfg = config_for(browser);
+
+    #[cfg(target_os = "macos")]
+    {
+        if cfg.macos_data.is_empty() {
+            return None;
+        }
+        let mut p = home_dir()?;
+        for seg in cfg.macos_data {
+            p.push(seg);
+        }
+        Some(p)
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        if cfg.linux_data.is_empty() {
+            return None;
+        }
+        let mut p = home_dir()?;
+        for seg in cfg.linux_data {
+            p.push(seg);
+        }
+        Some(p)
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if cfg.windows_data.is_empty() {
+            return None;
+        }
+        let mut p = appdata_base(cfg.windows_use_roaming)?;
+        for seg in cfg.windows_data {
+            p.push(seg);
+        }
+        Some(p)
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        let _ = cfg;
+        None
+    }
+}
+
+/// Build the native-messaging-hosts directory for a single browser on the
+/// current platform. Returns `None` on Windows (Windows uses registry, not a
+/// file path) and on platforms where the browser isn't supported.
+pub fn native_messaging_path_for(browser: ChromiumBrowser) -> Option<PathBuf> {
+    let cfg = config_for(browser);
+
+    #[cfg(target_os = "macos")]
+    {
+        if cfg.macos_native_messaging.is_empty() {
+            return None;
+        }
+        let mut p = home_dir()?;
+        for seg in cfg.macos_native_messaging {
+            p.push(seg);
+        }
+        Some(p)
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        if cfg.linux_native_messaging.is_empty() {
+            return None;
+        }
+        let mut p = home_dir()?;
+        for seg in cfg.linux_native_messaging {
+            p.push(seg);
+        }
+        Some(p)
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        // Windows uses a single shared manifest directory pointed at by registry.
+        let _ = cfg;
+        None
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        let _ = cfg;
+        None
+    }
+}
+
+/// Enumerate every supported browser's user-data path on the current platform.
+pub fn all_browser_data_paths() -> Vec<BrowserDataPath> {
+    BROWSER_DETECTION_ORDER
+        .iter()
+        .filter_map(|&browser| {
+            data_path_for(browser).map(|path| BrowserDataPath { browser, path })
+        })
+        .collect()
+}
+
+/// Enumerate every supported browser's native-messaging-hosts directory on
+/// the current platform. Empty on Windows (registry is used instead).
+pub fn all_native_messaging_paths() -> Vec<NativeMessagingPath> {
+    BROWSER_DETECTION_ORDER
+        .iter()
+        .filter_map(|&browser| {
+            native_messaging_path_for(browser)
+                .map(|path| NativeMessagingPath { browser, path })
+        })
+        .collect()
+}
+
+/// Enumerate every supported browser's Windows registry key (empty on non-Windows).
+pub fn all_windows_registry_keys() -> Vec<WindowsRegistryKey> {
+    BROWSER_DETECTION_ORDER
+        .iter()
+        .map(|&browser| {
+            let cfg = config_for(browser);
+            WindowsRegistryKey {
+                browser,
+                key: cfg.windows_registry_key.to_string(),
+            }
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Platform capability
+// ---------------------------------------------------------------------------
+
+/// Whether the first-party Chrome integration is supported on the current OS.
+///
+/// Supported: macOS, Linux, Windows. Everything else (non-WSL BSD, etc.)
+/// returns `false` and the `/chrome` command should tell the user so.
+pub fn supports_claude_in_chrome() -> bool {
+    cfg!(any(target_os = "macos", target_os = "linux", target_os = "windows"))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_browsers_have_distinct_slugs() {
+        let mut slugs: Vec<&str> =
+            BROWSER_DETECTION_ORDER.iter().map(|b| b.slug()).collect();
+        slugs.sort_unstable();
+        slugs.dedup();
+        assert_eq!(slugs.len(), BROWSER_DETECTION_ORDER.len());
+    }
+
+    #[test]
+    fn extension_ids_default_to_prod_only() {
+        // Reset USER_TYPE so we don't accidentally pick up the ant variant.
+        let prev = std::env::var("USER_TYPE").ok();
+        std::env::remove_var("USER_TYPE");
+
+        let ids = extension_ids();
+        assert_eq!(ids, vec![PROD_EXTENSION_ID]);
+
+        if let Some(v) = prev {
+            std::env::set_var("USER_TYPE", v);
+        }
+    }
+
+    #[test]
+    fn registry_keys_exist_for_every_browser() {
+        let keys = all_windows_registry_keys();
+        assert_eq!(keys.len(), BROWSER_DETECTION_ORDER.len());
+        for k in &keys {
+            assert!(k.key.starts_with("Software\\"));
+            assert!(k.key.contains("NativeMessagingHosts"));
+        }
+    }
+
+    #[test]
+    fn data_path_resolves_on_current_platform() {
+        // At least Chrome should resolve to *some* path on each supported OS.
+        let p = data_path_for(ChromiumBrowser::Chrome);
+        if supports_claude_in_chrome() {
+            assert!(p.is_some(), "Chrome data path should resolve on supported OS");
+        }
+    }
+
+    #[test]
+    fn detection_order_puts_chrome_first() {
+        assert_eq!(BROWSER_DETECTION_ORDER[0], ChromiumBrowser::Chrome);
+    }
+}

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -1,25 +1,35 @@
-//! Browser MCP — identification and UX for self-hosted browser MCP servers.
+//! Browser subsystem — two coexisting integrations with shared UX.
 //!
-//! A "browser MCP server" is any MCP server (e.g. `mcp-chrome`, `mcp-playwright`,
-//! or a user-rolled stdio server) that exposes browser-automation tools such as
-//! `navigate`, `get_page_text`, `tabs_create`, `click`, `fill`, and so on.
+//! The `browser/` module covers two related but independent ways cc-rust can
+//! talk to a web browser:
 //!
-//! This module does not embed a browser. It only recognizes browser-shaped tool
-//! capabilities coming in over MCP and adds four things on top:
+//! 1. **External browser MCP servers** (issues #2/#3). A user configures a
+//!    third-party MCP server (e.g. `mcp-chrome`, `@playwright/mcp`) in
+//!    `settings.json`; cc-rust identifies it and layers prompt guidance,
+//!    permission categories, and structured result rendering on top.
+//! 2. **First-party Chrome integration** (issues #4/#5). cc-rust ships its
+//!    own native messaging host + MCP bridge and talks directly to the
+//!    Anthropic Chrome extension — no third-party MCP server required.
 //!
-//! 1. **Detection** (`detection`) — mark a server as "browser" via explicit config
-//!    (`"browserMcp": true` in settings.json) **or** by a tool-name heuristic.
-//! 2. **Prompt guidance** (`prompt`) — inject a `# Browser Automation` section into
-//!    the system prompt when at least one browser MCP server is active.
-//! 3. **Permission categories** (`permissions`) — bucket browser actions into
-//!    navigation / read / write / upload / js / observability with risk levels,
-//!    so permission prompts read as "Allow navigating the browser to URL?" instead
-//!    of "Allow tool 'mcp__chrome__navigate'?".
-//! 4. **Tool result rendering** (`tool_rendering`) — classify common browser
-//!    result shapes (screenshots, page dumps, console/network) and produce a
-//!    compact one-line preview for the UI.
+//! Both paths feed into the same downstream UX (prompt, permissions,
+//! rendering), so they're grouped here rather than in separate crates.
+//!
+//! Module layout:
+//!
+//! - `detection` — heuristics for recognizing browser MCP tools (both paths).
+//! - `permissions` — category / risk classification for permission prompts.
+//! - `prompt` — `# Browser Automation` system-prompt section.
+//! - `tool_rendering` — one-line previews for browser tool results.
+//! - `common` — cross-platform Chromium browser paths + constants (#4+#5).
+//! - `state` — runtime state for the first-party Chrome subsystem (#4+#5).
+//! - `setup` — extension detection + native host manifest install (#4+#5).
+//! - `session` — `ChromeSession` lifecycle (#4; transport lives in #5).
 
+pub mod common;
 pub mod detection;
 pub mod permissions;
 pub mod prompt;
+pub mod session;
+pub mod setup;
+pub mod state;
 pub mod tool_rendering;

--- a/src/browser/session.rs
+++ b/src/browser/session.rs
@@ -11,7 +11,7 @@
 //! `Enabled` (ready for #5 to flip to `Connecting → Connected`).
 
 use anyhow::Result;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use super::setup::{self, ExtensionDetection};
 use super::state::{self, ChromeConnectionState};
@@ -137,8 +137,8 @@ impl ChromeSession {
             Err(e) => {
                 let msg = format!("native host install failed: {e}");
                 state::set_connection(ChromeConnectionState::Error(msg));
-                // Fall through — subsystem still transitions to Enabled
-                // below so the user can reconnect via /chrome after fixing.
+                warn!(error = %e, "claude-in-chrome: native host install failed");
+                return Ok(());
             }
         }
 

--- a/src/browser/session.rs
+++ b/src/browser/session.rs
@@ -1,0 +1,248 @@
+//! `ChromeSession` — orchestrates the first-party Chrome subsystem's lifecycle.
+//!
+//! A session wraps the decision "should Chrome be on this run?", performs
+//! the one-time setup (extension detection + manifest/shim install), and
+//! updates [`state`] so `/chrome` and the system-prompt assembler can see
+//! what's happening.
+//!
+//! Issue #4 (this PR) implements the *skeleton*: enable/disable, detection,
+//! manifest install. The actual socket connection to Chrome lives in #5.
+//! `connect()` is therefore a stub that moves the state machine to
+//! `Enabled` (ready for #5 to flip to `Connecting → Connected`).
+
+use anyhow::Result;
+use tracing::{debug, info};
+
+use super::setup::{self, ExtensionDetection};
+use super::state::{self, ChromeConnectionState};
+
+/// How the Chrome subsystem was asked to run for this session.
+///
+/// Resolved once during startup by combining the CLI flag, env var, and
+/// saved config (in that order). The outcome is immutable for the rest of
+/// the session — `/chrome reconnect` does not change *this*, it only nudges
+/// the connection state machine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChromeEnablement {
+    /// Explicitly off (`--no-chrome`, or `CLAUDE_CODE_ENABLE_CFC=false`, or
+    /// saved-config `claudeInChromeDefaultEnabled: false` with no opposite
+    /// CLI signal).
+    Disabled,
+    /// Explicitly on (`--chrome` or `CLAUDE_CODE_ENABLE_CFC=true`).
+    Enabled,
+}
+
+impl ChromeEnablement {
+    pub fn is_enabled(self) -> bool {
+        matches!(self, ChromeEnablement::Enabled)
+    }
+}
+
+/// Resolve the session's enablement from (CLI flag, env, config).
+///
+/// Precedence (highest first):
+/// 1. `cli_chrome == Some(true/false)` — `--chrome` / `--no-chrome`
+/// 2. `CLAUDE_CODE_ENABLE_CFC` env var (truthy / falsy)
+/// 3. `config_default` — `claudeInChromeDefaultEnabled` from settings.json
+/// 4. Default: disabled.
+///
+/// `cli_chrome` uses `Option<bool>`: `None` = flag not given, `Some(true)` =
+/// `--chrome`, `Some(false)` = `--no-chrome`.
+pub fn resolve_enablement(
+    cli_chrome: Option<bool>,
+    config_default: Option<bool>,
+) -> ChromeEnablement {
+    if let Some(v) = cli_chrome {
+        return if v {
+            ChromeEnablement::Enabled
+        } else {
+            ChromeEnablement::Disabled
+        };
+    }
+
+    match std::env::var("CLAUDE_CODE_ENABLE_CFC")
+        .ok()
+        .as_deref()
+        .map(env_truthy_falsy)
+    {
+        Some(Some(true)) => return ChromeEnablement::Enabled,
+        Some(Some(false)) => return ChromeEnablement::Disabled,
+        _ => {}
+    }
+
+    match config_default {
+        Some(true) => ChromeEnablement::Enabled,
+        Some(false) => ChromeEnablement::Disabled,
+        None => ChromeEnablement::Disabled,
+    }
+}
+
+/// Map env-var string to `Some(true)` / `Some(false)` / `None`.
+fn env_truthy_falsy(raw: &str) -> Option<bool> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        "" => None,
+        _ => None,
+    }
+}
+
+/// `ChromeSession` owns the one-shot startup work for the Chrome subsystem.
+pub struct ChromeSession {
+    enablement: ChromeEnablement,
+}
+
+impl ChromeSession {
+    /// Create a new session; no I/O yet.
+    pub fn new(enablement: ChromeEnablement) -> Self {
+        Self { enablement }
+    }
+
+    /// Perform startup: run extension detection, write native-host manifest
+    /// + wrapper script, and transition state to `Enabled`.
+    ///
+    /// Returns `Ok(())` even if sub-steps fail (extension not installed,
+    /// native-host install denied by the OS, etc.) — we record the error in
+    /// state and let `/chrome` surface it rather than crashing the whole
+    /// cc-rust process over a best-effort feature.
+    pub fn start(&self) -> Result<()> {
+        if !self.enablement.is_enabled() {
+            state::set_connection(ChromeConnectionState::Disabled);
+            return Ok(());
+        }
+
+        info!("claude-in-chrome: starting subsystem");
+
+        // Detection is pure filesystem reads; cheap and safe to run sync.
+        let detection: ExtensionDetection = setup::detect_extension_installed();
+        state::set_extension_detection(detection.is_installed, detection.browser);
+
+        // Best-effort native host install. Errors are recorded, not
+        // propagated, because a session without a native host is still
+        // useful — the user can install the extension later and re-run.
+        //
+        // In this skeleton PR the binary path points at the current
+        // cc-rust binary with `--chrome-native-host` (wired in #5). That's
+        // intentional: the manifest files will be correct the moment #5
+        // ships, without requiring a second install step.
+        match install_native_host() {
+            Ok(updated) => {
+                if updated > 0 {
+                    debug!(
+                        updated,
+                        "claude-in-chrome: native host manifest(s) installed/updated"
+                    );
+                }
+            }
+            Err(e) => {
+                let msg = format!("native host install failed: {e}");
+                state::set_connection(ChromeConnectionState::Error(msg));
+                // Fall through — subsystem still transitions to Enabled
+                // below so the user can reconnect via /chrome after fixing.
+            }
+        }
+
+        state::clear_error();
+        state::set_connection(ChromeConnectionState::Enabled);
+
+        info!(
+            extension_installed = detection.is_installed,
+            detected_browser = detection.browser.map(|b| b.slug()),
+            "claude-in-chrome: subsystem enabled"
+        );
+
+        Ok(())
+    }
+
+    /// Trigger a reconnect attempt.
+    ///
+    /// In #4 this is a stub: re-runs detection and re-installs the manifest
+    /// (idempotent), so the user can fix their setup and hit "reconnect"
+    /// without restarting cc-rust. #5 will additionally re-open the socket
+    /// and re-handshake with the extension.
+    pub fn reconnect(&self) -> Result<()> {
+        if !self.enablement.is_enabled() {
+            return Ok(());
+        }
+        info!("claude-in-chrome: reconnect requested");
+        self.start()
+    }
+}
+
+/// Install the native host manifest pointing at the current cc-rust binary.
+///
+/// The `--chrome-native-host` flag it's wired to is the entry point #5 will
+/// add. Until then, the manifest is correct-by-construction; nothing reads it
+/// because no extension can talk to a flag the binary doesn't yet honor.
+fn install_native_host() -> Result<usize> {
+    let exe = std::env::current_exe()?;
+    let command = format!("\"{}\" --chrome-native-host", exe.display());
+    let wrapper = setup::create_wrapper_script(&command)?;
+    setup::install_native_host_manifest(&wrapper)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn with_clean_env<F: FnOnce()>(f: F) {
+        let prev = std::env::var("CLAUDE_CODE_ENABLE_CFC").ok();
+        std::env::remove_var("CLAUDE_CODE_ENABLE_CFC");
+        f();
+        if let Some(v) = prev {
+            std::env::set_var("CLAUDE_CODE_ENABLE_CFC", v);
+        }
+    }
+
+    #[test]
+    fn cli_flag_beats_env_and_config() {
+        with_clean_env(|| {
+            std::env::set_var("CLAUDE_CODE_ENABLE_CFC", "true");
+            let got = resolve_enablement(Some(false), Some(true));
+            assert_eq!(got, ChromeEnablement::Disabled, "--no-chrome overrides env and config");
+            std::env::remove_var("CLAUDE_CODE_ENABLE_CFC");
+        });
+    }
+
+    #[test]
+    fn env_beats_config() {
+        with_clean_env(|| {
+            std::env::set_var("CLAUDE_CODE_ENABLE_CFC", "0");
+            let got = resolve_enablement(None, Some(true));
+            assert_eq!(got, ChromeEnablement::Disabled);
+            std::env::remove_var("CLAUDE_CODE_ENABLE_CFC");
+        });
+    }
+
+    #[test]
+    fn config_used_when_no_cli_or_env() {
+        with_clean_env(|| {
+            let got = resolve_enablement(None, Some(true));
+            assert_eq!(got, ChromeEnablement::Enabled);
+        });
+    }
+
+    #[test]
+    fn default_disabled() {
+        with_clean_env(|| {
+            let got = resolve_enablement(None, None);
+            assert_eq!(got, ChromeEnablement::Disabled);
+        });
+    }
+
+    #[test]
+    fn env_truthy_parsing() {
+        assert_eq!(env_truthy_falsy("1"), Some(true));
+        assert_eq!(env_truthy_falsy("true"), Some(true));
+        assert_eq!(env_truthy_falsy("YES"), Some(true));
+        assert_eq!(env_truthy_falsy("0"), Some(false));
+        assert_eq!(env_truthy_falsy("false"), Some(false));
+        assert_eq!(env_truthy_falsy("off"), Some(false));
+        assert_eq!(env_truthy_falsy(""), None);
+        assert_eq!(env_truthy_falsy("maybe"), None);
+    }
+}

--- a/src/browser/setup.rs
+++ b/src/browser/setup.rs
@@ -1,0 +1,372 @@
+//! Setup helpers for the first-party Chrome integration.
+//!
+//! Extension detection + native-host-manifest install + wrapper script.
+//!
+//! Scope for this file in the #4 skeleton PR:
+//!
+//! * **Implemented**: extension detection (scans browser `Extensions/` dirs
+//!   across profiles), wrapper script generation, native-host-manifest
+//!   writer (writes the JSON manifest to the per-browser
+//!   `NativeMessagingHosts/` dir; Windows registers the registry key).
+//! * **Deferred to #5**: the actual native host binary mode
+//!   (`--chrome-native-host`) and the companion MCP stdio mode
+//!   (`--claude-in-chrome-mcp`) that the manifest points at. Until #5
+//!   lands, the manifest points at the current cc-rust binary with a flag
+//!   we haven't wired — which is fine: an end-user who enables Chrome today
+//!   gets the right files on disk, and the second half turns on when #5
+//!   ships.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use tracing::{debug, warn};
+
+use super::common::{
+    all_browser_data_paths, all_native_messaging_paths, all_windows_registry_keys,
+    extension_ids, BrowserDataPath, ChromiumBrowser, NATIVE_HOST_IDENTIFIER,
+};
+
+// ---------------------------------------------------------------------------
+// Extension detection
+// ---------------------------------------------------------------------------
+
+/// Result of scanning every browser + profile for our extension.
+///
+/// `profile` is currently debug-logged during detection but not surfaced to
+/// callers — the #5 transport layer is what needs to know which profile owns
+/// the extension, and it will read the field then.
+#[derive(Debug, Clone, Default)]
+pub struct ExtensionDetection {
+    pub is_installed: bool,
+    pub browser: Option<ChromiumBrowser>,
+    /// Profile directory where the extension was found (e.g. `"Default"`).
+    #[allow(dead_code)] // Consumed by the native-host transport in #5.
+    pub profile: Option<String>,
+}
+
+/// Scan every supported browser's `Extensions/` directories and return the
+/// first hit. Mirrors the bun `detectExtensionInstallationPortable`.
+///
+/// A "profile" is any subdirectory of the browser's user-data dir named
+/// `Default` or `Profile N`. Within each profile, the extension is installed
+/// iff `Extensions/{extension_id}/` exists.
+pub fn detect_extension_installed() -> ExtensionDetection {
+    let paths = all_browser_data_paths();
+    if paths.is_empty() {
+        debug!("claude-in-chrome: no browser data paths on this platform");
+        return ExtensionDetection::default();
+    }
+
+    let ids = extension_ids();
+
+    for BrowserDataPath { browser, path } in &paths {
+        let Ok(entries) = fs::read_dir(path) else {
+            continue;
+        };
+
+        let profile_dirs: Vec<String> = entries
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+            .filter_map(|e| e.file_name().into_string().ok())
+            .filter(|name| name == "Default" || name.starts_with("Profile "))
+            .collect();
+
+        for profile in &profile_dirs {
+            for ext_id in &ids {
+                let candidate = path.join(profile).join("Extensions").join(ext_id);
+                if candidate.is_dir() {
+                    debug!(
+                        %ext_id,
+                        browser = browser.slug(),
+                        %profile,
+                        "claude-in-chrome: extension found"
+                    );
+                    return ExtensionDetection {
+                        is_installed: true,
+                        browser: Some(*browser),
+                        profile: Some(profile.clone()),
+                    };
+                }
+            }
+        }
+    }
+
+    debug!("claude-in-chrome: extension not found in any browser");
+    ExtensionDetection::default()
+}
+
+// ---------------------------------------------------------------------------
+// Wrapper script
+// ---------------------------------------------------------------------------
+
+/// Create a wrapper script in `~/.cc-rust/chrome/` that invokes `command`.
+///
+/// Chrome's native-host manifest `path` field cannot contain arguments, so we
+/// install a tiny shim that execs the real command. Returns the absolute path
+/// to the shim (that's what goes into the manifest).
+///
+/// If the shim already has the exact content we'd write, we leave it alone —
+/// Chrome watches manifest paths for mtime changes and avoiding a no-op
+/// rewrite is cheap.
+pub fn create_wrapper_script(command: &str) -> Result<PathBuf> {
+    let chrome_dir = cc_rust_chrome_dir()?;
+    fs::create_dir_all(&chrome_dir)
+        .with_context(|| format!("creating {}", chrome_dir.display()))?;
+
+    let (wrapper_path, content) = if cfg!(windows) {
+        let p = chrome_dir.join("chrome-native-host.bat");
+        let c = format!(
+            "@echo off\r\n\
+             REM Chrome native host wrapper script\r\n\
+             REM Generated by cc-rust - do not edit manually\r\n\
+             {command}\r\n",
+            command = command,
+        );
+        (p, c)
+    } else {
+        let p = chrome_dir.join("chrome-native-host");
+        let c = format!(
+            "#!/bin/sh\n\
+             # Chrome native host wrapper script\n\
+             # Generated by cc-rust - do not edit manually\n\
+             exec {command}\n",
+            command = command,
+        );
+        (p, c)
+    };
+
+    if let Ok(existing) = fs::read_to_string(&wrapper_path) {
+        if existing == content {
+            return Ok(wrapper_path);
+        }
+    }
+
+    fs::write(&wrapper_path, &content)
+        .with_context(|| format!("writing {}", wrapper_path.display()))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&wrapper_path)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&wrapper_path, perms)?;
+    }
+
+    debug!(path = %wrapper_path.display(), "claude-in-chrome: wrote wrapper script");
+    Ok(wrapper_path)
+}
+
+fn cc_rust_chrome_dir() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("could not locate $HOME")?;
+    Ok(home.join(".cc-rust").join("chrome"))
+}
+
+// ---------------------------------------------------------------------------
+// Native host manifest
+// ---------------------------------------------------------------------------
+
+/// JSON shape Chrome expects in the native-host manifest.
+///
+/// Chrome discovers native hosts by reading a manifest at a well-known
+/// location; the manifest `path` field points at the binary Chrome should
+/// launch. `allowed_origins` whitelists which extensions may talk to it.
+fn build_manifest_json(binary_path: &Path) -> serde_json::Value {
+    use super::common::{ANT_EXTENSION_ID, DEV_EXTENSION_ID, PROD_EXTENSION_ID};
+
+    let mut origins = vec![format!("chrome-extension://{}/", PROD_EXTENSION_ID)];
+    if std::env::var("USER_TYPE").as_deref() == Ok("ant") {
+        origins.push(format!("chrome-extension://{}/", DEV_EXTENSION_ID));
+        origins.push(format!("chrome-extension://{}/", ANT_EXTENSION_ID));
+    }
+
+    serde_json::json!({
+        "name": NATIVE_HOST_IDENTIFIER,
+        "description": "cc-rust browser extension native host",
+        "path": binary_path.to_string_lossy(),
+        "type": "stdio",
+        "allowed_origins": origins,
+    })
+}
+
+/// Write the native-host manifest to every supported browser's
+/// NativeMessagingHosts directory (on macOS/Linux) OR to a single cc-rust
+/// directory with registry entries pointing at it (on Windows).
+///
+/// Returns the number of manifests that were *newly written or updated* —
+/// zero means every browser already had an up-to-date manifest. Callers can
+/// use that count to decide whether to open the reconnect URL.
+pub fn install_native_host_manifest(binary_path: &Path) -> Result<usize> {
+    let manifest = build_manifest_json(binary_path);
+    let manifest_content = serde_json::to_string_pretty(&manifest)?;
+    let manifest_filename = format!("{}.json", NATIVE_HOST_IDENTIFIER);
+
+    let mut updated = 0usize;
+
+    if cfg!(windows) {
+        // Windows: write one manifest to a cc-rust-owned dir, then point each
+        // browser's registry key at it.
+        let manifest_dir = home_dir()?.join("AppData").join("Local").join("cc-rust").join("ChromeNativeHost");
+        fs::create_dir_all(&manifest_dir)
+            .with_context(|| format!("creating {}", manifest_dir.display()))?;
+        let manifest_path = manifest_dir.join(&manifest_filename);
+        if write_if_changed(&manifest_path, &manifest_content)? {
+            updated += 1;
+        }
+
+        if let Err(e) = register_windows_native_hosts(&manifest_path) {
+            warn!(error = %e, "claude-in-chrome: Windows registry registration had errors");
+        }
+    } else {
+        // macOS / Linux: write one manifest per browser directory.
+        for path in all_native_messaging_paths() {
+            let dir = path.path;
+            if let Err(e) = fs::create_dir_all(&dir) {
+                // Browser may not be installed — skip gracefully.
+                debug!(
+                    browser = path.browser.slug(),
+                    dir = %dir.display(),
+                    error = %e,
+                    "claude-in-chrome: could not create native messaging dir (browser missing?)"
+                );
+                continue;
+            }
+            let manifest_path = dir.join(&manifest_filename);
+            match write_if_changed(&manifest_path, &manifest_content) {
+                Ok(true) => updated += 1,
+                Ok(false) => {}
+                Err(e) => warn!(
+                    browser = path.browser.slug(),
+                    path = %manifest_path.display(),
+                    error = %e,
+                    "claude-in-chrome: failed to write manifest"
+                ),
+            }
+        }
+    }
+
+    Ok(updated)
+}
+
+fn write_if_changed(path: &Path, content: &str) -> io::Result<bool> {
+    if let Ok(existing) = fs::read_to_string(path) {
+        if existing == content {
+            return Ok(false);
+        }
+    }
+    fs::write(path, content)?;
+    Ok(true)
+}
+
+fn home_dir() -> Result<PathBuf> {
+    dirs::home_dir().context("could not locate $HOME")
+}
+
+#[cfg(windows)]
+fn register_windows_native_hosts(manifest_path: &Path) -> Result<()> {
+    use std::process::Command;
+    let manifest_path_str = manifest_path.to_string_lossy().to_string();
+
+    for entry in all_windows_registry_keys() {
+        let full_key = format!(
+            "HKCU\\{}\\{}",
+            entry.key, NATIVE_HOST_IDENTIFIER
+        );
+        let output = Command::new("reg")
+            .args([
+                "add",
+                &full_key,
+                "/ve",
+                "/t",
+                "REG_SZ",
+                "/d",
+                &manifest_path_str,
+                "/f",
+            ])
+            .output();
+        match output {
+            Ok(o) if o.status.success() => {
+                debug!(
+                    browser = entry.browser.slug(),
+                    key = %full_key,
+                    "claude-in-chrome: registered Windows native host"
+                );
+            }
+            Ok(o) => {
+                warn!(
+                    browser = entry.browser.slug(),
+                    stderr = %String::from_utf8_lossy(&o.stderr),
+                    "claude-in-chrome: reg add failed"
+                );
+            }
+            Err(e) => warn!(
+                browser = entry.browser.slug(),
+                error = %e,
+                "claude-in-chrome: could not spawn reg.exe"
+            ),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn register_windows_native_hosts(_: &Path) -> Result<()> {
+    // No-op on non-Windows — the manifest files in per-browser
+    // NativeMessagingHosts/ dirs are sufficient.
+    let _ = all_windows_registry_keys; // silence unused-import linting
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_json_has_expected_shape() {
+        let m = build_manifest_json(Path::new("/tmp/cc-rust-native-host"));
+        assert_eq!(m["name"], NATIVE_HOST_IDENTIFIER);
+        assert_eq!(m["type"], "stdio");
+        let origins = m["allowed_origins"].as_array().unwrap();
+        assert!(!origins.is_empty());
+        assert!(origins[0]
+            .as_str()
+            .unwrap()
+            .starts_with("chrome-extension://"));
+    }
+
+    #[test]
+    fn wrapper_script_round_trips() {
+        // Use a tempdir to avoid touching the real ~/.cc-rust.
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", tmp.path());
+        // On Windows, dirs::home_dir also checks USERPROFILE.
+        std::env::set_var("USERPROFILE", tmp.path());
+
+        let path = create_wrapper_script("\"/bin/echo\" hello").unwrap();
+        assert!(path.exists(), "wrapper should have been created");
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("hello"));
+
+        // Idempotent: second call with same command should not rewrite.
+        let mtime1 = fs::metadata(&path).unwrap().modified().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let path2 = create_wrapper_script("\"/bin/echo\" hello").unwrap();
+        let mtime2 = fs::metadata(&path2).unwrap().modified().unwrap();
+        assert_eq!(mtime1, mtime2, "wrapper should not be rewritten when unchanged");
+    }
+
+    #[test]
+    fn detect_extension_handles_missing_browsers() {
+        // On most test machines no Claude extension is installed. The
+        // function should just report is_installed=false without panicking.
+        let result = detect_extension_installed();
+        // Either result is fine (depends on the machine); this test just
+        // proves the function doesn't crash.
+        let _ = result.is_installed;
+    }
+}

--- a/src/browser/setup.rs
+++ b/src/browser/setup.rs
@@ -159,8 +159,7 @@ pub fn create_wrapper_script(command: &str) -> Result<PathBuf> {
 }
 
 fn cc_rust_chrome_dir() -> Result<PathBuf> {
-    let home = dirs::home_dir().context("could not locate $HOME")?;
-    Ok(home.join(".cc-rust").join("chrome"))
+    Ok(crate::config::settings::global_claude_dir()?.join("chrome"))
 }
 
 // ---------------------------------------------------------------------------
@@ -207,7 +206,7 @@ pub fn install_native_host_manifest(binary_path: &Path) -> Result<usize> {
     if cfg!(windows) {
         // Windows: write one manifest to a cc-rust-owned dir, then point each
         // browser's registry key at it.
-        let manifest_dir = home_dir()?.join("AppData").join("Local").join("cc-rust").join("ChromeNativeHost");
+        let manifest_dir = cc_rust_chrome_dir()?.join("native-host");
         fs::create_dir_all(&manifest_dir)
             .with_context(|| format!("creating {}", manifest_dir.display()))?;
         let manifest_path = manifest_dir.join(&manifest_filename);
@@ -258,11 +257,6 @@ fn write_if_changed(path: &Path, content: &str) -> io::Result<bool> {
     fs::write(path, content)?;
     Ok(true)
 }
-
-fn home_dir() -> Result<PathBuf> {
-    dirs::home_dir().context("could not locate $HOME")
-}
-
 #[cfg(windows)]
 fn register_windows_native_hosts(manifest_path: &Path) -> Result<()> {
     use std::process::Command;
@@ -343,12 +337,16 @@ mod tests {
     fn wrapper_script_round_trips() {
         // Use a tempdir to avoid touching the real ~/.cc-rust.
         let tmp = tempfile::tempdir().unwrap();
+        let prev_home = std::env::var("HOME").ok();
+        let prev_userprofile = std::env::var("USERPROFILE").ok();
+        let prev_cc_rust_home = std::env::var("CC_RUST_HOME").ok();
         std::env::set_var("HOME", tmp.path());
-        // On Windows, dirs::home_dir also checks USERPROFILE.
         std::env::set_var("USERPROFILE", tmp.path());
+        std::env::set_var("CC_RUST_HOME", tmp.path());
 
         let path = create_wrapper_script("\"/bin/echo\" hello").unwrap();
         assert!(path.exists(), "wrapper should have been created");
+        assert!(path.starts_with(tmp.path()));
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(content.contains("hello"));
 
@@ -358,6 +356,22 @@ mod tests {
         let path2 = create_wrapper_script("\"/bin/echo\" hello").unwrap();
         let mtime2 = fs::metadata(&path2).unwrap().modified().unwrap();
         assert_eq!(mtime1, mtime2, "wrapper should not be rewritten when unchanged");
+
+        if let Some(v) = prev_home {
+            std::env::set_var("HOME", v);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        if let Some(v) = prev_userprofile {
+            std::env::set_var("USERPROFILE", v);
+        } else {
+            std::env::remove_var("USERPROFILE");
+        }
+        if let Some(v) = prev_cc_rust_home {
+            std::env::set_var("CC_RUST_HOME", v);
+        } else {
+            std::env::remove_var("CC_RUST_HOME");
+        }
     }
 
     #[test]

--- a/src/browser/state.rs
+++ b/src/browser/state.rs
@@ -1,0 +1,213 @@
+//! Runtime state for the first-party Chrome integration.
+//!
+//! One `ChromeState` per process, stored behind a `parking_lot::RwLock` so
+//! the `/chrome` command and the native-host connection loop can read the
+//! status without contention.
+//!
+//! The fields here are *intentionally narrow*: they track things the user
+//! asks about ("is Chrome enabled? is the extension installed? are we
+//! connected?") and leave the heavy lifting (manifest writes, socket I/O)
+//! to other modules.
+
+use std::sync::OnceLock;
+
+use parking_lot::RwLock;
+
+use super::common::ChromiumBrowser;
+
+/// Coarse connection state for the Chrome subsystem.
+///
+/// Lifecycle: `Disabled` → `Enabled` → `Connecting` → (`Connected` | `Error(_)`).
+/// Disconnect flips back to `Enabled` (the user can run `/chrome reconnect`).
+///
+/// `Connecting` and `Connected` are not constructed in the #4 skeleton — they
+/// belong to the native-host transport layer in #5. They're declared here so
+/// the state machine is complete and `/chrome` can display them when #5
+/// lands without a second data-model change.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChromeConnectionState {
+    /// `--no-chrome` or never-enabled session.
+    Disabled,
+    /// `--chrome` (or auto-enabled): subsystem is on but no native-host
+    /// session exists yet.
+    Enabled,
+    /// Attempting to connect to the extension via the native host. (#5)
+    #[allow(dead_code)] // Constructed by #5's native-host transport loop.
+    Connecting,
+    /// Native host ↔ extension handshake complete; browser tools are live. (#5)
+    #[allow(dead_code)] // Constructed by #5's native-host transport loop.
+    Connected {
+        /// Which browser provided the extension that connected.
+        browser: ChromiumBrowser,
+    },
+    /// Connection failed or dropped; message is user-facing.
+    Error(String),
+}
+
+impl ChromeConnectionState {
+    /// One-word label suitable for `/chrome` status.
+    pub fn label(&self) -> &'static str {
+        match self {
+            ChromeConnectionState::Disabled => "disabled",
+            ChromeConnectionState::Enabled => "enabled (not yet connected)",
+            ChromeConnectionState::Connecting => "connecting",
+            ChromeConnectionState::Connected { .. } => "connected",
+            ChromeConnectionState::Error(_) => "error",
+        }
+    }
+
+    pub fn is_active(&self) -> bool {
+        matches!(
+            self,
+            ChromeConnectionState::Enabled
+                | ChromeConnectionState::Connecting
+                | ChromeConnectionState::Connected { .. }
+        )
+    }
+}
+
+/// Full runtime state snapshot for the Chrome subsystem.
+///
+/// Cloned cheaply (enum + bool + `Option<String>`), so readers can grab a
+/// snapshot without holding the lock while they format output.
+#[derive(Debug, Clone)]
+pub struct ChromeState {
+    /// Current connection state.
+    pub connection: ChromeConnectionState,
+    /// Whether the Anthropic Chrome extension was detected on disk.
+    ///
+    /// Detection runs asynchronously during session setup; `None` means
+    /// "haven't checked yet". See `setup::detect_extension_installed`.
+    pub extension_installed: Option<bool>,
+    /// Which browser the extension was detected in (if any).
+    pub detected_browser: Option<ChromiumBrowser>,
+    /// The last error reported by the connection loop (for `/chrome` to show).
+    pub last_error: Option<String>,
+}
+
+impl Default for ChromeState {
+    fn default() -> Self {
+        Self {
+            connection: ChromeConnectionState::Disabled,
+            extension_installed: None,
+            detected_browser: None,
+            last_error: None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Global singleton
+// ---------------------------------------------------------------------------
+//
+// A process-wide state lives behind a RwLock. The alternative — threading a
+// handle through every caller — balloons the API surface for a feature that
+// genuinely is process-singleton (there's at most one Chrome session per
+// cc-rust run).
+
+static CHROME_STATE: OnceLock<RwLock<ChromeState>> = OnceLock::new();
+
+fn state() -> &'static RwLock<ChromeState> {
+    CHROME_STATE.get_or_init(|| RwLock::new(ChromeState::default()))
+}
+
+/// Read the current state.
+pub fn snapshot() -> ChromeState {
+    state().read().clone()
+}
+
+/// Set the connection state.
+pub fn set_connection(new: ChromeConnectionState) {
+    let mut s = state().write();
+    // Mirror Error(_) into last_error for convenience.
+    if let ChromeConnectionState::Error(ref msg) = new {
+        s.last_error = Some(msg.clone());
+    }
+    s.connection = new;
+}
+
+/// Mark extension-installed status + which browser it was found in.
+pub fn set_extension_detection(installed: bool, browser: Option<ChromiumBrowser>) {
+    let mut s = state().write();
+    s.extension_installed = Some(installed);
+    s.detected_browser = browser;
+}
+
+/// Clear the last error (e.g. after a successful reconnect).
+pub fn clear_error() {
+    let mut s = state().write();
+    s.last_error = None;
+}
+
+/// Convenience: are we currently enabled in any form?
+pub fn is_enabled() -> bool {
+    state().read().connection.is_active()
+}
+
+/// Reset state — tests only.
+#[cfg(test)]
+pub(crate) fn reset_for_tests() {
+    let mut s = state().write();
+    *s = ChromeState::default();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_lock() -> std::sync::MutexGuard<'static, ()> {
+        use std::sync::{Mutex, OnceLock};
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+
+    #[test]
+    fn default_is_disabled() {
+        let _guard = test_lock();
+        reset_for_tests();
+        let s = snapshot();
+        assert_eq!(s.connection, ChromeConnectionState::Disabled);
+        assert!(!s.connection.is_active());
+    }
+
+    #[test]
+    fn set_connection_transitions() {
+        let _guard = test_lock();
+        reset_for_tests();
+
+        set_connection(ChromeConnectionState::Enabled);
+        assert!(is_enabled());
+
+        set_connection(ChromeConnectionState::Connecting);
+        assert!(is_enabled());
+
+        set_connection(ChromeConnectionState::Connected {
+            browser: ChromiumBrowser::Chrome,
+        });
+        assert!(is_enabled());
+
+        set_connection(ChromeConnectionState::Error("boom".into()));
+        assert!(!is_enabled());
+        assert_eq!(snapshot().last_error.as_deref(), Some("boom"));
+
+        clear_error();
+        assert!(snapshot().last_error.is_none());
+    }
+
+    #[test]
+    fn extension_detection_stored() {
+        let _guard = test_lock();
+        reset_for_tests();
+
+        set_extension_detection(true, Some(ChromiumBrowser::Chrome));
+        let s = snapshot();
+        assert_eq!(s.extension_installed, Some(true));
+        assert_eq!(s.detected_browser, Some(ChromiumBrowser::Chrome));
+    }
+}

--- a/src/commands/chrome_cmd.rs
+++ b/src/commands/chrome_cmd.rs
@@ -1,0 +1,286 @@
+//! `/chrome` command — first-party Chrome integration status + actions.
+//!
+//! Subcommands:
+//! - `/chrome`             — show current status (enablement, extension, connection, errors)
+//! - `/chrome reconnect`   — re-run detection + native-host install (stub in #4; real retry in #5)
+//! - `/chrome help`        — usage + install instructions
+//!
+//! Non-interactive by design: prints state, returns links to the extension
+//! install page and the permissions manager. The TUI-facing interactive menu
+//! (the `Dialog` component from the bun version) can layer on top later
+//! without changing this handler.
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use super::{CommandContext, CommandHandler, CommandResult};
+use crate::browser::common::{
+    supports_claude_in_chrome, CHROME_EXTENSION_URL, CHROME_PERMISSIONS_URL, CHROME_RECONNECT_URL,
+};
+use crate::browser::session::{ChromeEnablement, ChromeSession};
+use crate::browser::state::{self, ChromeConnectionState};
+
+/// Handler for the `/chrome` slash command.
+pub struct ChromeHandler;
+
+#[async_trait]
+impl CommandHandler for ChromeHandler {
+    async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> Result<CommandResult> {
+        let sub = args.split_whitespace().next().unwrap_or("");
+        match sub {
+            "" | "status" => Ok(CommandResult::Output(render_status())),
+            "reconnect" => Ok(CommandResult::Output(handle_reconnect())),
+            "help" | "?" => Ok(CommandResult::Output(render_help())),
+            other => Ok(CommandResult::Output(format!(
+                "Unknown /chrome subcommand: '{other}'\n\n{}",
+                render_help()
+            ))),
+        }
+    }
+}
+
+fn render_status() -> String {
+    let mut lines = Vec::new();
+    lines.push("Claude in Chrome (first-party Chrome integration)".to_string());
+    lines.push(String::new());
+
+    if !supports_claude_in_chrome() {
+        lines.push("  Platform: UNSUPPORTED".into());
+        lines.push(
+            "  Claude in Chrome is only available on macOS, Linux, and Windows.".into(),
+        );
+        return lines.join("\n");
+    }
+
+    let snap = state::snapshot();
+
+    lines.push(format!("  Status: {}", snap.connection.label()));
+
+    // Extension install
+    match snap.extension_installed {
+        Some(true) => {
+            let browser = snap
+                .detected_browser
+                .map(|b| format!(" ({})", b.display_name()))
+                .unwrap_or_default();
+            lines.push(format!("  Extension: installed{}", browser));
+        }
+        Some(false) => {
+            lines.push("  Extension: NOT detected".to_string());
+            lines.push(format!("    Install: {}", CHROME_EXTENSION_URL));
+        }
+        None => {
+            lines.push("  Extension: (not yet checked — enable with --chrome)".into());
+        }
+    }
+
+    // Detailed per-state hints
+    match &snap.connection {
+        ChromeConnectionState::Disabled => {
+            lines.push(String::new());
+            lines.push("  Enable with:".into());
+            lines.push("    claude --chrome".into());
+            lines.push("    or set CLAUDE_CODE_ENABLE_CFC=1".into());
+        }
+        ChromeConnectionState::Enabled => {
+            lines.push(String::new());
+            lines.push("  Subsystem is on; waiting for the Chrome extension to connect.".into());
+            lines.push(format!("  Reconnect: {}", CHROME_RECONNECT_URL));
+            lines.push("  To retry setup: /chrome reconnect".into());
+        }
+        ChromeConnectionState::Connecting => {
+            lines.push("  Handshake in progress — reconnect if this sticks...".into());
+        }
+        ChromeConnectionState::Connected { browser } => {
+            lines.push(format!(
+                "  Connected via {} — browser tools are live.",
+                browser.display_name()
+            ));
+            lines.push(format!("  Permissions: {}", CHROME_PERMISSIONS_URL));
+        }
+        ChromeConnectionState::Error(msg) => {
+            lines.push(format!("  Error: {}", msg));
+            lines.push("  Try: /chrome reconnect".into());
+        }
+    }
+
+    if let Some(err) = snap.last_error.as_deref() {
+        if !matches!(snap.connection, ChromeConnectionState::Error(_)) {
+            lines.push(format!("  Last error: {}", err));
+        }
+    }
+
+    lines.push(String::new());
+    lines.push("  Docs: docs/reference/browser-mcp-config.md".into());
+    lines.push("  Usage: /chrome, /chrome reconnect, /chrome help".into());
+
+    lines.join("\n")
+}
+
+fn render_help() -> String {
+    format!(
+        "Claude in Chrome (first-party Chrome integration)\n\n\
+         Usage:\n  \
+           /chrome              -- show status (extension + connection)\n  \
+           /chrome reconnect    -- re-run setup + reconnect attempt\n  \
+           /chrome help         -- this message\n\n\
+         CLI flags:\n  \
+           claude --chrome      -- enable Chrome subsystem\n  \
+           claude --no-chrome   -- explicitly disable Chrome subsystem\n\n\
+         Environment:\n  \
+           CLAUDE_CODE_ENABLE_CFC=1   -- enable by default\n  \
+           CLAUDE_CODE_ENABLE_CFC=0   -- disable by default\n\n\
+         Install the Chrome extension:  {install}\n\
+         Manage per-site permissions:   {perms}\n\
+         Troubleshoot disconnects:      {reconnect}",
+        install = CHROME_EXTENSION_URL,
+        perms = CHROME_PERMISSIONS_URL,
+        reconnect = CHROME_RECONNECT_URL,
+    )
+}
+
+fn handle_reconnect() -> String {
+    let snap = state::snapshot();
+    if matches!(snap.connection, ChromeConnectionState::Disabled) {
+        return "Chrome subsystem is disabled. Start cc-rust with --chrome first.".into();
+    }
+
+    // Re-run setup (detection + manifest install). #5 will additionally
+    // attempt to re-open the socket.
+    let session = ChromeSession::new(ChromeEnablement::Enabled);
+    match session.reconnect() {
+        Ok(()) => {
+            // Re-read state in case reconnect updated it.
+            let snap = state::snapshot();
+            match &snap.connection {
+                ChromeConnectionState::Error(msg) => {
+                    format!(
+                        "Reconnect ran but reported an error: {}\nCheck that Chrome is installed and the extension is present.\nReconnect URL: {}",
+                        msg, CHROME_RECONNECT_URL
+                    )
+                }
+                _ => format!(
+                    "Re-ran detection + manifest install.\nNow visit {} in Chrome to reconnect the extension.\n\n{}",
+                    CHROME_RECONNECT_URL,
+                    render_status()
+                ),
+            }
+        }
+        Err(e) => format!("Reconnect failed: {}", e),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::browser::common::ChromiumBrowser;
+    use crate::browser::state::{self, ChromeConnectionState};
+    use crate::bootstrap::SessionId;
+    use crate::types::app_state::AppState;
+    use std::path::PathBuf;
+
+    fn test_ctx() -> CommandContext {
+        CommandContext {
+            messages: vec![],
+            cwd: PathBuf::from("/tmp"),
+            app_state: AppState::default(),
+            session_id: SessionId::new(),
+        }
+    }
+
+    fn test_lock() -> std::sync::MutexGuard<'static, ()> {
+        use std::sync::{Mutex, OnceLock};
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+
+    #[tokio::test]
+    async fn status_when_disabled_mentions_cli_flag() {
+        let _guard = test_lock();
+        state::reset_for_tests();
+
+        let handler = ChromeHandler;
+        let mut ctx = test_ctx();
+        let result = handler.execute("", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(t) => {
+                assert!(t.contains("disabled"));
+                assert!(t.contains("--chrome"));
+            }
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[tokio::test]
+    async fn status_when_connected_shows_browser() {
+        let _guard = test_lock();
+        state::reset_for_tests();
+        state::set_extension_detection(true, Some(ChromiumBrowser::Chrome));
+        state::set_connection(ChromeConnectionState::Connected {
+            browser: ChromiumBrowser::Chrome,
+        });
+
+        let handler = ChromeHandler;
+        let mut ctx = test_ctx();
+        let result = handler.execute("", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(t) => {
+                assert!(t.contains("Connected via Google Chrome"));
+                assert!(t.contains("installed"));
+            }
+            _ => panic!("expected Output"),
+        }
+
+        state::reset_for_tests();
+    }
+
+    #[tokio::test]
+    async fn help_subcommand_shows_usage() {
+        let handler = ChromeHandler;
+        let mut ctx = test_ctx();
+        let result = handler.execute("help", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(t) => {
+                assert!(t.contains("--chrome"));
+                assert!(t.contains("--no-chrome"));
+                assert!(t.contains("CLAUDE_CODE_ENABLE_CFC"));
+            }
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[tokio::test]
+    async fn reconnect_from_disabled_reports_disabled() {
+        let _guard = test_lock();
+        state::reset_for_tests();
+        let handler = ChromeHandler;
+        let mut ctx = test_ctx();
+        let result = handler.execute("reconnect", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(t) => {
+                assert!(t.contains("disabled"));
+            }
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_subcommand_shows_help() {
+        let handler = ChromeHandler;
+        let mut ctx = test_ctx();
+        let result = handler.execute("nonsense", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(t) => {
+                assert!(t.contains("Unknown"));
+                assert!(t.contains("Usage"));
+            }
+            _ => panic!("expected Output"),
+        }
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -58,6 +58,9 @@ pub mod compact;
 pub mod mcp_cmd;
 pub mod plugin_cmd;
 
+// First-party Chrome integration (Claude in Chrome)
+pub mod chrome_cmd;
+
 // KAIROS / assistant commands
 pub mod assistant;
 pub mod brief;
@@ -324,6 +327,12 @@ pub fn get_all_commands() -> Vec<Command> {
             aliases: vec![],
             description: "MCP server management (list, status)".into(),
             handler: Box::new(mcp_cmd::McpHandler),
+        },
+        Command {
+            name: "chrome".into(),
+            aliases: vec![],
+            description: "Claude in Chrome (first-party integration) status + reconnect".into(),
+            handler: Box::new(chrome_cmd::ChromeHandler),
         },
         Command {
             name: "plugin".into(),

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -38,6 +38,9 @@ pub struct GlobalConfig {
     pub system_prompt: Option<String>,
     /// Hooks configuration (keyed by hook point).
     pub hooks: Option<HashMap<String, serde_json::Value>>,
+    /// Whether Claude in Chrome should be enabled by default.
+    #[serde(rename = "claudeInChromeDefaultEnabled")]
+    pub claude_in_chrome_default_enabled: Option<bool>,
     /// API key override (not recommended -- prefer env vars).
     pub api_key: Option<String>,
     /// Additional arbitrary settings.
@@ -66,6 +69,9 @@ pub struct ProjectConfig {
     pub system_prompt: Option<String>,
     /// Hooks configuration.
     pub hooks: Option<HashMap<String, serde_json::Value>>,
+    /// Whether Claude in Chrome should be enabled by default for this project.
+    #[serde(rename = "claudeInChromeDefaultEnabled")]
+    pub claude_in_chrome_default_enabled: Option<bool>,
     /// Additional arbitrary settings.
     #[serde(flatten)]
     pub extra: HashMap<String, serde_json::Value>,
@@ -84,6 +90,7 @@ pub struct MergedConfig {
     #[allow(dead_code)]
     pub system_prompt: Option<String>,
     pub hooks: HashMap<String, serde_json::Value>,
+    pub claude_in_chrome_default_enabled: Option<bool>,
     pub api_key: Option<String>,
     #[allow(dead_code)]
     pub extra: HashMap<String, serde_json::Value>,
@@ -184,6 +191,9 @@ pub fn merge_configs(global: &GlobalConfig, project: &ProjectConfig) -> MergedCo
             .clone()
             .or_else(|| global.system_prompt.clone()),
         hooks: merge_maps(global.hooks.as_ref(), project.hooks.as_ref()),
+        claude_in_chrome_default_enabled: project
+            .claude_in_chrome_default_enabled
+            .or(global.claude_in_chrome_default_enabled),
         api_key: global.api_key.clone(),
         extra: merge_maps(Some(&global.extra), Some(&project.extra)),
     };
@@ -275,6 +285,7 @@ mod tests {
             model: Some("claude-opus".into()),
             backend: Some("codex".into()),
             verbose: Some(true),
+            claude_in_chrome_default_enabled: Some(true),
             ..Default::default()
         };
 
@@ -283,6 +294,7 @@ mod tests {
         assert_eq!(merged.backend.as_deref(), Some("codex"));
         assert_eq!(merged.theme.as_deref(), Some("dark")); // falls through to global
         assert!(merged.verbose);
+        assert_eq!(merged.claude_in_chrome_default_enabled, Some(true));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -332,12 +332,10 @@ fn main() -> ExitCode {
         // Mirror the full-init path: when Chrome subsystem is requested via
         // CLI / env, pre-register the first-party server name so the
         // `# Browser Automation` prompt fires under --dump-system-prompt too.
-        let chrome_wanted = cli.chrome
-            || (!cli.no_chrome
-                && matches!(
-                    std::env::var("CLAUDE_CODE_ENABLE_CFC").ok().as_deref(),
-                    Some("1") | Some("true") | Some("TRUE") | Some("yes") | Some("on")
-                ));
+        let chrome_config_default = settings::load_and_merge(&cwd)
+            .ok()
+            .and_then(|cfg| cfg.claude_in_chrome_default_enabled);
+        let chrome_wanted = chrome_requested(&cli, chrome_config_default);
         if chrome_wanted {
             browser_servers.insert(
                 crate::browser::common::CLAUDE_IN_CHROME_MCP_SERVER_NAME.to_string(),
@@ -477,13 +475,7 @@ async fn run_full_init(cli: Cli) -> anyhow::Result<ExitCode> {
         // (or equivalent) is on. The actual tools come online via #5; doing
         // this early means the system prompt, permissions, and /mcp list all
         // already know the capability is expected.
-        if cli.chrome
-            || (!cli.no_chrome
-                && matches!(
-                    std::env::var("CLAUDE_CODE_ENABLE_CFC").ok().as_deref(),
-                    Some("1") | Some("true") | Some("TRUE") | Some("yes") | Some("on")
-                ))
-        {
+        if chrome_requested(&cli, merged_config.claude_in_chrome_default_enabled) {
             browser_servers.insert(
                 crate::browser::common::CLAUDE_IN_CHROME_MCP_SERVER_NAME.to_string(),
             );
@@ -518,16 +510,10 @@ async fn run_full_init(cli: Cli) -> anyhow::Result<ExitCode> {
     {
         use crate::browser::session::{resolve_enablement, ChromeSession};
 
-        let cli_chrome = if cli.chrome {
-            Some(true)
-        } else if cli.no_chrome {
-            Some(false)
-        } else {
-            None
-        };
-        // TODO(#5): thread `claudeInChromeDefaultEnabled` out of settings.json.
-        // For now we pass None and rely on CLI flag + env var only.
-        let enablement = resolve_enablement(cli_chrome, None);
+        let enablement = resolve_enablement(
+            chrome_cli_override(&cli),
+            merged_config.claude_in_chrome_default_enabled,
+        );
         let session = ChromeSession::new(enablement);
         if let Err(e) = session.start() {
             warn!(error = %e, "Chrome subsystem startup failed");
@@ -985,6 +971,23 @@ fn resolve_cwd(cli: &Cli) -> String {
             .map(|p| p.to_string_lossy().to_string())
             .unwrap_or_else(|_| ".".to_string())
     })
+}
+
+fn chrome_cli_override(cli: &Cli) -> Option<bool> {
+    if cli.chrome {
+        Some(true)
+    } else if cli.no_chrome {
+        Some(false)
+    } else {
+        None
+    }
+}
+
+fn chrome_requested(cli: &Cli, config_default: Option<bool>) -> bool {
+    matches!(
+        crate::browser::session::resolve_enablement(chrome_cli_override(cli), config_default),
+        crate::browser::session::ChromeEnablement::Enabled
+    )
 }
 
 /// Resolve the permission mode from CLI arg or config.

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,6 +174,18 @@ struct Cli {
     #[arg(long = "computer-use")]
     computer_use: bool,
 
+    /// Enable the first-party Chrome integration ("Claude in Chrome"). Scans
+    /// for the Anthropic Chrome extension and installs the native messaging
+    /// host manifest. Overrides the `CLAUDE_CODE_ENABLE_CFC` env var and the
+    /// saved `claudeInChromeDefaultEnabled` config.
+    #[arg(long = "chrome", conflicts_with = "no_chrome")]
+    chrome: bool,
+
+    /// Explicitly disable the first-party Chrome integration for this session.
+    /// Overrides env and saved config.
+    #[arg(long = "no-chrome")]
+    no_chrome: bool,
+
     /// Launch web UI mode (HTTP server with chat interface).
     #[arg(long)]
     web: bool,
@@ -315,7 +327,22 @@ fn main() -> ExitCode {
         let cwd_path = std::path::Path::new(&cwd);
         let server_configs =
             crate::mcp::discovery::discover_mcp_servers(cwd_path).unwrap_or_default();
-        let browser_servers = crate::browser::detection::detect_browser_servers(&server_configs, &tools);
+        let mut browser_servers =
+            crate::browser::detection::detect_browser_servers(&server_configs, &tools);
+        // Mirror the full-init path: when Chrome subsystem is requested via
+        // CLI / env, pre-register the first-party server name so the
+        // `# Browser Automation` prompt fires under --dump-system-prompt too.
+        let chrome_wanted = cli.chrome
+            || (!cli.no_chrome
+                && matches!(
+                    std::env::var("CLAUDE_CODE_ENABLE_CFC").ok().as_deref(),
+                    Some("1") | Some("true") | Some("TRUE") | Some("yes") | Some("on")
+                ));
+        if chrome_wanted {
+            browser_servers.insert(
+                crate::browser::common::CLAUDE_IN_CHROME_MCP_SERVER_NAME.to_string(),
+            );
+        }
         crate::browser::detection::install_browser_servers(browser_servers);
 
         let (parts, _, _) = crate::engine::system_prompt::build_system_prompt(
@@ -444,8 +471,23 @@ async fn run_full_init(cli: Cli) -> anyhow::Result<ExitCode> {
         // Install the browser MCP server registry exactly once after MCP tools
         // are folded into the tool list. Used by system-prompt injection,
         // permission prompts, and `/mcp list` styling.
-        let browser_servers =
+        let mut browser_servers =
             crate::browser::detection::detect_browser_servers(&configs_for_browser, &tools);
+        // Pre-register the first-party Chrome MCP server name when --chrome
+        // (or equivalent) is on. The actual tools come online via #5; doing
+        // this early means the system prompt, permissions, and /mcp list all
+        // already know the capability is expected.
+        if cli.chrome
+            || (!cli.no_chrome
+                && matches!(
+                    std::env::var("CLAUDE_CODE_ENABLE_CFC").ok().as_deref(),
+                    Some("1") | Some("true") | Some("TRUE") | Some("yes") | Some("on")
+                ))
+        {
+            browser_servers.insert(
+                crate::browser::common::CLAUDE_IN_CHROME_MCP_SERVER_NAME.to_string(),
+            );
+        }
         if !browser_servers.is_empty() {
             info!(
                 count = browser_servers.len(),
@@ -465,6 +507,34 @@ async fn run_full_init(cli: Cli) -> anyhow::Result<ExitCode> {
             "Computer Use: registered native desktop control tools"
         );
         tools.extend(cu_tools);
+    }
+
+    // ── B.3f: Start the first-party Chrome subsystem (if --chrome) ─────
+    // Resolves CLI flag → env → saved config, runs extension detection and
+    // native-host manifest install. Tool registration for the first-party
+    // bridge lands in #5; for now this just flips state so /chrome reports
+    // accurate status and the system-prompt assembler knows a browser path
+    // is active.
+    {
+        use crate::browser::session::{resolve_enablement, ChromeSession};
+
+        let cli_chrome = if cli.chrome {
+            Some(true)
+        } else if cli.no_chrome {
+            Some(false)
+        } else {
+            None
+        };
+        // TODO(#5): thread `claudeInChromeDefaultEnabled` out of settings.json.
+        // For now we pass None and rely on CLI flag + env var only.
+        let enablement = resolve_enablement(cli_chrome, None);
+        let session = ChromeSession::new(enablement);
+        if let Err(e) = session.start() {
+            warn!(error = %e, "Chrome subsystem startup failed");
+        }
+        if crate::browser::state::is_enabled() {
+            info!("Claude in Chrome subsystem active — use /chrome for status");
+        }
     }
 
     // ── B.4: Create AppState ─────────────────────────────────────────

--- a/tests/e2e_chrome_subsystem.rs
+++ b/tests/e2e_chrome_subsystem.rs
@@ -1,0 +1,141 @@
+//! E2E smoke tests for the first-party Chrome integration skeleton (Issue #4).
+//!
+//! #4 adds the user-facing surface only — the CLI flag, the `/chrome`
+//! command, and the subsystem state machine. Issue #5 wires the native host
+//! and socket transport. These tests verify:
+//!
+//! 1. `--chrome` is accepted as a flag and doesn't crash startup.
+//! 2. `--no-chrome` is accepted and mutually exclusive with `--chrome`.
+//! 3. `--chrome` causes the browser system-prompt section to appear (via
+//!    registry pre-seeding with `claude-in-chrome`) even without a real
+//!    Chrome extension connected.
+//! 4. `CLAUDE_CODE_ENABLE_CFC=1` works the same as `--chrome` when no CLI flag is given.
+//!
+//! No live Chrome or extension required.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[path = "test_workspace.rs"]
+#[allow(dead_code)]
+mod test_workspace;
+
+fn cli() -> Command {
+    Command::cargo_bin("claude-code-rs").expect("binary not found")
+}
+
+fn strip_api_keys(cmd: &mut Command) -> &mut Command {
+    cmd.env("ANTHROPIC_API_KEY", "")
+        .env("AZURE_API_KEY", "")
+        .env("OPENAI_API_KEY", "")
+        .env("OPENROUTER_API_KEY", "")
+        .env("GOOGLE_API_KEY", "")
+        .env("DEEPSEEK_API_KEY", "")
+        .env_remove("ANTHROPIC_AUTH_TOKEN")
+        .env_remove("CLAUDE_CODE_ENABLE_CFC")
+}
+
+// =========================================================================
+// 1. Flag acceptance
+// =========================================================================
+
+#[test]
+fn chrome_flag_is_accepted() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut cmd = cli();
+    strip_api_keys(&mut cmd)
+        .args(["--chrome", "--init-only", "-C", dir.path().to_str().unwrap()])
+        .env("CC_RUST_HOME", dir.path().to_str().unwrap())
+        .assert()
+        .success();
+}
+
+#[test]
+fn no_chrome_flag_is_accepted() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut cmd = cli();
+    strip_api_keys(&mut cmd)
+        .args([
+            "--no-chrome",
+            "--init-only",
+            "-C",
+            dir.path().to_str().unwrap(),
+        ])
+        .env("CC_RUST_HOME", dir.path().to_str().unwrap())
+        .assert()
+        .success();
+}
+
+#[test]
+fn chrome_and_no_chrome_are_mutually_exclusive() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut cmd = cli();
+    strip_api_keys(&mut cmd)
+        .args([
+            "--chrome",
+            "--no-chrome",
+            "--init-only",
+            "-C",
+            dir.path().to_str().unwrap(),
+        ])
+        .env("CC_RUST_HOME", dir.path().to_str().unwrap())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+// =========================================================================
+// 2. Prompt integration
+// =========================================================================
+
+#[test]
+fn chrome_flag_emits_browser_automation_section() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut cmd = cli();
+    strip_api_keys(&mut cmd)
+        .args([
+            "--dump-system-prompt",
+            "-C",
+            dir.path().to_str().unwrap(),
+        ])
+        .env("CC_RUST_HOME", dir.path().to_str().unwrap())
+        .env("CLAUDE_CODE_ENABLE_CFC", "1")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("# Browser Automation"))
+        .stdout(predicate::str::contains("claude-in-chrome"));
+}
+
+#[test]
+fn no_env_no_cli_no_browser_section() {
+    // Without --chrome, CFC env, or any external browser MCP, the section
+    // must NOT appear.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut cmd = cli();
+    strip_api_keys(&mut cmd)
+        .args([
+            "--dump-system-prompt",
+            "-C",
+            dir.path().to_str().unwrap(),
+        ])
+        .env("CC_RUST_HOME", dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("# Browser Automation").not());
+}
+
+#[test]
+fn cfc_env_truthy_enables_subsystem() {
+    // The dump-system-prompt fast path doesn't start the session, but the
+    // environment-variable resolution is a pure function we can exercise
+    // via the session module's unit tests. Here we just confirm that
+    // supplying CFC env doesn't crash startup under --init-only.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut cmd = cli();
+    strip_api_keys(&mut cmd)
+        .args(["--init-only", "-C", dir.path().to_str().unwrap()])
+        .env("CC_RUST_HOME", dir.path().to_str().unwrap())
+        .env("CLAUDE_CODE_ENABLE_CFC", "true")
+        .assert()
+        .success();
+}


### PR DESCRIPTION
## Summary

Closes #4. Adds the first-party "Claude in Chrome" skeleton — CLI flag, `/chrome` command, state machine, cross-platform browser config, setup helpers — stacked on top of the browser MCP work in #2/#3 ([PR #14](https://github.com/Crsei/claude-code-rust/pull/14)).

Native-host transport and the real tool bridge follow in #5.

> **⚠️ Stacked PR**: this branch contains the commits from [PR #14](https://github.com/Crsei/claude-code-rust/pull/14) (issues #2/#3) **plus** the Chrome skeleton on top. Merge #14 first, then this one — the diff will shrink to just the Chrome-specific commit.

## What changed (on top of #14)

### Rust — new `src/browser/` submodules

- **`common.rs`** — cross-platform table for 7 Chromium-based browsers (Chrome, Brave, Arc, Chromium, Edge, Vivaldi, Opera) × 3 OSs. Covers user-data directories, `NativeMessagingHosts/` directories, Windows registry keys, Opera's `AppData/Roaming` quirk, and every supported extension ID (prod + dev + ant).
- **`state.rs`** — `ChromeConnectionState` enum (`Disabled` / `Enabled` / `Connecting` / `Connected { browser }` / `Error(String)`) behind a process-wide `parking_lot::RwLock`. `Connecting`/`Connected` are pre-declared for #5's transport loop.
- **`setup.rs`** — extension detection (scan `Extensions/{id}/` across every browser's `Default` and `Profile N` dirs), wrapper-script generation (`.bat` / `/bin/sh` — needed because Chrome's manifest `path` can't take arguments), native-host manifest writer (per-browser JSON on mac/linux; one manifest + `reg add` per browser on Windows).
- **`session.rs`** — `ChromeSession` lifecycle. `resolve_enablement()` implements CLI > env > config > default precedence.

### CLI + slash command

- **`--chrome` / `--no-chrome`** flags (clap `conflicts_with`).
- **`CLAUDE_CODE_ENABLE_CFC`** env var (truthy / falsy / unset).
- **`/chrome`** slash command: status (default), `reconnect`, `help`. Shows extension-install state, connection state, detected browser, action URLs (install / permissions / reconnect), and per-state hints ("enable with `--chrome`", "try `/chrome reconnect`", etc.).

### Integration with #2/#3

- `main.rs` Phase B starts the Chrome session after MCP init.
- When Chrome is requested (via CLI or env), the browser MCP server registry from #3 is pre-seeded with `claude-in-chrome`. This makes the `# Browser Automation` prompt section fire immediately — the model learns the capability is available even before #5's real tools are online.
- Same pre-seed mirrored in `--dump-system-prompt` fast path for config validation.

## NOT in this PR (issue #5)

- Native messaging host binary mode (`--chrome-native-host`)
- MCP stdio bridge mode (`--claude-in-chrome-mcp`)
- Unix socket / Windows named-pipe transport
- Actual tool execution (navigate / click / read_page / …)

The skeleton deliberately leaves those attachment points ready: the native-host manifest points at `{current_exe} --chrome-native-host` (a flag #5 adds), and the state machine has `Connecting`/`Connected` variants waiting.

## Results

- `cargo build --bin claude-code-rs`: clean (6 pre-existing warnings unchanged).
- Unit: `cargo test chrome` → 6 passed; `cargo test browser` → 38 passed (no regression from #2/#3).
- E2E: `cargo test --test e2e_chrome_subsystem` → 6 passed (flag acceptance, mutex exclusion, prompt emission under CFC env, prompt absence without enable).
- Regression: `cargo test --test e2e_browser_mcp` → 3/3 still passing.

## Test plan

- [x] Compile: `cargo build`
- [x] Unit + e2e tests all green (53 browser/chrome tests total, new + existing)
- [ ] **Manual (pending #5)**: install the Anthropic Chrome extension, run `claude --chrome`, verify `/chrome` shows extension detected and reports the right browser. Native-host handshake is wired in #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)