### PR TITLE
Align config + permission systems with Claude Code spec (issues #6, #7)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -27,7 +27,11 @@ fn main() {
     println!("cargo:warning=Building web-ui frontend...");
 
     // Check if npm is available
-    let npm_cmd = if cfg!(target_os = "windows") { "npm.cmd" } else { "npm" };
+    let npm_cmd = if cfg!(target_os = "windows") {
+        "npm.cmd"
+    } else {
+        "npm"
+    };
 
     let npm_check = Command::new(npm_cmd).arg("--version").output();
     if npm_check.is_err() || !npm_check.unwrap().status.success() {
@@ -49,7 +53,10 @@ fn main() {
         match install {
             Ok(s) if s.success() => {}
             Ok(s) => {
-                println!("cargo:warning=npm install failed (exit {}), skipping web build", s);
+                println!(
+                    "cargo:warning=npm install failed (exit {}), skipping web build",
+                    s
+                );
                 return;
             }
             Err(e) => {

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -50,10 +50,35 @@ These live **inside your project directory** (not under `$ROOT`) and behave like
 | Path | Purpose |
 |------|---------|
 | `{cwd}/.cc-rust/settings.json` | Project-level settings. Loaded in addition to global settings. |
+| `{cwd}/.cc-rust/settings.local.json` | Project-local overrides. Intended to be gitignored. |
 | `{cwd}/.cc-rust/memory/` | Project-scoped memory. |
 | `{cwd}/.cc-rust/skills/` | Project-scoped skills. |
 
 These are discovered by ancestor-walk from the current working directory.
+
+## Settings layering
+
+`settings.json` is loaded from up to four files and merged in this order
+(higher overrides lower):
+
+| Priority | Source | Path |
+|---------:|--------|------|
+| 1 (lowest) | `managed` | Windows: `%ProgramData%\cc-rust\settings.json` · others: `/etc/cc-rust/managed-settings.json` · or `$CC_RUST_MANAGED_SETTINGS` |
+| 2 | `user` | `$ROOT/settings.json` |
+| 3 | `project` | `{cwd}/.cc-rust/settings.json` |
+| 4 | `local` | `{cwd}/.cc-rust/settings.local.json` |
+| 5 | `env` | `CLAUDE_*` / `CC_*` overrides |
+| 6 (highest) | `cli` | `--model`, `--verbose`, `--permission-mode`, ... |
+
+Use `/config show` to see the merged effective values; `/config sources`
+prints which layer won for each key. Schema is at
+[`docs/schemas/settings.schema.json`](schemas/settings.schema.json) and
+generated from `src/config/settings.rs::settings_schema()` (the in-crate
+test `schema_file_matches_runtime` keeps them in sync).
+
+When `/config set` writes a key, the existing file is copied to a
+timestamped `.bak` sibling first; the five most recent backups are
+retained.
 
 ## Platform notes
 

--- a/docs/schemas/settings.schema.json
+++ b/docs/schemas/settings.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cc-rust/settings.schema.json",
+  "title": "cc-rust settings",
+  "description": "On-disk shape of settings.json (managed/user/project/local). Generated from src/config/settings.rs::settings_schema() — keep in sync via the `schema_file_matches_runtime` test.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "model": { "type": "string" },
+    "backend": { "type": "string", "enum": ["native", "codex"] },
+    "theme": { "type": "string" },
+    "verbose": { "type": "boolean" },
+    "permissionMode": {
+      "type": "string",
+      "enum": ["default", "ask", "auto", "bypass", "plan", "acceptEdits", "dontAsk"]
+    },
+    "allowedTools": { "type": "array", "items": { "type": "string" } },
+    "permissions": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "defaultMode": {
+          "type": "string",
+          "enum": ["default", "ask", "auto", "bypass", "plan", "acceptEdits", "dontAsk"]
+        },
+        "allow": { "type": "array", "items": { "type": "string" } },
+        "ask": { "type": "array", "items": { "type": "string" } },
+        "deny": { "type": "array", "items": { "type": "string" } },
+        "additionalDirectories": { "type": "array", "items": { "type": "string" } },
+        "enableBypassMode": { "type": "boolean" },
+        "enableAutoMode": { "type": "boolean" }
+      }
+    },
+    "sandbox": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "mode": { "type": "string" },
+        "allowedCommands": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "hooks": { "type": "object", "additionalProperties": true },
+    "statusLine": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": { "type": "string" },
+        "command": { "type": "string" },
+        "script": { "type": "string" },
+        "format": { "type": "string" }
+      }
+    },
+    "outputStyle": { "type": "string" },
+    "language": { "type": "string" },
+    "voiceEnabled": { "type": "boolean" },
+    "editorMode": { "type": "string", "enum": ["normal", "vim"] },
+    "viewMode": { "type": "string" },
+    "spinnerTips": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "intervalMs": { "type": "integer", "minimum": 0 },
+        "customTips": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "terminalProgressBarEnabled": { "type": "boolean" },
+    "availableModels": { "type": "array", "items": { "type": "string" } },
+    "effortLevel": { "type": "string" },
+    "fastMode": { "type": "boolean" },
+    "fastModePerSessionOptIn": { "type": "boolean" },
+    "teammateMode": { "type": "boolean" },
+    "claudeInChromeDefaultEnabled": { "type": "boolean" },
+    "systemPrompt": { "type": "string" },
+    "apiKey": { "type": "string" }
+  }
+}

--- a/docs/schemas/settings.schema.json
+++ b/docs/schemas/settings.schema.json
@@ -36,8 +36,36 @@
       "additionalProperties": true,
       "properties": {
         "enabled": { "type": "boolean" },
-        "mode": { "type": "string" },
-        "allowedCommands": { "type": "array", "items": { "type": "string" } }
+        "mode": {
+          "type": "string",
+          "enum": ["read-only", "workspace", "full"]
+        },
+        "failIfUnavailable": { "type": "boolean" },
+        "allowUnsandboxedCommands": { "type": "boolean" },
+        "allowManagedReadPathsOnly": { "type": "boolean" },
+        "allowManagedDomainsOnly": { "type": "boolean" },
+        "excludedCommands": { "type": "array", "items": { "type": "string" } },
+        "allowedCommands": { "type": "array", "items": { "type": "string" } },
+        "filesystem": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "allowRead": { "type": "array", "items": { "type": "string" } },
+            "denyRead": { "type": "array", "items": { "type": "string" } },
+            "allowWrite": { "type": "array", "items": { "type": "string" } },
+            "denyWrite": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "network": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "disabled": { "type": "boolean" },
+            "allowedDomains": { "type": "array", "items": { "type": "string" } },
+            "httpProxyPort": { "type": "integer", "minimum": 0, "maximum": 65535 },
+            "socksProxyPort": { "type": "integer", "minimum": 0, "maximum": 65535 }
+          }
+        }
       }
     },
     "hooks": { "type": "object", "additionalProperties": true },

--- a/src/api/openai_compat.rs
+++ b/src/api/openai_compat.rs
@@ -305,11 +305,7 @@ pub(crate) async fn openai_compat_stream(
         req_builder = req_builder.header("Authorization", format!("Bearer {}", api_key));
     }
 
-    let response = match req_builder
-        .json(&body)
-        .send()
-        .await
-    {
+    let response = match req_builder.json(&body).send().await {
         Ok(resp) => resp,
         Err(e) => {
             tracing::error!(

--- a/src/browser/common.rs
+++ b/src/browser/common.rs
@@ -249,11 +249,7 @@ fn config_for(browser: ChromiumBrowser) -> BrowserConfig {
         },
         ChromiumBrowser::Opera => BrowserConfig {
             macos_app_bundle: "Opera",
-            macos_data: &[
-                "Library",
-                "Application Support",
-                "com.operasoftware.Opera",
-            ],
+            macos_data: &["Library", "Application Support", "com.operasoftware.Opera"],
             macos_native_messaging: &[
                 "Library",
                 "Application Support",
@@ -407,9 +403,7 @@ pub fn native_messaging_path_for(browser: ChromiumBrowser) -> Option<PathBuf> {
 pub fn all_browser_data_paths() -> Vec<BrowserDataPath> {
     BROWSER_DETECTION_ORDER
         .iter()
-        .filter_map(|&browser| {
-            data_path_for(browser).map(|path| BrowserDataPath { browser, path })
-        })
+        .filter_map(|&browser| data_path_for(browser).map(|path| BrowserDataPath { browser, path }))
         .collect()
 }
 
@@ -419,8 +413,7 @@ pub fn all_native_messaging_paths() -> Vec<NativeMessagingPath> {
     BROWSER_DETECTION_ORDER
         .iter()
         .filter_map(|&browser| {
-            native_messaging_path_for(browser)
-                .map(|path| NativeMessagingPath { browser, path })
+            native_messaging_path_for(browser).map(|path| NativeMessagingPath { browser, path })
         })
         .collect()
 }
@@ -448,7 +441,11 @@ pub fn all_windows_registry_keys() -> Vec<WindowsRegistryKey> {
 /// Supported: macOS, Linux, Windows. Everything else (non-WSL BSD, etc.)
 /// returns `false` and the `/chrome` command should tell the user so.
 pub fn supports_claude_in_chrome() -> bool {
-    cfg!(any(target_os = "macos", target_os = "linux", target_os = "windows"))
+    cfg!(any(
+        target_os = "macos",
+        target_os = "linux",
+        target_os = "windows"
+    ))
 }
 
 // ---------------------------------------------------------------------------
@@ -461,8 +458,7 @@ mod tests {
 
     #[test]
     fn all_browsers_have_distinct_slugs() {
-        let mut slugs: Vec<&str> =
-            BROWSER_DETECTION_ORDER.iter().map(|b| b.slug()).collect();
+        let mut slugs: Vec<&str> = BROWSER_DETECTION_ORDER.iter().map(|b| b.slug()).collect();
         slugs.sort_unstable();
         slugs.dedup();
         assert_eq!(slugs.len(), BROWSER_DETECTION_ORDER.len());
@@ -497,7 +493,10 @@ mod tests {
         // At least Chrome should resolve to *some* path on each supported OS.
         let p = data_path_for(ChromiumBrowser::Chrome);
         if supports_claude_in_chrome() {
-            assert!(p.is_some(), "Chrome data path should resolve on supported OS");
+            assert!(
+                p.is_some(),
+                "Chrome data path should resolve on supported OS"
+            );
         }
     }
 

--- a/src/browser/mcp_bridge.rs
+++ b/src/browser/mcp_bridge.rs
@@ -276,7 +276,9 @@ async fn connect_native_host() -> Result<tokio::net::UnixStream> {
                 debug!(path = %path.display(), "mcp-bridge: connected to native host");
                 return Ok(s);
             }
-            Err(e) => debug!(path = %path.display(), error = %e, "mcp-bridge: socket not available"),
+            Err(e) => {
+                debug!(path = %path.display(), error = %e, "mcp-bridge: socket not available")
+            }
         }
     }
     anyhow::bail!(
@@ -350,16 +352,17 @@ async fn socket_reader_task<R: tokio::io::AsyncReadExt + Unpin>(
                 // Native host strips `type` before forwarding, but the
                 // extension includes `request_id` (per the wire protocol).
                 // If this is a tool_response for a known request, deliver it.
-                let request_id = value
-                    .get("request_id")
-                    .and_then(|v| v.as_u64());
+                let request_id = value.get("request_id").and_then(|v| v.as_u64());
                 if let Some(id) = request_id {
                     if let Some(sender) = pending.lock().remove(&id) {
                         let _ = sender.send(value);
                         continue;
                     }
                 }
-                debug!(?value, "mcp-bridge: unsolicited socket message (no matching request_id)");
+                debug!(
+                    ?value,
+                    "mcp-bridge: unsolicited socket message (no matching request_id)"
+                );
             }
             Ok(None) => {
                 warn!("mcp-bridge: native-host socket closed");
@@ -387,8 +390,7 @@ async fn forward_tool_call(
     connections: &NativeConnectionStore,
     method: &str,
     params: Value,
-) -> Result<Value>
-{
+) -> Result<Value> {
     let connection = ensure_native_host_connection(connections).await?;
     let request_id = next_request_id();
     let (tx, rx) = oneshot::channel();
@@ -547,7 +549,11 @@ mod tests {
     #[test]
     fn tool_catalogue_has_input_schemas() {
         for tool in tool_catalogue() {
-            assert!(tool.get("inputSchema").is_some(), "tool missing inputSchema: {:?}", tool);
+            assert!(
+                tool.get("inputSchema").is_some(),
+                "tool missing inputSchema: {:?}",
+                tool
+            );
         }
     }
 

--- a/src/browser/native_host.rs
+++ b/src/browser/native_host.rs
@@ -101,7 +101,10 @@ pub async fn read_framed<R: AsyncReadExt + Unpin>(reader: &mut R) -> io::Result<
 }
 
 /// Write one framed message to an async writer.
-pub async fn write_framed<W: AsyncWriteExt + Unpin>(writer: &mut W, payload: &[u8]) -> io::Result<()> {
+pub async fn write_framed<W: AsyncWriteExt + Unpin>(
+    writer: &mut W,
+    payload: &[u8],
+) -> io::Result<()> {
     let len = payload.len();
     if len > MAX_MESSAGE_SIZE as usize {
         return Err(io::Error::new(
@@ -250,7 +253,10 @@ struct McpToolRequest {
 
 fn chrome_tool_request_message(req: McpToolRequest) -> Value {
     let mut payload = serde_json::Map::new();
-    payload.insert("type".to_string(), Value::String("tool_request".to_string()));
+    payload.insert(
+        "type".to_string(),
+        Value::String("tool_request".to_string()),
+    );
     payload.insert("method".to_string(), Value::String(req.method));
     payload.insert("params".to_string(), req.params.unwrap_or(Value::Null));
     if let Some(request_id) = req.request_id {
@@ -260,7 +266,11 @@ fn chrome_tool_request_message(req: McpToolRequest) -> Value {
 }
 
 #[cfg(unix)]
-async fn run_socket_server(chrome: ChromeSink, mcp_bus: McpBus, client_count: Arc<SyncMutex<usize>>) -> Result<()> {
+async fn run_socket_server(
+    chrome: ChromeSink,
+    mcp_bus: McpBus,
+    client_count: Arc<SyncMutex<usize>>,
+) -> Result<()> {
     use tokio::net::UnixListener;
     prepare_socket_dir()?;
     let path = secure_socket_path();
@@ -291,7 +301,11 @@ async fn run_socket_server(chrome: ChromeSink, mcp_bus: McpBus, client_count: Ar
 }
 
 #[cfg(windows)]
-async fn run_socket_server(chrome: ChromeSink, mcp_bus: McpBus, client_count: Arc<SyncMutex<usize>>) -> Result<()> {
+async fn run_socket_server(
+    chrome: ChromeSink,
+    mcp_bus: McpBus,
+    client_count: Arc<SyncMutex<usize>>,
+) -> Result<()> {
     use tokio::net::windows::named_pipe::{PipeMode, ServerOptions};
     let pipe_name = secure_socket_path();
     let pipe_name_str = pipe_name.to_string_lossy().to_string();
@@ -365,9 +379,7 @@ where
         };
         match serde_json::from_slice::<McpToolRequest>(&frame) {
             Ok(req) => {
-                let _ = chrome
-                    .send(&chrome_tool_request_message(req))
-                    .await;
+                let _ = chrome.send(&chrome_tool_request_message(req)).await;
             }
             Err(e) => {
                 warn!(error = %e, "chrome-native-host: bad tool_request from MCP client");
@@ -417,26 +429,24 @@ pub async fn run() -> Result<()> {
     let mut stdin = tokio::io::stdin();
     loop {
         match read_framed(&mut stdin).await {
-            Ok(Some(bytes)) => {
-                match serde_json::from_slice::<ChromeMessage>(&bytes) {
-                    Ok(msg) => {
-                        if let Err(e) =
-                            handle_chrome_message(msg, &chrome, &mcp_bus, &client_count).await
-                        {
-                            warn!(error = %e, "chrome-native-host: handler failed");
-                        }
-                    }
-                    Err(e) => {
-                        warn!(error = %e, "chrome-native-host: invalid Chrome JSON");
-                        let _ = chrome
-                            .send(&make_chrome_message(
-                                "error",
-                                serde_json::json!({ "error": "Invalid message format" }),
-                            ))
-                            .await;
+            Ok(Some(bytes)) => match serde_json::from_slice::<ChromeMessage>(&bytes) {
+                Ok(msg) => {
+                    if let Err(e) =
+                        handle_chrome_message(msg, &chrome, &mcp_bus, &client_count).await
+                    {
+                        warn!(error = %e, "chrome-native-host: handler failed");
                     }
                 }
-            }
+                Err(e) => {
+                    warn!(error = %e, "chrome-native-host: invalid Chrome JSON");
+                    let _ = chrome
+                        .send(&make_chrome_message(
+                            "error",
+                            serde_json::json!({ "error": "Invalid message format" }),
+                        ))
+                        .await;
+                }
+            },
             Ok(None) => {
                 info!("chrome-native-host: Chrome closed stdin, exiting");
                 break;

--- a/src/browser/permissions.rs
+++ b/src/browser/permissions.rs
@@ -117,8 +117,9 @@ fn action_verb(action: &str) -> String {
         "navigate" | "navigate_page" | "goto" => "navigating the browser".to_string(),
         "tabs_create" | "tabs_create_mcp" | "new_page" => "opening a new browser tab".to_string(),
         "tabs_close" | "tabs_close_mcp" | "close_page" => "closing a browser tab".to_string(),
-        "tabs_context" | "tabs_context_mcp" | "list_pages" | "select_page"
-        | "switch_browser" => "reading tab context".to_string(),
+        "tabs_context" | "tabs_context_mcp" | "list_pages" | "select_page" | "switch_browser" => {
+            "reading tab context".to_string()
+        }
         "read_page" | "get_page_text" | "get_page" => "reading the current page".to_string(),
         "take_snapshot" | "snapshot" => "taking a DOM snapshot".to_string(),
         "take_screenshot" | "screenshot" => "taking a screenshot".to_string(),
@@ -160,16 +161,28 @@ mod tests {
 
     #[test]
     fn categorizes_by_action_basename() {
-        assert_eq!(classify_browser_action("navigate"), BrowserCategory::Navigation);
+        assert_eq!(
+            classify_browser_action("navigate"),
+            BrowserCategory::Navigation
+        );
         assert_eq!(classify_browser_action("read_page"), BrowserCategory::Read);
         assert_eq!(classify_browser_action("click"), BrowserCategory::Write);
-        assert_eq!(classify_browser_action("upload_file"), BrowserCategory::Upload);
-        assert_eq!(classify_browser_action("evaluate_script"), BrowserCategory::JavaScript);
+        assert_eq!(
+            classify_browser_action("upload_file"),
+            BrowserCategory::Upload
+        );
+        assert_eq!(
+            classify_browser_action("evaluate_script"),
+            BrowserCategory::JavaScript
+        );
         assert_eq!(
             classify_browser_action("list_console_messages"),
             BrowserCategory::Observability
         );
-        assert_eq!(classify_browser_action("something_else"), BrowserCategory::Other);
+        assert_eq!(
+            classify_browser_action("something_else"),
+            BrowserCategory::Other
+        );
     }
 
     #[test]

--- a/src/browser/session.rs
+++ b/src/browser/session.rs
@@ -203,7 +203,11 @@ mod tests {
         with_clean_env(|| {
             std::env::set_var("CLAUDE_CODE_ENABLE_CFC", "true");
             let got = resolve_enablement(Some(false), Some(true));
-            assert_eq!(got, ChromeEnablement::Disabled, "--no-chrome overrides env and config");
+            assert_eq!(
+                got,
+                ChromeEnablement::Disabled,
+                "--no-chrome overrides env and config"
+            );
             std::env::remove_var("CLAUDE_CODE_ENABLE_CFC");
         });
     }

--- a/src/browser/setup.rs
+++ b/src/browser/setup.rs
@@ -24,8 +24,8 @@ use anyhow::{Context, Result};
 use tracing::{debug, warn};
 
 use super::common::{
-    all_browser_data_paths, all_native_messaging_paths, all_windows_registry_keys,
-    extension_ids, BrowserDataPath, ChromiumBrowser, NATIVE_HOST_IDENTIFIER,
+    all_browser_data_paths, all_native_messaging_paths, all_windows_registry_keys, extension_ids,
+    BrowserDataPath, ChromiumBrowser, NATIVE_HOST_IDENTIFIER,
 };
 
 // ---------------------------------------------------------------------------
@@ -263,10 +263,7 @@ fn register_windows_native_hosts(manifest_path: &Path) -> Result<()> {
     let manifest_path_str = manifest_path.to_string_lossy().to_string();
 
     for entry in all_windows_registry_keys() {
-        let full_key = format!(
-            "HKCU\\{}\\{}",
-            entry.key, NATIVE_HOST_IDENTIFIER
-        );
+        let full_key = format!("HKCU\\{}\\{}", entry.key, NATIVE_HOST_IDENTIFIER);
         let output = Command::new("reg")
             .args([
                 "add",
@@ -355,7 +352,10 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(10));
         let path2 = create_wrapper_script("\"/bin/echo\" hello").unwrap();
         let mtime2 = fs::metadata(&path2).unwrap().modified().unwrap();
-        assert_eq!(mtime1, mtime2, "wrapper should not be rewritten when unchanged");
+        assert_eq!(
+            mtime1, mtime2,
+            "wrapper should not be rewritten when unchanged"
+        );
 
         if let Some(v) = prev_home {
             std::env::set_var("HOME", v);

--- a/src/browser/tool_rendering.rs
+++ b/src/browser/tool_rendering.rs
@@ -66,9 +66,9 @@ pub fn infer_kind(action: &str, has_image: bool) -> BrowserResultKind {
         },
         BrowserCategory::Write => BrowserResultKind::WriteAck,
         BrowserCategory::Observability => match action {
-            "get_network_request"
-            | "list_network_requests"
-            | "read_network_requests" => BrowserResultKind::NetworkLog,
+            "get_network_request" | "list_network_requests" | "read_network_requests" => {
+                BrowserResultKind::NetworkLog
+            }
             _ => BrowserResultKind::ConsoleLog,
         },
         _ => BrowserResultKind::Generic,
@@ -209,10 +209,7 @@ mod tests {
             BrowserResultKind::DomSnapshot
         );
         // screenshot flag dominates
-        assert_eq!(
-            infer_kind("anything", true),
-            BrowserResultKind::Screenshot
-        );
+        assert_eq!(infer_kind("anything", true), BrowserResultKind::Screenshot);
         assert_eq!(infer_kind("click", false), BrowserResultKind::WriteAck);
         assert_eq!(
             infer_kind("list_console_messages", false),

--- a/src/browser/transport.rs
+++ b/src/browser/transport.rs
@@ -55,10 +55,7 @@ pub fn socket_dir() -> PathBuf {
 pub fn secure_socket_path() -> PathBuf {
     if cfg!(windows) {
         let user = socket_username();
-        PathBuf::from(format!(
-            r"\\.\pipe\claude-mcp-browser-bridge-{}",
-            user
-        ))
+        PathBuf::from(format!(r"\\.\pipe\claude-mcp-browser-bridge-{}", user))
     } else {
         let pid = std::process::id();
         socket_dir().join(format!("{}.sock", pid))

--- a/src/commands/chrome_cmd.rs
+++ b/src/commands/chrome_cmd.rs
@@ -46,9 +46,7 @@ fn render_status() -> String {
 
     if !supports_claude_in_chrome() {
         lines.push("  Platform: UNSUPPORTED".into());
-        lines.push(
-            "  Claude in Chrome is only available on macOS, Linux, and Windows.".into(),
-        );
+        lines.push("  Claude in Chrome is only available on macOS, Linux, and Windows.".into());
         return lines.join("\n");
     }
 
@@ -177,9 +175,9 @@ fn handle_reconnect() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bootstrap::SessionId;
     use crate::browser::common::ChromiumBrowser;
     use crate::browser::state::{self, ChromeConnectionState};
-    use crate::bootstrap::SessionId;
     use crate::types::app_state::AppState;
     use std::path::PathBuf;
 

--- a/src/commands/config_cmd.rs
+++ b/src/commands/config_cmd.rs
@@ -685,7 +685,7 @@ mod tests {
             _ => panic!("Expected Output result"),
         }
         assert_eq!(ctx.app_state.main_loop_model, "claude-opus");
-        assert!(settings::user_settings_path().exists());
+        assert!(dir.path().join("settings.json").exists());
     }
 
     #[tokio::test]

--- a/src/commands/config_cmd.rs
+++ b/src/commands/config_cmd.rs
@@ -78,12 +78,7 @@ fn handle_show(parts: &[&str], ctx: &CommandContext) -> Result<CommandResult> {
         lines.push(format!("  {:<32} {:<10} {}", k, src(src_key), v));
     };
 
-    row(
-        "model",
-        state.main_loop_model.clone(),
-        "model",
-        &mut lines,
-    );
+    row("model", state.main_loop_model.clone(), "model", &mut lines);
     row(
         "backend",
         state.main_loop_backend.clone(),
@@ -100,12 +95,7 @@ fn handle_show(parts: &[&str], ctx: &CommandContext) -> Result<CommandResult> {
         "theme",
         &mut lines,
     );
-    row(
-        "verbose",
-        state.verbose.to_string(),
-        "verbose",
-        &mut lines,
-    );
+    row("verbose", state.verbose.to_string(), "verbose", &mut lines);
     row(
         "permissionMode",
         state
@@ -260,14 +250,17 @@ fn handle_show(parts: &[&str], ctx: &CommandContext) -> Result<CommandResult> {
 
     lines.push(String::new());
     lines.push("File locations:".into());
-    lines.push(format!("  user:    {}", settings::user_settings_path().display()));
+    lines.push(format!(
+        "  user:    {}",
+        settings::user_settings_path().display()
+    ));
     lines.push(format!(
         "  project: {}",
-        ctx.cwd.join(".cc-rust").join("settings.json").display()
+        settings::project_settings_path(&ctx.cwd).display()
     ));
     lines.push(format!(
         "  local:   {}",
-        ctx.cwd.join(".cc-rust").join("settings.local.json").display()
+        settings::local_settings_path(&ctx.cwd).display()
     ));
     lines.push(format!(
         "  managed: {}",
@@ -409,12 +402,12 @@ fn handle_set(parts: &[&str], ctx: &mut CommandContext) -> Result<CommandResult>
         WriteScope::Project => SettingsSource::Project,
         WriteScope::Local => SettingsSource::Local,
     };
-    ctx.app_state
-        .settings
-        .sources
-        .insert(key.to_string(), src);
+    ctx.app_state.settings.sources.insert(key.to_string(), src);
 
-    Ok(CommandResult::Output(format!("{}\n{}", in_memory_msg, file_msg)))
+    Ok(CommandResult::Output(format!(
+        "{}\n{}",
+        in_memory_msg, file_msg
+    )))
 }
 
 /// Apply a key=value to the live AppState. Returns a user-facing message.
@@ -448,6 +441,8 @@ fn apply_set_in_memory(key: &str, value: &str, ctx: &mut CommandContext) -> Resu
         "permissionMode" | "permission_mode" => {
             s.permission_mode = Some(value.to_string());
             s.permissions.default_mode = Some(value.to_string());
+            ctx.app_state.tool_permission_context.mode =
+                crate::types::tool::PermissionMode::parse(value);
             Ok(format!("Permission mode set to: {}", value))
         }
         "outputStyle" | "output_style" => {
@@ -487,10 +482,7 @@ fn apply_set_in_memory(key: &str, value: &str, ctx: &mut CommandContext) -> Resu
         }
         "fastModePerSessionOptIn" | "fast_mode_per_session_opt_in" => {
             s.fast_mode_per_session_opt_in = parsed_bool_opt();
-            Ok(format!(
-                "Fast mode per-session opt-in: {}",
-                parsed_bool()
-            ))
+            Ok(format!("Fast mode per-session opt-in: {}", parsed_bool()))
         }
         "teammateMode" | "teammate_mode" => {
             s.teammate_mode = parsed_bool_opt();
@@ -498,10 +490,7 @@ fn apply_set_in_memory(key: &str, value: &str, ctx: &mut CommandContext) -> Resu
         }
         "claudeInChromeDefaultEnabled" | "claude_in_chrome_default_enabled" => {
             s.claude_in_chrome_default_enabled = parsed_bool_opt();
-            Ok(format!(
-                "Claude-in-Chrome default: {}",
-                parsed_bool()
-            ))
+            Ok(format!("Claude-in-Chrome default: {}", parsed_bool()))
         }
         _ => anyhow::bail!(
             "Unknown config key: '{}'. Run `/config show` to see available keys.",
@@ -531,15 +520,18 @@ fn persist_set(scope: WriteScope, key: &str, value: &str, cwd: &Path) -> Result<
         WriteScope::Project => settings::write_project_settings(cwd, &raw)?,
         WriteScope::Local => settings::write_local_settings(cwd, &raw)?,
     };
-    Ok(format!("→ persisted to {} (backups kept)", written.display()))
+    Ok(format!(
+        "→ persisted to {} (backups kept)",
+        written.display()
+    ))
 }
 
 /// Compute the on-disk path for a scope without touching the filesystem.
 fn scope_path(scope: WriteScope, cwd: &Path) -> std::path::PathBuf {
     match scope {
         WriteScope::User => settings::user_settings_path(),
-        WriteScope::Project => cwd.join(".cc-rust").join("settings.json"),
-        WriteScope::Local => cwd.join(".cc-rust").join("settings.local.json"),
+        WriteScope::Project => settings::project_settings_path(cwd),
+        WriteScope::Local => settings::local_settings_path(cwd),
     }
 }
 
@@ -617,8 +609,8 @@ fn handle_reset(parts: &[&str], ctx: &mut CommandContext) -> Result<CommandResul
     if let Some(scope) = scope {
         let path = match scope {
             WriteScope::User => settings::user_settings_path(),
-            WriteScope::Project => ctx.cwd.join(".cc-rust").join("settings.json"),
-            WriteScope::Local => ctx.cwd.join(".cc-rust").join("settings.local.json"),
+            WriteScope::Project => settings::project_settings_path(&ctx.cwd),
+            WriteScope::Local => settings::local_settings_path(&ctx.cwd),
         };
         settings::write_settings_file(&path, &RawSettings::default())?;
         return Ok(CommandResult::Output(format!(
@@ -646,9 +638,13 @@ mod tests {
     use std::path::PathBuf;
 
     fn test_ctx() -> CommandContext {
+        test_ctx_with_cwd(PathBuf::from("/test/project"))
+    }
+
+    fn test_ctx_with_cwd(cwd: PathBuf) -> CommandContext {
         CommandContext {
             messages: Vec::new(),
-            cwd: PathBuf::from("/test/project"),
+            cwd,
             app_state: AppState::default(),
             session_id: SessionId::from_string("test-session"),
         }
@@ -689,7 +685,64 @@ mod tests {
             _ => panic!("Expected Output result"),
         }
         assert_eq!(ctx.app_state.main_loop_model, "claude-opus");
-        assert!(dir.path().join("settings.json").exists());
+        assert!(settings::user_settings_path().exists());
+    }
+
+    #[tokio::test]
+    async fn test_config_set_permission_mode_updates_live_context() {
+        let dir = tempfile::tempdir().unwrap();
+        let _g = EnvGuard::set("CC_RUST_HOME", dir.path().to_str().unwrap());
+        let handler = ConfigHandler;
+        let mut ctx = test_ctx();
+        let result = handler
+            .execute("set permissionMode dontAsk", &mut ctx)
+            .await
+            .unwrap();
+        let CommandResult::Output(text) = result else {
+            panic!("expected output")
+        };
+        assert!(text.contains("Permission mode set to: dontAsk"));
+        assert_eq!(
+            ctx.app_state.tool_permission_context.mode,
+            crate::types::tool::PermissionMode::DontAsk
+        );
+    }
+
+    #[tokio::test]
+    async fn test_config_set_project_from_subdir_preserves_existing_settings() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_root = dir.path().join("workspace");
+        let nested = project_root.join("src").join("nested");
+        let project_dir = project_root.join(".cc-rust");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        let existing = serde_json::json!({
+            "model": "claude-opus",
+            "verbose": true,
+            "theme": "dark"
+        });
+        std::fs::write(
+            project_dir.join("settings.json"),
+            serde_json::to_string_pretty(&existing).unwrap(),
+        )
+        .unwrap();
+
+        let handler = ConfigHandler;
+        let mut ctx = test_ctx_with_cwd(nested.clone());
+        handler
+            .execute("set theme light --project", &mut ctx)
+            .await
+            .unwrap();
+
+        let written: RawSettings = serde_json::from_str(
+            &std::fs::read_to_string(project_dir.join("settings.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(written.model.as_deref(), Some("claude-opus"));
+        assert_eq!(written.verbose, Some(true));
+        assert_eq!(written.theme.as_deref(), Some("light"));
+        assert!(!nested.join(".cc-rust").join("settings.json").exists());
     }
 
     #[tokio::test]

--- a/src/commands/config_cmd.rs
+++ b/src/commands/config_cmd.rs
@@ -1,15 +1,22 @@
 //! /config command -- show and modify configuration settings.
 //!
 //! Subcommands:
-//! - `/config show`         -- display current configuration
-//! - `/config set <key> <value>` -- set a configuration value
-//! - `/config reset`        -- reset to defaults
+//! - `/config show`                       -- show effective settings + sources
+//! - `/config show --raw`                 -- show every loaded layer separately
+//! - `/config sources`                    -- print per-key origin map
+//! - `/config schema`                     -- print JSON Schema for settings
+//! - `/config set <key> <value> [--scope] -- set a value (default scope: user)
+//! - `/config reset [--scope]`            -- reset specific layer or all to defaults
+//!
+//! Scope flags: `--user` (default), `--project`, `--local`.
+
+use std::path::Path;
 
 use anyhow::Result;
 use async_trait::async_trait;
 
 use super::{CommandContext, CommandHandler, CommandResult};
-use crate::config::settings;
+use crate::config::settings::{self, RawSettings, SettingsSource};
 
 /// Handler for the `/config` slash command.
 pub struct ConfigHandler;
@@ -20,114 +27,583 @@ impl CommandHandler for ConfigHandler {
         let parts: Vec<&str> = args.split_whitespace().collect();
 
         match parts.first().copied() {
-            Some("show") | None => handle_show(ctx),
+            Some("show") | None => handle_show(&parts[parts.first().map_or(0, |_| 1)..], ctx),
             Some("set") => handle_set(&parts[1..], ctx),
-            Some("reset") => handle_reset(ctx),
+            Some("reset") => handle_reset(&parts[1..], ctx),
+            Some("sources") => handle_sources(ctx),
+            Some("schema") => handle_schema(),
             Some(sub) => Ok(CommandResult::Output(format!(
-                "Unknown config subcommand: '{}'\n\
-                 Usage:\n  \
-                   /config show          -- show current settings\n  \
-                   /config set <key> <value> -- set a value\n  \
-                   /config reset         -- reset to defaults",
-                sub
+                "Unknown config subcommand: '{}'\n{}",
+                sub,
+                usage_text()
             ))),
         }
     }
 }
 
-/// Display the current configuration.
-fn handle_show(ctx: &CommandContext) -> Result<CommandResult> {
+fn usage_text() -> &'static str {
+    "Usage:\n  \
+       /config show [--raw]                  -- show effective config + sources\n  \
+       /config sources                       -- list which layer set each key\n  \
+       /config schema                        -- print JSON Schema for settings\n  \
+       /config set <key> <value> [scope]     -- set a value (scope: --user|--project|--local)\n  \
+       /config reset [scope]                 -- reset to defaults"
+}
+
+// ---------------------------------------------------------------------------
+// /config show
+// ---------------------------------------------------------------------------
+
+fn handle_show(parts: &[&str], ctx: &CommandContext) -> Result<CommandResult> {
+    let raw_mode = parts.iter().any(|p| *p == "--raw");
+    if raw_mode {
+        return handle_show_raw(ctx);
+    }
+
     let state = &ctx.app_state;
     let mut lines = Vec::new();
-
-    lines.push("Current configuration:".into());
+    lines.push("Effective configuration:".into());
     lines.push(String::new());
-    lines.push(format!("  model:         {}", state.main_loop_model));
-    lines.push(format!("  backend:       {}", state.main_loop_backend));
-    lines.push(format!(
-        "  theme:         {}",
-        state.settings.theme.as_deref().unwrap_or("(default)")
-    ));
-    lines.push(format!("  verbose:       {}", state.verbose));
-    lines.push(format!(
-        "  thinking:      {}",
-        state
-            .thinking_enabled
-            .map(|v| v.to_string())
-            .unwrap_or_else(|| "(auto)".into())
-    ));
-    lines.push(format!("  fast_mode:     {}", state.fast_mode));
-    lines.push(format!(
-        "  effort:        {}",
-        state.effort_value.as_deref().unwrap_or("(default)")
-    ));
-    lines.push(format!(
-        "  permission_mode: {:?}",
-        state.tool_permission_context.mode
-    ));
 
-    // Try to show the config file locations.
-    if let Ok(global_dir) = settings::global_claude_dir() {
-        lines.push(String::new());
-        lines.push(format!(
-            "  Global config: {}",
-            global_dir.join("settings.json").display()
-        ));
-    }
+    let src = |key: &str| -> String {
+        state
+            .settings
+            .sources
+            .get(key)
+            .map(|s| format!("[{}]", s.as_str()))
+            .unwrap_or_else(|| "[default]".into())
+    };
+
+    let row = |k: &str, v: String, src_key: &str, lines: &mut Vec<String>| {
+        lines.push(format!("  {:<32} {:<10} {}", k, src(src_key), v));
+    };
+
+    row(
+        "model",
+        state.main_loop_model.clone(),
+        "model",
+        &mut lines,
+    );
+    row(
+        "backend",
+        state.main_loop_backend.clone(),
+        "backend",
+        &mut lines,
+    );
+    row(
+        "theme",
+        state
+            .settings
+            .theme
+            .clone()
+            .unwrap_or_else(|| "(default)".into()),
+        "theme",
+        &mut lines,
+    );
+    row(
+        "verbose",
+        state.verbose.to_string(),
+        "verbose",
+        &mut lines,
+    );
+    row(
+        "permissionMode",
+        state
+            .settings
+            .permission_mode
+            .clone()
+            .unwrap_or_else(|| format!("{:?}", state.tool_permission_context.mode).to_lowercase()),
+        "permissionMode",
+        &mut lines,
+    );
+    row(
+        "permissions.allow",
+        join_or_dash(&state.settings.permissions.allow),
+        "permissions",
+        &mut lines,
+    );
+    row(
+        "permissions.deny",
+        join_or_dash(&state.settings.permissions.deny),
+        "permissions",
+        &mut lines,
+    );
+    row(
+        "permissions.ask",
+        join_or_dash(&state.settings.permissions.ask),
+        "permissions",
+        &mut lines,
+    );
+    row(
+        "sandbox.enabled",
+        opt_str(state.settings.sandbox.enabled.map(|b| b.to_string())),
+        "sandbox",
+        &mut lines,
+    );
+    row(
+        "statusLine.type",
+        opt_str(state.settings.status_line.r#type.clone()),
+        "statusLine",
+        &mut lines,
+    );
+    row(
+        "spinnerTips.enabled",
+        opt_str(state.settings.spinner_tips.enabled.map(|b| b.to_string())),
+        "spinnerTips",
+        &mut lines,
+    );
+    row(
+        "spinnerTips.intervalMs",
+        opt_str(
+            state
+                .settings
+                .spinner_tips
+                .interval_ms
+                .map(|n| n.to_string()),
+        ),
+        "spinnerTips",
+        &mut lines,
+    );
+    row(
+        "spinnerTips.customTips",
+        join_or_dash(&state.settings.spinner_tips.custom_tips),
+        "spinnerTips",
+        &mut lines,
+    );
+    row(
+        "outputStyle",
+        opt_str(state.settings.output_style.clone()),
+        "outputStyle",
+        &mut lines,
+    );
+    row(
+        "language",
+        opt_str(state.settings.language.clone()),
+        "language",
+        &mut lines,
+    );
+    row(
+        "voiceEnabled",
+        opt_str(state.settings.voice_enabled.map(|b| b.to_string())),
+        "voiceEnabled",
+        &mut lines,
+    );
+    row(
+        "editorMode",
+        opt_str(state.settings.editor_mode.clone()),
+        "editorMode",
+        &mut lines,
+    );
+    row(
+        "viewMode",
+        opt_str(state.settings.view_mode.clone()),
+        "viewMode",
+        &mut lines,
+    );
+    row(
+        "terminalProgressBarEnabled",
+        opt_str(
+            state
+                .settings
+                .terminal_progress_bar_enabled
+                .map(|b| b.to_string()),
+        ),
+        "terminalProgressBarEnabled",
+        &mut lines,
+    );
+    row(
+        "availableModels",
+        join_or_dash(&state.settings.available_models),
+        "availableModels",
+        &mut lines,
+    );
+    row(
+        "effortLevel",
+        opt_str(state.settings.effort_level.clone()),
+        "effortLevel",
+        &mut lines,
+    );
+    row(
+        "fastMode",
+        opt_str(state.settings.fast_mode.map(|b| b.to_string())),
+        "fastMode",
+        &mut lines,
+    );
+    row(
+        "fastModePerSessionOptIn",
+        opt_str(
+            state
+                .settings
+                .fast_mode_per_session_opt_in
+                .map(|b| b.to_string()),
+        ),
+        "fastModePerSessionOptIn",
+        &mut lines,
+    );
+    row(
+        "teammateMode",
+        opt_str(state.settings.teammate_mode.map(|b| b.to_string())),
+        "teammateMode",
+        &mut lines,
+    );
+    row(
+        "claudeInChromeDefaultEnabled",
+        opt_str(
+            state
+                .settings
+                .claude_in_chrome_default_enabled
+                .map(|b| b.to_string()),
+        ),
+        "claudeInChromeDefaultEnabled",
+        &mut lines,
+    );
+
+    lines.push(String::new());
+    lines.push("File locations:".into());
+    lines.push(format!("  user:    {}", settings::user_settings_path().display()));
     lines.push(format!(
-        "  Project dir:   {}",
+        "  project: {}",
         ctx.cwd.join(".cc-rust").join("settings.json").display()
+    ));
+    lines.push(format!(
+        "  local:   {}",
+        ctx.cwd.join(".cc-rust").join("settings.local.json").display()
+    ));
+    lines.push(format!(
+        "  managed: {}",
+        settings::managed_settings_path().display()
     ));
 
     Ok(CommandResult::Output(lines.join("\n")))
 }
 
-/// Set a single configuration value.
-fn handle_set(parts: &[&str], ctx: &mut CommandContext) -> Result<CommandResult> {
-    if parts.len() < 2 {
+fn opt_str(v: Option<String>) -> String {
+    v.unwrap_or_else(|| "(unset)".into())
+}
+
+fn join_or_dash(v: &[String]) -> String {
+    if v.is_empty() {
+        "-".to_string()
+    } else {
+        v.join(", ")
+    }
+}
+
+fn handle_show_raw(ctx: &CommandContext) -> Result<CommandResult> {
+    let loaded = settings::load_effective(&ctx.cwd)?;
+    let mut lines = Vec::new();
+    lines.push("Raw settings layers (lowest -> highest priority):".into());
+    lines.push(String::new());
+
+    let render = |label: &str, raw: &Option<RawSettings>, lines: &mut Vec<String>| {
+        lines.push(format!("== {} ==", label));
+        match raw {
+            None => lines.push("  (none)".into()),
+            Some(r) => match serde_json::to_string_pretty(r) {
+                Ok(json) => {
+                    for l in json.lines() {
+                        lines.push(format!("  {}", l));
+                    }
+                }
+                Err(e) => lines.push(format!("  (failed to serialize: {})", e)),
+            },
+        }
+        lines.push(String::new());
+    };
+
+    render("managed", &loaded.managed, &mut lines);
+    render("user", &loaded.user, &mut lines);
+    render("project", &loaded.project, &mut lines);
+    render("local", &loaded.local, &mut lines);
+
+    Ok(CommandResult::Output(lines.join("\n")))
+}
+
+// ---------------------------------------------------------------------------
+// /config sources
+// ---------------------------------------------------------------------------
+
+fn handle_sources(ctx: &CommandContext) -> Result<CommandResult> {
+    if ctx.app_state.settings.sources.is_empty() {
         return Ok(CommandResult::Output(
-            "Usage: /config set <key> <value>\n\
-             Available keys: model, backend, theme, verbose"
-                .into(),
+            "(no settings overrides recorded — every key is default)".into(),
         ));
+    }
+    let mut lines = vec!["Per-key sources:".into(), String::new()];
+    for (k, v) in &ctx.app_state.settings.sources {
+        lines.push(format!("  {:<36} {}", k, v.as_str()));
+    }
+    Ok(CommandResult::Output(lines.join("\n")))
+}
+
+// ---------------------------------------------------------------------------
+// /config schema
+// ---------------------------------------------------------------------------
+
+fn handle_schema() -> Result<CommandResult> {
+    let schema = settings::settings_schema();
+    let pretty =
+        serde_json::to_string_pretty(&schema).unwrap_or_else(|_| "(failed to render)".into());
+    Ok(CommandResult::Output(pretty))
+}
+
+// ---------------------------------------------------------------------------
+// /config set
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy)]
+enum WriteScope {
+    User,
+    Project,
+    Local,
+}
+
+fn parse_scope(parts: &mut Vec<&str>) -> WriteScope {
+    let mut scope = WriteScope::User;
+    parts.retain(|p| match *p {
+        "--user" => {
+            scope = WriteScope::User;
+            false
+        }
+        "--project" => {
+            scope = WriteScope::Project;
+            false
+        }
+        "--local" => {
+            scope = WriteScope::Local;
+            false
+        }
+        _ => true,
+    });
+    scope
+}
+
+fn handle_set(parts: &[&str], ctx: &mut CommandContext) -> Result<CommandResult> {
+    let mut parts: Vec<&str> = parts.to_vec();
+    let scope = parse_scope(&mut parts);
+
+    if parts.len() < 2 {
+        return Ok(CommandResult::Output(format!(
+            "Usage: /config set <key> <value> [--user|--project|--local]\n\n\
+             Available keys: model, backend, theme, verbose, permissionMode,\n  \
+               outputStyle, language, voiceEnabled, editorMode, viewMode,\n  \
+               terminalProgressBarEnabled, effortLevel, fastMode,\n  \
+               fastModePerSessionOptIn, teammateMode, claudeInChromeDefaultEnabled\n\n{}",
+            usage_text()
+        )));
     }
 
     let key = parts[0];
     let value = parts[1..].join(" ");
 
+    // 1. Mutate the in-memory AppState so subsequent reads in this session
+    //    see the new value.
+    let in_memory_msg = apply_set_in_memory(key, &value, ctx)?;
+
+    // 2. Persist to the chosen scope's file (with backup).
+    let file_msg = persist_set(scope, key, &value, &ctx.cwd)?;
+
+    // 3. Update the source map so /config sources reflects the change.
+    let src = match scope {
+        WriteScope::User => SettingsSource::User,
+        WriteScope::Project => SettingsSource::Project,
+        WriteScope::Local => SettingsSource::Local,
+    };
+    ctx.app_state
+        .settings
+        .sources
+        .insert(key.to_string(), src);
+
+    Ok(CommandResult::Output(format!("{}\n{}", in_memory_msg, file_msg)))
+}
+
+/// Apply a key=value to the live AppState. Returns a user-facing message.
+fn apply_set_in_memory(key: &str, value: &str, ctx: &mut CommandContext) -> Result<String> {
+    let s = &mut ctx.app_state.settings;
+    let parsed_bool = || value == "true" || value == "1";
+    let parsed_bool_opt = || Some(parsed_bool());
+
     match key {
         "model" => {
-            ctx.app_state.main_loop_model = value.clone();
-            Ok(CommandResult::Output(format!("Model set to: {}", value)))
+            ctx.app_state.main_loop_model = value.to_string();
+            s.model = Some(value.to_string());
+            Ok(format!("Model set to: {}", value))
         }
         "backend" => {
-            let normalized = crate::engine::codex_exec::normalize_backend(Some(&value));
+            let normalized = crate::engine::codex_exec::normalize_backend(Some(value));
             ctx.app_state.main_loop_backend = normalized.clone();
-            ctx.app_state.settings.backend = Some(normalized.clone());
-            Ok(CommandResult::Output(format!(
-                "Backend set to: {}",
-                normalized
-            )))
+            s.backend = Some(normalized.clone());
+            Ok(format!("Backend set to: {}", normalized))
         }
         "theme" => {
-            ctx.app_state.settings.theme = Some(value.clone());
-            Ok(CommandResult::Output(format!("Theme set to: {}", value)))
+            s.theme = Some(value.to_string());
+            Ok(format!("Theme set to: {}", value))
         }
         "verbose" => {
-            let v = value == "true" || value == "1";
+            let v = parsed_bool();
             ctx.app_state.verbose = v;
-            ctx.app_state.settings.verbose = Some(v);
-            Ok(CommandResult::Output(format!("Verbose set to: {}", v)))
+            s.verbose = Some(v);
+            Ok(format!("Verbose set to: {}", v))
         }
-        _ => Ok(CommandResult::Output(format!(
-            "Unknown config key: '{}'\nAvailable keys: model, backend, theme, verbose",
+        "permissionMode" | "permission_mode" => {
+            s.permission_mode = Some(value.to_string());
+            s.permissions.default_mode = Some(value.to_string());
+            Ok(format!("Permission mode set to: {}", value))
+        }
+        "outputStyle" | "output_style" => {
+            s.output_style = Some(value.to_string());
+            Ok(format!("Output style set to: {}", value))
+        }
+        "language" => {
+            s.language = Some(value.to_string());
+            Ok(format!("Language set to: {}", value))
+        }
+        "voiceEnabled" | "voice_enabled" => {
+            s.voice_enabled = parsed_bool_opt();
+            Ok(format!("Voice enabled: {}", parsed_bool()))
+        }
+        "editorMode" | "editor_mode" => {
+            s.editor_mode = Some(value.to_string());
+            Ok(format!("Editor mode set to: {}", value))
+        }
+        "viewMode" | "view_mode" => {
+            s.view_mode = Some(value.to_string());
+            Ok(format!("View mode set to: {}", value))
+        }
+        "terminalProgressBarEnabled" | "terminal_progress_bar_enabled" => {
+            s.terminal_progress_bar_enabled = parsed_bool_opt();
+            Ok(format!("Terminal progress bar: {}", parsed_bool()))
+        }
+        "effortLevel" | "effort_level" => {
+            s.effort_level = Some(value.to_string());
+            ctx.app_state.effort_value = Some(value.to_string());
+            Ok(format!("Effort level set to: {}", value))
+        }
+        "fastMode" | "fast_mode" => {
+            let v = parsed_bool();
+            s.fast_mode = Some(v);
+            ctx.app_state.fast_mode = v;
+            Ok(format!("Fast mode set to: {}", v))
+        }
+        "fastModePerSessionOptIn" | "fast_mode_per_session_opt_in" => {
+            s.fast_mode_per_session_opt_in = parsed_bool_opt();
+            Ok(format!(
+                "Fast mode per-session opt-in: {}",
+                parsed_bool()
+            ))
+        }
+        "teammateMode" | "teammate_mode" => {
+            s.teammate_mode = parsed_bool_opt();
+            Ok(format!("Teammate mode: {}", parsed_bool()))
+        }
+        "claudeInChromeDefaultEnabled" | "claude_in_chrome_default_enabled" => {
+            s.claude_in_chrome_default_enabled = parsed_bool_opt();
+            Ok(format!(
+                "Claude-in-Chrome default: {}",
+                parsed_bool()
+            ))
+        }
+        _ => anyhow::bail!(
+            "Unknown config key: '{}'. Run `/config show` to see available keys.",
             key
-        ))),
+        ),
     }
 }
 
-/// Reset configuration to defaults.
-fn handle_reset(ctx: &mut CommandContext) -> Result<CommandResult> {
+/// Persist a key=value into the given scope's settings.json (with backup).
+fn persist_set(scope: WriteScope, key: &str, value: &str, cwd: &Path) -> Result<String> {
+    // 1. Read current file content (or empty default).
+    let path = scope_path(scope, cwd);
+    let mut raw = if path.exists() {
+        let txt = std::fs::read_to_string(&path)?;
+        serde_json::from_str::<RawSettings>(&txt)?
+    } else {
+        RawSettings::default()
+    };
+
+    // 2. Patch the key in-place.
+    apply_set_to_raw(&mut raw, key, value);
+
+    // 3. Write back via the scope-specific helper (handles backups + dir
+    //    creation + atomic rename).
+    let written = match scope {
+        WriteScope::User => settings::write_user_settings(&raw)?,
+        WriteScope::Project => settings::write_project_settings(cwd, &raw)?,
+        WriteScope::Local => settings::write_local_settings(cwd, &raw)?,
+    };
+    Ok(format!("→ persisted to {} (backups kept)", written.display()))
+}
+
+/// Compute the on-disk path for a scope without touching the filesystem.
+fn scope_path(scope: WriteScope, cwd: &Path) -> std::path::PathBuf {
+    match scope {
+        WriteScope::User => settings::user_settings_path(),
+        WriteScope::Project => cwd.join(".cc-rust").join("settings.json"),
+        WriteScope::Local => cwd.join(".cc-rust").join("settings.local.json"),
+    }
+}
+
+fn apply_set_to_raw(raw: &mut RawSettings, key: &str, value: &str) {
+    let bool_val = || value == "true" || value == "1";
+    let bool_opt = || Some(bool_val());
+
+    match key {
+        "model" => raw.model = Some(value.into()),
+        "backend" => {
+            raw.backend =
+                Some(crate::engine::codex_exec::normalize_backend(Some(value)).to_string());
+        }
+        "theme" => raw.theme = Some(value.into()),
+        "verbose" => raw.verbose = bool_opt(),
+        "permissionMode" | "permission_mode" => {
+            raw.permission_mode = Some(value.into());
+            let mut perms = raw.permissions.take().unwrap_or_default();
+            perms.default_mode = Some(value.into());
+            raw.permissions = Some(perms);
+        }
+        "outputStyle" | "output_style" => raw.output_style = Some(value.into()),
+        "language" => raw.language = Some(value.into()),
+        "voiceEnabled" | "voice_enabled" => raw.voice_enabled = bool_opt(),
+        "editorMode" | "editor_mode" => raw.editor_mode = Some(value.into()),
+        "viewMode" | "view_mode" => raw.view_mode = Some(value.into()),
+        "terminalProgressBarEnabled" | "terminal_progress_bar_enabled" => {
+            raw.terminal_progress_bar_enabled = bool_opt();
+        }
+        "effortLevel" | "effort_level" => raw.effort_level = Some(value.into()),
+        "fastMode" | "fast_mode" => raw.fast_mode = bool_opt(),
+        "fastModePerSessionOptIn" | "fast_mode_per_session_opt_in" => {
+            raw.fast_mode_per_session_opt_in = bool_opt();
+        }
+        "teammateMode" | "teammate_mode" => raw.teammate_mode = bool_opt(),
+        "claudeInChromeDefaultEnabled" | "claude_in_chrome_default_enabled" => {
+            raw.claude_in_chrome_default_enabled = bool_opt();
+        }
+        // Unknown keys get stuffed in `extra` so users can experiment with
+        // future fields without losing data.
+        _ => {
+            raw.extra
+                .insert(key.to_string(), serde_json::Value::String(value.into()));
+        }
+    }
+}
+
+// Small helper to allow `take()` on Option<PermissionsSettings> without
+// pulling in extra crates. Using `Option::take` works directly above; this
+// trait is intentionally *not* defined — we only need the inherent `take`.
+
+// ---------------------------------------------------------------------------
+// /config reset
+// ---------------------------------------------------------------------------
+
+fn handle_reset(parts: &[&str], ctx: &mut CommandContext) -> Result<CommandResult> {
+    let mut parts: Vec<&str> = parts.to_vec();
+    let scope = if parts.is_empty() {
+        None
+    } else {
+        Some(parse_scope(&mut parts))
+    };
+
+    // Reset in-memory state (always).
     let default_state = crate::types::app_state::AppState::default();
     ctx.app_state.settings = default_state.settings;
     ctx.app_state.main_loop_model = default_state.main_loop_model;
@@ -137,8 +613,24 @@ fn handle_reset(ctx: &mut CommandContext) -> Result<CommandResult> {
     ctx.app_state.effort_value = default_state.effort_value;
     ctx.app_state.thinking_enabled = default_state.thinking_enabled;
 
+    // Optional: also rewrite a scope's file to defaults (backed up).
+    if let Some(scope) = scope {
+        let path = match scope {
+            WriteScope::User => settings::user_settings_path(),
+            WriteScope::Project => ctx.cwd.join(".cc-rust").join("settings.json"),
+            WriteScope::Local => ctx.cwd.join(".cc-rust").join("settings.local.json"),
+        };
+        settings::write_settings_file(&path, &RawSettings::default())?;
+        return Ok(CommandResult::Output(format!(
+            "In-memory configuration reset; {} rewritten to defaults (backup kept).",
+            path.display()
+        )));
+    }
+
     Ok(CommandResult::Output(
-        "Configuration reset to defaults.".into(),
+        "In-memory configuration reset to defaults. Files on disk untouched — \
+         pass --user / --project / --local to also rewrite a file."
+            .into(),
     ))
 }
 
@@ -169,17 +661,20 @@ mod tests {
         let result = handler.execute("show", &mut ctx).await.unwrap();
         match result {
             CommandResult::Output(text) => {
-                assert!(text.contains("model:"));
-                assert!(text.contains("backend:"));
-                assert!(text.contains("verbose:"));
-                assert!(text.contains("permission_mode:"));
+                assert!(text.contains("model"));
+                assert!(text.contains("backend"));
+                assert!(text.contains("permissionMode"));
+                assert!(text.contains("File locations"));
             }
             _ => panic!("Expected Output result"),
         }
     }
 
     #[tokio::test]
-    async fn test_config_set_model() {
+    async fn test_config_set_model_in_memory() {
+        // Use a tempdir as CC_RUST_HOME so we don't clobber the real user file.
+        let dir = tempfile::tempdir().unwrap();
+        let _g = EnvGuard::set("CC_RUST_HOME", dir.path().to_str().unwrap());
         let handler = ConfigHandler;
         let mut ctx = test_ctx();
         let result = handler
@@ -189,52 +684,12 @@ mod tests {
         match result {
             CommandResult::Output(text) => {
                 assert!(text.contains("claude-opus"));
+                assert!(text.contains("persisted"));
             }
             _ => panic!("Expected Output result"),
         }
         assert_eq!(ctx.app_state.main_loop_model, "claude-opus");
-    }
-
-    #[tokio::test]
-    async fn test_config_set_verbose() {
-        let handler = ConfigHandler;
-        let mut ctx = test_ctx();
-        let _result = handler.execute("set verbose true", &mut ctx).await.unwrap();
-        assert!(ctx.app_state.verbose);
-    }
-
-    #[tokio::test]
-    async fn test_config_set_backend() {
-        let handler = ConfigHandler;
-        let mut ctx = test_ctx();
-        let result = handler
-            .execute("set backend codex", &mut ctx)
-            .await
-            .unwrap();
-        match result {
-            CommandResult::Output(text) => {
-                assert!(text.contains("codex"));
-            }
-            _ => panic!("Expected Output result"),
-        }
-        assert_eq!(ctx.app_state.main_loop_backend, "codex");
-    }
-
-    #[tokio::test]
-    async fn test_config_reset() {
-        let handler = ConfigHandler;
-        let mut ctx = test_ctx();
-        ctx.app_state.main_loop_model = "custom-model".into();
-        ctx.app_state.verbose = true;
-
-        let result = handler.execute("reset", &mut ctx).await.unwrap();
-        match result {
-            CommandResult::Output(text) => {
-                assert!(text.contains("reset to defaults"));
-            }
-            _ => panic!("Expected Output result"),
-        }
-        assert!(!ctx.app_state.verbose);
+        assert!(dir.path().join("settings.json").exists());
     }
 
     #[tokio::test]
@@ -251,15 +706,52 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_config_no_args_shows_config() {
+    async fn test_config_schema_emits_object() {
         let handler = ConfigHandler;
         let mut ctx = test_ctx();
-        let result = handler.execute("", &mut ctx).await.unwrap();
+        let result = handler.execute("schema", &mut ctx).await.unwrap();
         match result {
             CommandResult::Output(text) => {
-                assert!(text.contains("Current configuration"));
+                assert!(text.contains("\"properties\""));
+                assert!(text.contains("\"permissions\""));
             }
             _ => panic!("Expected Output result"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_config_sources_empty_default() {
+        let handler = ConfigHandler;
+        let mut ctx = test_ctx();
+        let result = handler.execute("sources", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(text) => {
+                assert!(text.contains("no settings overrides") || text.contains("Per-key sources"));
+            }
+            _ => panic!("Expected Output result"),
+        }
+    }
+
+    /// Process-env guard for tests that mutate CC_RUST_HOME.
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
         }
     }
 }

--- a/src/commands/mcp_cmd.rs
+++ b/src/commands/mcp_cmd.rs
@@ -72,10 +72,7 @@ fn handle_list(ctx: &CommandContext) -> Result<CommandResult> {
     }
 
     let mut lines = Vec::new();
-    let browser_count = servers
-        .iter()
-        .filter(|s| is_server_browser(s))
-        .count();
+    let browser_count = servers.iter().filter(|s| is_server_browser(s)).count();
     if browser_count > 0 {
         lines.push(format!(
             "Discovered MCP servers ({}; {} browser):",

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -42,6 +42,9 @@ pub mod status;
 // Workspace
 pub mod add_dir;
 
+// Sandbox
+pub mod sandbox_cmd;
+
 // Export
 pub mod audit_export;
 pub mod export;
@@ -393,6 +396,12 @@ pub fn get_all_commands() -> Vec<Command> {
             aliases: vec![],
             description: "Add a new working directory".into(),
             handler: Box::new(add_dir::AddDirHandler),
+        },
+        Command {
+            name: "sandbox".into(),
+            aliases: vec![],
+            description: "View or toggle sandbox + network access settings".into(),
+            handler: Box::new(sandbox_cmd::SandboxHandler),
         },
     ]
 }

--- a/src/commands/permissions_cmd.rs
+++ b/src/commands/permissions_cmd.rs
@@ -238,11 +238,7 @@ fn handle_mode(parts: &[&str], ctx: &mut CommandContext) -> Result<CommandResult
     }
 
     if matches!(requested, PermissionMode::Auto)
-        && ctx
-            .app_state
-            .tool_permission_context
-            .is_auto_mode_available
-            == Some(false)
+        && ctx.app_state.tool_permission_context.is_auto_mode_available == Some(false)
     {
         return Ok(CommandResult::Output(
             "Auto mode is disabled by configuration (permissions.enableAutoMode=false).".into(),
@@ -260,11 +256,7 @@ fn handle_mode(parts: &[&str], ctx: &mut CommandContext) -> Result<CommandResult
 // Add (allow/ask/deny) with scope persistence
 // ---------------------------------------------------------------------------
 
-fn handle_add(
-    kind: RuleKind,
-    parts: &[&str],
-    ctx: &mut CommandContext,
-) -> Result<CommandResult> {
+fn handle_add(kind: RuleKind, parts: &[&str], ctx: &mut CommandContext) -> Result<CommandResult> {
     let mut parts: Vec<&str> = parts.to_vec();
     let scope = PersistScope::parse(&mut parts);
 
@@ -319,8 +311,8 @@ fn persist_rule(
 ) -> Result<String> {
     let path = match scope {
         PersistScope::User => settings::user_settings_path(),
-        PersistScope::Project => cwd.join(".cc-rust").join("settings.json"),
-        PersistScope::Local => cwd.join(".cc-rust").join("settings.local.json"),
+        PersistScope::Project => settings::project_settings_path(cwd),
+        PersistScope::Local => settings::local_settings_path(cwd),
         PersistScope::Session => unreachable!(),
     };
     let mut raw = if path.exists() {
@@ -367,9 +359,7 @@ fn handle_session_grant(parts: &[&str], ctx: &mut CommandContext) -> Result<Comm
 }
 
 fn handle_clear_session(ctx: &mut CommandContext) -> Result<CommandResult> {
-    ctx.app_state
-        .tool_permission_context
-        .clear_session_grants();
+    ctx.app_state.tool_permission_context.clear_session_grants();
     Ok(CommandResult::Output("Session grants cleared.".into()))
 }
 
@@ -393,9 +383,13 @@ mod tests {
     use std::path::PathBuf;
 
     fn test_ctx() -> CommandContext {
+        test_ctx_with_cwd(PathBuf::from("."))
+    }
+
+    fn test_ctx_with_cwd(cwd: PathBuf) -> CommandContext {
         CommandContext {
             messages: Vec::new(),
-            cwd: PathBuf::from("."),
+            cwd,
             app_state: AppState::default(),
             session_id: SessionId::from_string("test-session"),
         }
@@ -504,6 +498,45 @@ mod tests {
         assert!(text.contains("allow rule"));
         assert!(text.contains("persisted"));
         assert!(dir.path().join("settings.json").exists());
+    }
+
+    #[tokio::test]
+    async fn test_permissions_allow_project_from_subdir_preserves_existing_settings() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_root = dir.path().join("workspace");
+        let nested = project_root.join("src").join("nested");
+        let project_dir = project_root.join(".cc-rust");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        let existing = serde_json::json!({
+            "permissions": {
+                "deny": ["Bash(rm)"],
+                "allow": ["Read"]
+            }
+        });
+        std::fs::write(
+            project_dir.join("settings.json"),
+            serde_json::to_string_pretty(&existing).unwrap(),
+        )
+        .unwrap();
+
+        let handler = PermissionsHandler;
+        let mut ctx = test_ctx_with_cwd(nested.clone());
+        handler
+            .execute("allow Bash(prefix:git) --project", &mut ctx)
+            .await
+            .unwrap();
+
+        let written: settings::RawSettings = serde_json::from_str(
+            &std::fs::read_to_string(project_dir.join("settings.json")).unwrap(),
+        )
+        .unwrap();
+        let perms = written.permissions.expect("permissions present");
+        assert!(perms.deny.iter().any(|rule| rule == "Bash(rm)"));
+        assert!(perms.allow.iter().any(|rule| rule == "Read"));
+        assert!(perms.allow.iter().any(|rule| rule == "Bash(prefix:git)"));
+        assert!(!nested.join(".cc-rust").join("settings.json").exists());
     }
 
     #[tokio::test]

--- a/src/commands/permissions_cmd.rs
+++ b/src/commands/permissions_cmd.rs
@@ -1,20 +1,87 @@
-//! /permissions command -- view and modify permission settings.
+//! /permissions command — source-aware view and management of the
+//! permission system.
 //!
 //! Subcommands:
-//! - `/permissions`           -- show current permission mode and rules
-//! - `/permissions mode <m>`  -- switch permission mode
-//! - `/permissions allow <t>` -- add a tool to the always-allow list
-//! - `/permissions deny <t>`  -- add a tool to the always-deny list
-//! - `/permissions reset`     -- reset all permission rules to defaults
+//! - `/permissions`                              show effective rules + sources
+//! - `/permissions mode <m>`                     switch permission mode
+//!     where `<m>` ∈ default | auto | bypass | plan | acceptEdits | dontAsk
+//! - `/permissions allow <rule>  [scope]`        add an always-allow rule
+//! - `/permissions deny  <rule>  [scope]`        add an always-deny rule
+//! - `/permissions ask   <rule>  [scope]`        add an always-ask rule
+//! - `/permissions session-grant <tool>`         add a session-only grant
+//! - `/permissions clear-session-grants`         drop all session grants
+//! - `/permissions reset`                        reset all in-memory rules
 //!
-//! The TypeScript version opens a React-based PermissionRuleList component.
-//! In the Rust CLI we display a text listing and accept subcommands.
+//! `<scope>` is one of `--user|--project|--local|--session` (default: --user).
+//! Persistent scopes are also written back to the corresponding settings
+//! file via [`config::settings`] (with backup).
 
 use anyhow::Result;
 use async_trait::async_trait;
 
 use super::{CommandContext, CommandHandler, CommandResult};
+use crate::config::settings;
 use crate::types::tool::PermissionMode;
+
+#[derive(Debug, Clone, Copy)]
+enum PersistScope {
+    User,
+    Project,
+    Local,
+    Session,
+}
+
+impl PersistScope {
+    fn parse(parts: &mut Vec<&str>) -> PersistScope {
+        let mut scope = PersistScope::User;
+        parts.retain(|p| match *p {
+            "--user" => {
+                scope = PersistScope::User;
+                false
+            }
+            "--project" => {
+                scope = PersistScope::Project;
+                false
+            }
+            "--local" => {
+                scope = PersistScope::Local;
+                false
+            }
+            "--session" => {
+                scope = PersistScope::Session;
+                false
+            }
+            _ => true,
+        });
+        scope
+    }
+
+    fn source_label(self) -> &'static str {
+        match self {
+            PersistScope::User => "user",
+            PersistScope::Project => "project",
+            PersistScope::Local => "local",
+            PersistScope::Session => "session",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum RuleKind {
+    Allow,
+    Ask,
+    Deny,
+}
+
+impl RuleKind {
+    fn label(self) -> &'static str {
+        match self {
+            RuleKind::Allow => "allow",
+            RuleKind::Ask => "ask",
+            RuleKind::Deny => "deny",
+        }
+    }
+}
 
 /// Handler for the `/permissions` slash command.
 pub struct PermissionsHandler;
@@ -26,73 +93,90 @@ impl CommandHandler for PermissionsHandler {
 
         match parts.first().copied() {
             Some("mode") => handle_mode(&parts[1..], ctx),
-            Some("allow") => handle_allow(&parts[1..], ctx),
-            Some("deny") => handle_deny(&parts[1..], ctx),
+            Some("allow") => handle_add(RuleKind::Allow, &parts[1..], ctx),
+            Some("ask") => handle_add(RuleKind::Ask, &parts[1..], ctx),
+            Some("deny") => handle_add(RuleKind::Deny, &parts[1..], ctx),
+            Some("session-grant") => handle_session_grant(&parts[1..], ctx),
+            Some("clear-session-grants") => handle_clear_session(ctx),
             Some("reset") => handle_reset(ctx),
             None => handle_show(ctx),
             Some(sub) => Ok(CommandResult::Output(format!(
-                "Unknown permissions subcommand: '{}'\n\
-                 Usage:\n  \
-                   /permissions               -- show current settings\n  \
-                   /permissions mode <mode>    -- set mode (default, auto, bypass, plan)\n  \
-                   /permissions allow <tool>   -- always allow a tool\n  \
-                   /permissions deny <tool>    -- always deny a tool\n  \
-                   /permissions reset          -- reset to defaults",
-                sub
+                "Unknown permissions subcommand: '{}'\n{}",
+                sub,
+                usage()
             ))),
         }
     }
 }
 
-/// Display current permission settings.
+fn usage() -> &'static str {
+    "Usage:\n  \
+       /permissions                              -- show effective settings + sources\n  \
+       /permissions mode <m>                     -- m: default|auto|bypass|plan|acceptEdits|dontAsk\n  \
+       /permissions allow <rule> [scope]         -- always-allow rule\n  \
+       /permissions ask   <rule> [scope]         -- always-ask rule\n  \
+       /permissions deny  <rule> [scope]         -- always-deny rule\n  \
+       /permissions session-grant <tool>         -- session-only allow\n  \
+       /permissions clear-session-grants         -- drop all session grants\n  \
+       /permissions reset                        -- reset in-memory rules\n\n  \
+       scope: --user (default) | --project | --local | --session"
+}
+
+// ---------------------------------------------------------------------------
+// Show
+// ---------------------------------------------------------------------------
+
 fn handle_show(ctx: &CommandContext) -> Result<CommandResult> {
     let perm = &ctx.app_state.tool_permission_context;
 
     let mut lines = Vec::new();
     lines.push("Permission settings:".into());
     lines.push(String::new());
-    lines.push(format!("  Mode: {:?}", perm.mode));
     lines.push(format!(
-        "  Bypass available: {}",
-        perm.is_bypass_permissions_mode_available
+        "  Mode:                {} (bypass available={}, auto available={:?})",
+        perm.mode.as_str(),
+        perm.is_bypass_permissions_mode_available,
+        perm.is_auto_mode_available,
     ));
 
-    // Always-allow rules.
-    if !perm.always_allow_rules.is_empty() {
-        lines.push(String::new());
-        lines.push("  Always allow:".into());
-        for (source, rules) in &perm.always_allow_rules {
+    // Effective rules grouped by kind, with source.
+    render_rules(
+        "Always deny  (deny > ask > allow)",
+        &perm.always_deny_rules,
+        &mut lines,
+    );
+    render_rules("Always ask", &perm.always_ask_rules, &mut lines);
+    render_rules("Always allow", &perm.always_allow_rules, &mut lines);
+
+    // Session grants — separate section so users can audit transient state.
+    lines.push(String::new());
+    lines.push("  Session grants:".into());
+    if perm.session_allow_rules.is_empty() {
+        lines.push("    (none — cleared on session end)".into());
+    } else {
+        for (source, rules) in &perm.session_allow_rules {
             for rule in rules {
-                lines.push(format!("    {} (from {})", rule, source));
+                lines.push(format!("    {:<40} (from {}) [transient]", rule, source));
             }
         }
     }
 
-    // Always-deny rules.
-    if !perm.always_deny_rules.is_empty() {
-        lines.push(String::new());
-        lines.push("  Always deny:".into());
-        for (source, rules) in &perm.always_deny_rules {
-            for rule in rules {
-                lines.push(format!("    {} (from {})", rule, source));
-            }
-        }
-    }
-
-    // Always-ask rules.
-    if !perm.always_ask_rules.is_empty() {
-        lines.push(String::new());
-        lines.push("  Always ask:".into());
-        for (source, rules) in &perm.always_ask_rules {
-            for rule in rules {
-                lines.push(format!("    {} (from {})", rule, source));
-            }
+    // Additional working directories.
+    lines.push(String::new());
+    lines.push("  Additional working directories:".into());
+    if perm.additional_working_directories.is_empty() {
+        lines.push("    (none)".into());
+    } else {
+        for (path, dir) in &perm.additional_working_directories {
+            let ro = if dir.read_only { " [read-only]" } else { "" };
+            lines.push(format!("    {}{}", path, ro));
         }
     }
 
     if perm.always_allow_rules.is_empty()
         && perm.always_deny_rules.is_empty()
         && perm.always_ask_rules.is_empty()
+        && perm.session_allow_rules.is_empty()
     {
         lines.push(String::new());
         lines.push("  No custom permission rules configured.".into());
@@ -101,100 +185,203 @@ fn handle_show(ctx: &CommandContext) -> Result<CommandResult> {
     Ok(CommandResult::Output(lines.join("\n")))
 }
 
-/// Switch the permission mode.
+fn render_rules(
+    title: &str,
+    rules_by_source: &std::collections::HashMap<String, Vec<String>>,
+    lines: &mut Vec<String>,
+) {
+    lines.push(String::new());
+    lines.push(format!("  {}:", title));
+    if rules_by_source.is_empty() {
+        lines.push("    (none)".into());
+        return;
+    }
+    // Sort sources for stable output.
+    let mut sorted: Vec<(&String, &Vec<String>)> = rules_by_source.iter().collect();
+    sorted.sort_by_key(|(k, _)| (*k).clone());
+    for (source, rules) in sorted {
+        for rule in rules {
+            lines.push(format!("    {:<40} (from {})", rule, source));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mode
+// ---------------------------------------------------------------------------
+
 fn handle_mode(parts: &[&str], ctx: &mut CommandContext) -> Result<CommandResult> {
     if parts.is_empty() {
         return Ok(CommandResult::Output(format!(
-            "Current mode: {:?}\n\
-             Usage: /permissions mode <default|auto|bypass|plan>",
-            ctx.app_state.tool_permission_context.mode
+            "Current mode: {}\nUsage: /permissions mode <default|auto|bypass|plan|acceptEdits|dontAsk>",
+            ctx.app_state.tool_permission_context.mode.as_str(),
         )));
     }
 
-    let mode_str = parts[0];
-    let mode = match mode_str.to_lowercase().as_str() {
-        "default" | "ask" => PermissionMode::Default,
-        "auto" => PermissionMode::Auto,
-        "bypass" => {
-            if !ctx
-                .app_state
-                .tool_permission_context
-                .is_bypass_permissions_mode_available
-            {
-                return Ok(CommandResult::Output(
-                    "Bypass mode is not available in the current configuration.".into(),
-                ));
-            }
-            PermissionMode::Bypass
+    let requested = PermissionMode::parse(parts[0]);
+    if matches!(requested, PermissionMode::Default) && !parts[0].eq_ignore_ascii_case("default") {
+        return Ok(CommandResult::Output(format!(
+            "Unknown permission mode: '{}'.\nAvailable: default, auto, bypass, plan, acceptEdits, dontAsk",
+            parts[0]
+        )));
+    }
+
+    if matches!(requested, PermissionMode::Bypass)
+        && !ctx
+            .app_state
+            .tool_permission_context
+            .is_bypass_permissions_mode_available
+    {
+        return Ok(CommandResult::Output(
+            "Bypass mode is disabled by configuration (permissions.enableBypassMode=false).".into(),
+        ));
+    }
+
+    if matches!(requested, PermissionMode::Auto)
+        && ctx
+            .app_state
+            .tool_permission_context
+            .is_auto_mode_available
+            == Some(false)
+    {
+        return Ok(CommandResult::Output(
+            "Auto mode is disabled by configuration (permissions.enableAutoMode=false).".into(),
+        ));
+    }
+
+    ctx.app_state.tool_permission_context.mode = requested.clone();
+    Ok(CommandResult::Output(format!(
+        "Permission mode set to: {}",
+        requested.as_str(),
+    )))
+}
+
+// ---------------------------------------------------------------------------
+// Add (allow/ask/deny) with scope persistence
+// ---------------------------------------------------------------------------
+
+fn handle_add(
+    kind: RuleKind,
+    parts: &[&str],
+    ctx: &mut CommandContext,
+) -> Result<CommandResult> {
+    let mut parts: Vec<&str> = parts.to_vec();
+    let scope = PersistScope::parse(&mut parts);
+
+    if parts.is_empty() {
+        return Ok(CommandResult::Output(format!(
+            "Usage: /permissions {} <rule> [--user|--project|--local|--session]",
+            kind.label()
+        )));
+    }
+    let rule = parts.join(" ");
+
+    // 1. Mutate in-memory state so the rule applies immediately.
+    let bucket = match (kind, scope) {
+        (RuleKind::Allow, PersistScope::Session) => {
+            &mut ctx.app_state.tool_permission_context.session_allow_rules
         }
-        "plan" | "readonly" => PermissionMode::Plan,
-        _ => {
-            return Ok(CommandResult::Output(format!(
-                "Unknown permission mode: '{}'\n\
-                 Available modes: default, auto, bypass, plan",
-                mode_str
-            )));
+        (RuleKind::Ask, PersistScope::Session) | (RuleKind::Deny, PersistScope::Session) => {
+            return Ok(CommandResult::Output(
+                "Session scope only supports allow grants. Use --user/--project/--local for ask/deny."
+                    .into(),
+            ));
         }
+        (RuleKind::Allow, _) => &mut ctx.app_state.tool_permission_context.always_allow_rules,
+        (RuleKind::Ask, _) => &mut ctx.app_state.tool_permission_context.always_ask_rules,
+        (RuleKind::Deny, _) => &mut ctx.app_state.tool_permission_context.always_deny_rules,
+    };
+    bucket
+        .entry(scope.source_label().to_string())
+        .or_default()
+        .push(rule.clone());
+
+    // 2. Persist to disk for non-session scopes.
+    let persist_msg = match scope {
+        PersistScope::Session => "(session-only — not persisted)".to_string(),
+        other => persist_rule(kind, other, &rule, &ctx.cwd)?,
     };
 
-    ctx.app_state.tool_permission_context.mode = mode;
     Ok(CommandResult::Output(format!(
-        "Permission mode set to: {:?}",
-        ctx.app_state.tool_permission_context.mode
+        "{} rule '{}' added (scope={}). {}",
+        kind.label(),
+        rule,
+        scope.source_label(),
+        persist_msg,
     )))
 }
 
-/// Add a tool to the always-allow list.
-fn handle_allow(parts: &[&str], ctx: &mut CommandContext) -> Result<CommandResult> {
+fn persist_rule(
+    kind: RuleKind,
+    scope: PersistScope,
+    rule: &str,
+    cwd: &std::path::Path,
+) -> Result<String> {
+    let path = match scope {
+        PersistScope::User => settings::user_settings_path(),
+        PersistScope::Project => cwd.join(".cc-rust").join("settings.json"),
+        PersistScope::Local => cwd.join(".cc-rust").join("settings.local.json"),
+        PersistScope::Session => unreachable!(),
+    };
+    let mut raw = if path.exists() {
+        let txt = std::fs::read_to_string(&path)?;
+        serde_json::from_str::<settings::RawSettings>(&txt)?
+    } else {
+        settings::RawSettings::default()
+    };
+    let mut perms = raw.permissions.clone().unwrap_or_default();
+    match kind {
+        RuleKind::Allow => perms.allow.push(rule.to_string()),
+        RuleKind::Ask => perms.ask.push(rule.to_string()),
+        RuleKind::Deny => perms.deny.push(rule.to_string()),
+    }
+    raw.permissions = Some(perms);
+
+    let written = match scope {
+        PersistScope::User => settings::write_user_settings(&raw)?,
+        PersistScope::Project => settings::write_project_settings(cwd, &raw)?,
+        PersistScope::Local => settings::write_local_settings(cwd, &raw)?,
+        PersistScope::Session => unreachable!(),
+    };
+    Ok(format!("→ persisted to {}", written.display()))
+}
+
+// ---------------------------------------------------------------------------
+// Session grants
+// ---------------------------------------------------------------------------
+
+fn handle_session_grant(parts: &[&str], ctx: &mut CommandContext) -> Result<CommandResult> {
     if parts.is_empty() {
         return Ok(CommandResult::Output(
-            "Usage: /permissions allow <tool_name>".into(),
+            "Usage: /permissions session-grant <tool_name>".into(),
         ));
     }
-
-    let tool_name = parts[0].to_string();
+    let tool = parts[0];
     ctx.app_state
         .tool_permission_context
-        .always_allow_rules
-        .entry("user".into())
-        .or_default()
-        .push(tool_name.clone());
-
+        .grant_session_allow(tool);
     Ok(CommandResult::Output(format!(
-        "Tool '{}' added to always-allow list.",
-        tool_name
+        "Session grant added for '{}' (transient — cleared on session end).",
+        tool,
     )))
 }
 
-/// Add a tool to the always-deny list.
-fn handle_deny(parts: &[&str], ctx: &mut CommandContext) -> Result<CommandResult> {
-    if parts.is_empty() {
-        return Ok(CommandResult::Output(
-            "Usage: /permissions deny <tool_name>".into(),
-        ));
-    }
-
-    let tool_name = parts[0].to_string();
+fn handle_clear_session(ctx: &mut CommandContext) -> Result<CommandResult> {
     ctx.app_state
         .tool_permission_context
-        .always_deny_rules
-        .entry("user".into())
-        .or_default()
-        .push(tool_name.clone());
-
-    Ok(CommandResult::Output(format!(
-        "Tool '{}' added to always-deny list.",
-        tool_name
-    )))
+        .clear_session_grants();
+    Ok(CommandResult::Output("Session grants cleared.".into()))
 }
 
-/// Reset all permission rules to defaults.
+// ---------------------------------------------------------------------------
+// Reset
+// ---------------------------------------------------------------------------
+
 fn handle_reset(ctx: &mut CommandContext) -> Result<CommandResult> {
     let default = crate::types::app_state::AppState::default();
     ctx.app_state.tool_permission_context = default.tool_permission_context;
-
     Ok(CommandResult::Output(
-        "Permission rules reset to defaults.".into(),
+        "Permission rules reset to defaults (in-memory only — files on disk untouched).".into(),
     ))
 }
 
@@ -215,89 +402,108 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_permissions_show() {
+    async fn test_permissions_show_includes_sections() {
         let handler = PermissionsHandler;
         let mut ctx = test_ctx();
         let result = handler.execute("", &mut ctx).await.unwrap();
-        match result {
-            CommandResult::Output(text) => {
-                assert!(text.contains("Permission settings"));
-                assert!(text.contains("Mode:"));
-            }
-            _ => panic!("Expected Output result"),
-        }
+        let CommandResult::Output(text) = result else {
+            panic!("expected output")
+        };
+        assert!(text.contains("Permission settings"));
+        assert!(text.contains("Mode:"));
+        assert!(text.contains("Always deny"));
+        assert!(text.contains("Always ask"));
+        assert!(text.contains("Always allow"));
+        assert!(text.contains("Session grants"));
+        assert!(text.contains("Additional working directories"));
     }
 
     #[tokio::test]
-    async fn test_permissions_mode_switch() {
+    async fn test_permissions_mode_accept_edits() {
         let handler = PermissionsHandler;
         let mut ctx = test_ctx();
-        let result = handler.execute("mode auto", &mut ctx).await.unwrap();
-        match result {
-            CommandResult::Output(text) => {
-                assert!(text.contains("Auto"));
-            }
-            _ => panic!("Expected Output result"),
-        }
+        let result = handler.execute("mode acceptEdits", &mut ctx).await.unwrap();
+        let CommandResult::Output(text) = result else {
+            panic!("expected output")
+        };
+        assert!(text.contains("acceptEdits"));
         assert_eq!(
             ctx.app_state.tool_permission_context.mode,
-            PermissionMode::Auto
+            PermissionMode::AcceptEdits
         );
     }
 
     #[tokio::test]
-    async fn test_permissions_allow() {
+    async fn test_permissions_mode_dont_ask() {
         let handler = PermissionsHandler;
         let mut ctx = test_ctx();
-        let result = handler.execute("allow Bash", &mut ctx).await.unwrap();
-        match result {
-            CommandResult::Output(text) => {
-                assert!(text.contains("Bash"));
-                assert!(text.contains("always-allow"));
-            }
-            _ => panic!("Expected Output result"),
-        }
+        let result = handler.execute("mode dontAsk", &mut ctx).await.unwrap();
+        let CommandResult::Output(text) = result else {
+            panic!("expected output")
+        };
+        assert!(text.contains("dontAsk"));
+        assert_eq!(
+            ctx.app_state.tool_permission_context.mode,
+            PermissionMode::DontAsk
+        );
     }
 
     #[tokio::test]
-    async fn test_permissions_deny() {
+    async fn test_permissions_session_grant_and_clear() {
         let handler = PermissionsHandler;
         let mut ctx = test_ctx();
-        let result = handler.execute("deny Bash", &mut ctx).await.unwrap();
-        match result {
-            CommandResult::Output(text) => {
-                assert!(text.contains("Bash"));
-                assert!(text.contains("always-deny"));
-            }
-            _ => panic!("Expected Output result"),
-        }
-    }
-
-    #[tokio::test]
-    async fn test_permissions_reset() {
-        let handler = PermissionsHandler;
-        let mut ctx = test_ctx();
-        // First add a rule.
-        handler.execute("allow Bash", &mut ctx).await.unwrap();
-        assert!(!ctx
-            .app_state
-            .tool_permission_context
-            .always_allow_rules
-            .is_empty());
-
-        // Then reset.
-        let result = handler.execute("reset", &mut ctx).await.unwrap();
-        match result {
-            CommandResult::Output(text) => {
-                assert!(text.contains("reset to defaults"));
-            }
-            _ => panic!("Expected Output result"),
-        }
+        handler
+            .execute("session-grant Bash", &mut ctx)
+            .await
+            .unwrap();
         assert!(ctx
             .app_state
             .tool_permission_context
-            .always_allow_rules
-            .is_empty());
+            .has_session_grant("Bash"));
+
+        handler
+            .execute("clear-session-grants", &mut ctx)
+            .await
+            .unwrap();
+        assert!(!ctx
+            .app_state
+            .tool_permission_context
+            .has_session_grant("Bash"));
+    }
+
+    #[tokio::test]
+    async fn test_permissions_ask_rule_session_rejected() {
+        let handler = PermissionsHandler;
+        let mut ctx = test_ctx();
+        let result = handler
+            .execute("ask Bash --session", &mut ctx)
+            .await
+            .unwrap();
+        let CommandResult::Output(text) = result else {
+            panic!("expected output")
+        };
+        assert!(text.contains("Session scope"));
+    }
+
+    #[tokio::test]
+    async fn test_permissions_allow_user_persist() {
+        // Use a tempdir as CC_RUST_HOME so /permissions allow doesn't
+        // touch the developer's real settings file.
+        let dir = tempfile::tempdir().unwrap();
+        let _g = EnvGuard::set("CC_RUST_HOME", dir.path().to_str().unwrap());
+
+        let handler = PermissionsHandler;
+        let mut ctx = test_ctx();
+        let result = handler
+            .execute("allow Bash(prefix:git)", &mut ctx)
+            .await
+            .unwrap();
+        let CommandResult::Output(text) = result else {
+            panic!("expected output")
+        };
+        assert!(text.contains("allow rule"));
+        assert!(text.contains("persisted"));
+        assert!(dir.path().join("settings.json").exists());
     }
 
     #[tokio::test]
@@ -305,11 +511,32 @@ mod tests {
         let handler = PermissionsHandler;
         let mut ctx = test_ctx();
         let result = handler.execute("foobar", &mut ctx).await.unwrap();
-        match result {
-            CommandResult::Output(text) => {
-                assert!(text.contains("Unknown permissions subcommand"));
+        let CommandResult::Output(text) = result else {
+            panic!("expected output")
+        };
+        assert!(text.contains("Unknown permissions subcommand"));
+    }
+
+    /// Process-env guard for tests that mutate CC_RUST_HOME.
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
             }
-            _ => panic!("Expected Output result"),
         }
     }
 }

--- a/src/commands/sandbox_cmd.rs
+++ b/src/commands/sandbox_cmd.rs
@@ -1,0 +1,307 @@
+//! `/sandbox` slash command — inspect + toggle the sandbox.
+//!
+//! Usage:
+//!   /sandbox                  show status
+//!   /sandbox status           show status (explicit)
+//!   /sandbox on               set enabled=true (mode defaults to workspace)
+//!   /sandbox off              set enabled=false (mode=full)
+//!   /sandbox mode <name>      switch mode (read-only | workspace | full)
+//!   /sandbox no-network       disable all network (network.disabled=true)
+//!   /sandbox network on|off   toggle network.disabled
+//!
+//! Changes are applied to the in-memory [`crate::types::app_state::AppState`]
+//! via the session-level override path — they do not persist to
+//! `settings.json`. Use `/config set sandbox.*` for persistent edits.
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use super::{CommandContext, CommandHandler, CommandResult};
+use crate::sandbox::{policy_from_app_state, Availability, Mechanism, SandboxMode};
+
+pub struct SandboxHandler;
+
+#[async_trait]
+impl CommandHandler for SandboxHandler {
+    async fn execute(&self, args: &str, ctx: &mut CommandContext) -> Result<CommandResult> {
+        let args = args.trim();
+        let mut parts = args.split_whitespace();
+        let sub = parts.next().unwrap_or("").to_ascii_lowercase();
+
+        match sub.as_str() {
+            "" | "status" | "show" => Ok(CommandResult::Output(render_status(ctx))),
+            "on" | "enable" => {
+                ctx.app_state.settings.sandbox.enabled = Some(true);
+                if ctx.app_state.settings.sandbox.mode.is_none() {
+                    ctx.app_state.settings.sandbox.mode =
+                        Some(SandboxMode::default_enabled().as_str().to_string());
+                }
+                Ok(CommandResult::Output(format!(
+                    "Sandbox enabled (mode={}).\n\n{}",
+                    ctx.app_state
+                        .settings
+                        .sandbox
+                        .mode
+                        .clone()
+                        .unwrap_or_default(),
+                    render_status(ctx)
+                )))
+            }
+            "off" | "disable" => {
+                ctx.app_state.settings.sandbox.enabled = Some(false);
+                Ok(CommandResult::Output(format!(
+                    "Sandbox disabled.\n\n{}",
+                    render_status(ctx)
+                )))
+            }
+            "mode" => {
+                let name = parts.next().unwrap_or("").trim();
+                if name.is_empty() {
+                    return Ok(CommandResult::Output(
+                        "Usage: /sandbox mode <read-only | workspace | full>".into(),
+                    ));
+                }
+                match name.parse::<SandboxMode>() {
+                    Ok(mode) => {
+                        ctx.app_state.settings.sandbox.mode = Some(mode.as_str().to_string());
+                        ctx.app_state.settings.sandbox.enabled = Some(mode.is_active());
+                        Ok(CommandResult::Output(format!(
+                            "Sandbox mode set to '{}'.\n\n{}",
+                            mode.as_str(),
+                            render_status(ctx)
+                        )))
+                    }
+                    Err(e) => Ok(CommandResult::Output(format!("Error: {}", e))),
+                }
+            }
+            "no-network" | "offline" => {
+                ctx.app_state.settings.sandbox.network.disabled = Some(true);
+                Ok(CommandResult::Output(format!(
+                    "Network disabled for this session.\n\n{}",
+                    render_status(ctx)
+                )))
+            }
+            "network" => {
+                let val = parts.next().unwrap_or("").to_ascii_lowercase();
+                match val.as_str() {
+                    "on" | "enable" => {
+                        ctx.app_state.settings.sandbox.network.disabled = Some(false);
+                        Ok(CommandResult::Output(format!(
+                            "Network enabled.\n\n{}",
+                            render_status(ctx)
+                        )))
+                    }
+                    "off" | "disable" => {
+                        ctx.app_state.settings.sandbox.network.disabled = Some(true);
+                        Ok(CommandResult::Output(format!(
+                            "Network disabled.\n\n{}",
+                            render_status(ctx)
+                        )))
+                    }
+                    "" => Ok(CommandResult::Output(
+                        "Usage: /sandbox network <on|off>".into(),
+                    )),
+                    other => Ok(CommandResult::Output(format!(
+                        "Unknown subcommand '{}'. Try: /sandbox network <on|off>",
+                        other
+                    ))),
+                }
+            }
+            other => Ok(CommandResult::Output(format!(
+                "Unknown /sandbox subcommand '{}'.\n\nUsage:\n  \
+                 /sandbox                — show status\n  \
+                 /sandbox on             — enable sandbox\n  \
+                 /sandbox off            — disable sandbox\n  \
+                 /sandbox mode <name>    — switch mode (read-only | workspace | full)\n  \
+                 /sandbox no-network     — disable network\n  \
+                 /sandbox network on|off — toggle network access",
+                other
+            ))),
+        }
+    }
+}
+
+/// Render a multi-line status block for display in the REPL.
+fn render_status(ctx: &CommandContext) -> String {
+    let policy = policy_from_app_state(&ctx.app_state, ctx.cwd.clone(), false);
+    let mut out = String::new();
+    out.push_str("Sandbox status\n");
+    out.push_str("──────────────\n");
+    out.push_str(&format!(
+        "  Enabled:  {}\n",
+        if policy.enabled { "yes" } else { "no" }
+    ));
+    out.push_str(&format!("  Mode:     {}\n", policy.mode.as_str()));
+    out.push_str(&format!(
+        "  Escape:   allowUnsandboxedCommands = {}\n",
+        policy.allow_unsandboxed_commands
+    ));
+    out.push_str(&format!(
+        "  Fail if unavailable: {}\n",
+        policy.fail_if_unavailable
+    ));
+    out.push_str(&format!("  Workspace: {}\n", policy.paths.workspace().display()));
+
+    // Platform / OS primitive
+    out.push_str("\nPlatform:\n");
+    match &policy.availability {
+        Availability::Available(m) => {
+            out.push_str(&format!(
+                "  OS-level sandbox: available via {}\n",
+                mechanism_label(*m)
+            ));
+        }
+        Availability::Unavailable { platform, reason } => {
+            out.push_str(&format!(
+                "  OS-level sandbox: UNAVAILABLE on {}\n    {}\n",
+                platform, reason
+            ));
+        }
+    }
+
+    // Network summary
+    out.push_str("\nNetwork:\n");
+    out.push_str(&format!(
+        "  Disabled:        {}\n",
+        policy.network.disabled
+    ));
+    if policy.network.allowed_domains.is_empty() {
+        out.push_str("  Allowed domains: (all, no restriction)\n");
+    } else {
+        out.push_str("  Allowed domains:\n");
+        for d in &policy.network.allowed_domains {
+            out.push_str(&format!("    - {}\n", d));
+        }
+    }
+
+    // Filesystem summary
+    out.push_str("\nFilesystem:\n");
+    render_path_list(&mut out, "allowWrite", policy.paths.allow_write_paths());
+    render_path_list(&mut out, "denyWrite", policy.paths.deny_write_paths());
+    render_path_list(&mut out, "allowRead", policy.paths.allow_read_paths());
+    render_path_list(&mut out, "denyRead", policy.paths.deny_read_paths());
+
+    // Excluded / allowed commands
+    if !policy.excluded_commands.is_empty() {
+        out.push_str("\nExcluded commands (run outside sandbox):\n");
+        for c in &policy.excluded_commands {
+            out.push_str(&format!("  - {}\n", c));
+        }
+    }
+
+    out
+}
+
+fn render_path_list(out: &mut String, label: &str, paths: &[std::path::PathBuf]) {
+    if paths.is_empty() {
+        out.push_str(&format!("  {}: (none)\n", label));
+        return;
+    }
+    out.push_str(&format!("  {}:\n", label));
+    for p in paths {
+        out.push_str(&format!("    - {}\n", p.display()));
+    }
+}
+
+fn mechanism_label(m: Mechanism) -> &'static str {
+    m.as_str()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bootstrap::SessionId;
+    use crate::types::app_state::AppState;
+
+    fn make_ctx() -> CommandContext {
+        CommandContext {
+            messages: vec![],
+            cwd: std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+            app_state: AppState::default(),
+            session_id: SessionId::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn status_shows_disabled_by_default() {
+        let handler = SandboxHandler;
+        let mut ctx = make_ctx();
+        let result = handler.execute("", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(s) => {
+                assert!(s.contains("Enabled:  no") || s.contains("Enabled: no"));
+                assert!(s.contains("Mode:"));
+            }
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[tokio::test]
+    async fn on_enables_sandbox_and_sets_workspace_default() {
+        let handler = SandboxHandler;
+        let mut ctx = make_ctx();
+        handler.execute("on", &mut ctx).await.unwrap();
+        assert_eq!(ctx.app_state.settings.sandbox.enabled, Some(true));
+        assert_eq!(
+            ctx.app_state.settings.sandbox.mode.as_deref(),
+            Some("workspace")
+        );
+    }
+
+    #[tokio::test]
+    async fn mode_accepts_read_only() {
+        let handler = SandboxHandler;
+        let mut ctx = make_ctx();
+        handler.execute("mode read-only", &mut ctx).await.unwrap();
+        assert_eq!(
+            ctx.app_state.settings.sandbox.mode.as_deref(),
+            Some("read-only")
+        );
+        assert_eq!(ctx.app_state.settings.sandbox.enabled, Some(true));
+    }
+
+    #[tokio::test]
+    async fn mode_full_disables_sandbox() {
+        let handler = SandboxHandler;
+        let mut ctx = make_ctx();
+        handler.execute("mode full", &mut ctx).await.unwrap();
+        assert_eq!(ctx.app_state.settings.sandbox.enabled, Some(false));
+    }
+
+    #[tokio::test]
+    async fn no_network_toggles_disabled() {
+        let handler = SandboxHandler;
+        let mut ctx = make_ctx();
+        handler.execute("no-network", &mut ctx).await.unwrap();
+        assert_eq!(
+            ctx.app_state.settings.sandbox.network.disabled,
+            Some(true)
+        );
+    }
+
+    #[tokio::test]
+    async fn network_on_reenables() {
+        let handler = SandboxHandler;
+        let mut ctx = make_ctx();
+        ctx.app_state.settings.sandbox.network.disabled = Some(true);
+        handler.execute("network on", &mut ctx).await.unwrap();
+        assert_eq!(
+            ctx.app_state.settings.sandbox.network.disabled,
+            Some(false)
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_subcommand_returns_usage() {
+        let handler = SandboxHandler;
+        let mut ctx = make_ctx();
+        let result = handler.execute("bogus", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(s) => {
+                assert!(s.contains("Unknown /sandbox subcommand"));
+                assert!(s.contains("Usage:"));
+            }
+            _ => panic!("expected Output"),
+        }
+    }
+}

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -297,17 +297,11 @@ impl RawSettings {
         merge_opt!(editor_mode, "editorMode");
         merge_opt!(view_mode, "viewMode");
         merge_opt!(spinner_tips, "spinnerTips");
-        merge_opt!(
-            terminal_progress_bar_enabled,
-            "terminalProgressBarEnabled"
-        );
+        merge_opt!(terminal_progress_bar_enabled, "terminalProgressBarEnabled");
         merge_opt!(available_models, "availableModels");
         merge_opt!(effort_level, "effortLevel");
         merge_opt!(fast_mode, "fastMode");
-        merge_opt!(
-            fast_mode_per_session_opt_in,
-            "fastModePerSessionOptIn"
-        );
+        merge_opt!(fast_mode_per_session_opt_in, "fastModePerSessionOptIn");
         merge_opt!(teammate_mode, "teammateMode");
         merge_opt!(
             claude_in_chrome_default_enabled,
@@ -323,7 +317,10 @@ impl RawSettings {
     }
 }
 
-fn merge_permissions(base: Option<PermissionsSettings>, over: PermissionsSettings) -> PermissionsSettings {
+fn merge_permissions(
+    base: Option<PermissionsSettings>,
+    over: PermissionsSettings,
+) -> PermissionsSettings {
     let mut out = base.unwrap_or_default();
     if over.default_mode.is_some() {
         out.default_mode = over.default_mode;
@@ -520,6 +517,27 @@ pub fn global_claude_dir() -> Result<PathBuf> {
 /// Path to the user-level settings file.
 pub fn user_settings_path() -> PathBuf {
     crate::config::paths::data_root().join("settings.json")
+}
+
+/// Path to the effective project-level settings file for `cwd`.
+///
+/// If `cwd` is inside an existing `.cc-rust/` project hierarchy, this
+/// resolves to the nearest ancestor settings file location. Otherwise it
+/// points at `cwd/.cc-rust/settings.json`, which is also where a new file
+/// would be created.
+pub fn project_settings_path(cwd: &Path) -> PathBuf {
+    find_project_dir(cwd)
+        .unwrap_or_else(|| cwd.join(".cc-rust"))
+        .join("settings.json")
+}
+
+/// Path to the effective local override settings file for `cwd`.
+///
+/// Mirrors [`project_settings_path`] but targets `settings.local.json`.
+pub fn local_settings_path(cwd: &Path) -> PathBuf {
+    find_project_dir(cwd)
+        .unwrap_or_else(|| cwd.join(".cc-rust"))
+        .join("settings.local.json")
 }
 
 /// Path to the managed/policy settings file, if one is configured.
@@ -801,13 +819,12 @@ pub fn write_settings_file(path: &Path, raw: &RawSettings) -> Result<()> {
         prune_backups(path, MAX_SETTINGS_BACKUPS);
     }
 
-    let pretty = serde_json::to_string_pretty(raw)
-        .context("Failed to serialize settings to JSON")?;
+    let pretty =
+        serde_json::to_string_pretty(raw).context("Failed to serialize settings to JSON")?;
 
     // Atomic-ish: write to a tmp sibling, then rename.
     let tmp = path.with_extension("json.tmp");
-    std::fs::write(&tmp, pretty)
-        .with_context(|| format!("Failed to write {}", tmp.display()))?;
+    std::fs::write(&tmp, pretty).with_context(|| format!("Failed to write {}", tmp.display()))?;
     std::fs::rename(&tmp, path)
         .with_context(|| format!("Failed to rename {} -> {}", tmp.display(), path.display()))?;
 
@@ -823,16 +840,14 @@ pub fn write_user_settings(raw: &RawSettings) -> Result<PathBuf> {
 
 /// Write to `cwd/.cc-rust/settings.json`, creating the directory if needed.
 pub fn write_project_settings(cwd: &Path, raw: &RawSettings) -> Result<PathBuf> {
-    let dir = find_project_dir(cwd).unwrap_or_else(|| cwd.join(".cc-rust"));
-    let path = dir.join("settings.json");
+    let path = project_settings_path(cwd);
     write_settings_file(&path, raw)?;
     Ok(path)
 }
 
 /// Write to `cwd/.cc-rust/settings.local.json`.
 pub fn write_local_settings(cwd: &Path, raw: &RawSettings) -> Result<PathBuf> {
-    let dir = find_project_dir(cwd).unwrap_or_else(|| cwd.join(".cc-rust"));
-    let path = dir.join("settings.local.json");
+    let path = local_settings_path(cwd);
     write_settings_file(&path, raw)?;
     Ok(path)
 }
@@ -845,7 +860,9 @@ fn prune_backups(path: &Path, keep: usize) {
     let prefix = format!("{}.", stem);
 
     let mut backups: Vec<PathBuf> = Vec::new();
-    let Ok(entries) = std::fs::read_dir(parent) else { return };
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return;
+    };
     for entry in entries.flatten() {
         let name = entry.file_name().to_string_lossy().into_owned();
         if name.starts_with(&prefix) && name.ends_with(".bak") {

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -141,18 +141,124 @@ impl PermissionsSettings {
     }
 }
 
+/// Filesystem paths the sandbox permits or denies access to.
+///
+/// Paths accept three prefix conventions (matching Claude Code):
+/// - `/absolute/path` — absolute path
+/// - `~/relative` — relative to `$HOME`
+/// - `./relative` or bare `relative` — relative to the project root (or the
+///   enclosing `~/.cc-rust/` for user settings)
+///
+/// Lists from every [`SettingsSource`] are **merged**, not replaced, so users
+/// can extend managed rules without overriding them.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, rename_all = "camelCase")]
+pub struct SandboxFilesystemSettings {
+    pub allow_read: Vec<String>,
+    pub deny_read: Vec<String>,
+    pub allow_write: Vec<String>,
+    pub deny_write: Vec<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+impl SandboxFilesystemSettings {
+    pub fn is_effectively_empty(&self) -> bool {
+        self.allow_read.is_empty()
+            && self.deny_read.is_empty()
+            && self.allow_write.is_empty()
+            && self.deny_write.is_empty()
+            && self.extra.is_empty()
+    }
+}
+
+/// Network restrictions applied to shell subprocesses and WebFetch.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, rename_all = "camelCase")]
+pub struct SandboxNetworkSettings {
+    /// Hard-disable all network access (matches `--no-network`).
+    pub disabled: Option<bool>,
+    /// Domain allowlist. Empty list means "no restriction".
+    pub allowed_domains: Vec<String>,
+    /// Optional HTTP proxy port for advanced network sandboxing.
+    pub http_proxy_port: Option<u16>,
+    /// Optional SOCKS proxy port for advanced network sandboxing.
+    pub socks_proxy_port: Option<u16>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+impl SandboxNetworkSettings {
+    pub fn is_effectively_empty(&self) -> bool {
+        self.disabled.is_none()
+            && self.allowed_domains.is_empty()
+            && self.http_proxy_port.is_none()
+            && self.socks_proxy_port.is_none()
+            && self.extra.is_empty()
+    }
+}
+
 /// Sandbox section of settings.json.
+///
+/// Aligned with Claude Code's `sandbox.*` settings surface. A pragmatic
+/// subset of the TypeScript reference is enforced at runtime:
+/// - `enabled` + `mode` drive policy assembly
+/// - `failIfUnavailable` controls the hard-fail path when the OS primitives
+///   (bubblewrap / sandbox-exec / Restricted Token) are missing
+/// - `allowUnsandboxedCommands` gates the `dangerouslyDisableSandbox` escape
+///   hatch
+/// - `excludedCommands` forces specific commands outside the sandbox
+/// - `filesystem.*` controls subprocess fs access (merged with Read/Edit
+///   permission rules)
+/// - `network.*` controls subprocess + WebFetch network access
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default, rename_all = "camelCase")]
 pub struct SandboxSettings {
-    /// Enable sandbox for shell / tool execution.
+    /// Enable sandbox for shell / tool execution. Defaults to `false`.
     pub enabled: Option<bool>,
-    /// Sandbox profile / mode identifier.
+    /// Sandbox profile identifier: `read-only`, `workspace`, or `full` (off).
     pub mode: Option<String>,
-    /// Per-command allow list.
+    /// When `true` and the OS primitive is unavailable, fail hard instead of
+    /// falling back to unsandboxed execution (default: `false`).
+    pub fail_if_unavailable: Option<bool>,
+    /// When `false`, reject the `dangerouslyDisableSandbox` escape hatch
+    /// regardless of permission rules (default: `true`).
+    pub allow_unsandboxed_commands: Option<bool>,
+    /// When `true` in managed settings, only managed `allowRead` entries are
+    /// respected; user/project/local entries are ignored. `denyRead` still
+    /// merges from every source.
+    pub allow_managed_read_paths_only: Option<bool>,
+    /// When `true` in managed settings, only managed `allowedDomains` entries
+    /// are respected; user/project/local entries are ignored.
+    pub allow_managed_domains_only: Option<bool>,
+    /// Commands (glob patterns / prefixes) that must run outside the sandbox.
+    pub excluded_commands: Vec<String>,
+    /// Commands that are pre-approved for sandboxed execution. When the
+    /// active mode is `workspace`, commands in this list are run without
+    /// going through the ask/allow flow.
     pub allowed_commands: Vec<String>,
+    /// Filesystem allow/deny lists (merged with Read/Edit permission rules).
+    pub filesystem: SandboxFilesystemSettings,
+    /// Network policy (allowed domains + --no-network).
+    pub network: SandboxNetworkSettings,
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
+}
+
+impl SandboxSettings {
+    pub fn is_effectively_empty(&self) -> bool {
+        self.enabled.is_none()
+            && self.mode.is_none()
+            && self.fail_if_unavailable.is_none()
+            && self.allow_unsandboxed_commands.is_none()
+            && self.allow_managed_read_paths_only.is_none()
+            && self.allow_managed_domains_only.is_none()
+            && self.excluded_commands.is_empty()
+            && self.allowed_commands.is_empty()
+            && self.filesystem.is_effectively_empty()
+            && self.network.is_effectively_empty()
+            && self.extra.is_empty()
+    }
 }
 
 /// Status-line configuration.
@@ -279,7 +385,12 @@ impl RawSettings {
             }
         }
 
-        merge_opt!(sandbox, "sandbox");
+        if let Some(sbx) = other.sandbox {
+            if !sbx.is_effectively_empty() {
+                self.sandbox = Some(merge_sandbox(self.sandbox.take(), sbx));
+                sources.insert("sandbox".to_string(), source);
+            }
+        }
 
         if let Some(hooks) = other.hooks {
             let mut merged = self.hooks.take().unwrap_or_default();
@@ -337,6 +448,78 @@ fn merge_permissions(
     }
     if over.enable_auto_mode.is_some() {
         out.enable_auto_mode = over.enable_auto_mode;
+    }
+    for (k, v) in over.extra {
+        out.extra.insert(k, v);
+    }
+    out
+}
+
+/// Merge sandbox settings by overlaying scalar fields and concatenating
+/// (deduped) list fields. This matches the Claude Code spec where
+/// `allowWrite` / `denyWrite` / `allowRead` / `denyRead` / `allowedDomains`
+/// / `excludedCommands` are merged across scopes rather than replaced.
+fn merge_sandbox(base: Option<SandboxSettings>, over: SandboxSettings) -> SandboxSettings {
+    let mut out = base.unwrap_or_default();
+    if over.enabled.is_some() {
+        out.enabled = over.enabled;
+    }
+    if over.mode.is_some() {
+        out.mode = over.mode;
+    }
+    if over.fail_if_unavailable.is_some() {
+        out.fail_if_unavailable = over.fail_if_unavailable;
+    }
+    if over.allow_unsandboxed_commands.is_some() {
+        out.allow_unsandboxed_commands = over.allow_unsandboxed_commands;
+    }
+    if over.allow_managed_read_paths_only.is_some() {
+        out.allow_managed_read_paths_only = over.allow_managed_read_paths_only;
+    }
+    if over.allow_managed_domains_only.is_some() {
+        out.allow_managed_domains_only = over.allow_managed_domains_only;
+    }
+    out.excluded_commands =
+        merge_str_lists(Some(&out.excluded_commands), Some(&over.excluded_commands));
+    out.allowed_commands =
+        merge_str_lists(Some(&out.allowed_commands), Some(&over.allowed_commands));
+    out.filesystem = merge_sandbox_fs(out.filesystem, over.filesystem);
+    out.network = merge_sandbox_net(out.network, over.network);
+    for (k, v) in over.extra {
+        out.extra.insert(k, v);
+    }
+    out
+}
+
+fn merge_sandbox_fs(
+    base: SandboxFilesystemSettings,
+    over: SandboxFilesystemSettings,
+) -> SandboxFilesystemSettings {
+    let mut out = base;
+    out.allow_read = merge_str_lists(Some(&out.allow_read), Some(&over.allow_read));
+    out.deny_read = merge_str_lists(Some(&out.deny_read), Some(&over.deny_read));
+    out.allow_write = merge_str_lists(Some(&out.allow_write), Some(&over.allow_write));
+    out.deny_write = merge_str_lists(Some(&out.deny_write), Some(&over.deny_write));
+    for (k, v) in over.extra {
+        out.extra.insert(k, v);
+    }
+    out
+}
+
+fn merge_sandbox_net(
+    base: SandboxNetworkSettings,
+    over: SandboxNetworkSettings,
+) -> SandboxNetworkSettings {
+    let mut out = base;
+    if over.disabled.is_some() {
+        out.disabled = over.disabled;
+    }
+    out.allowed_domains = merge_str_lists(Some(&out.allowed_domains), Some(&over.allowed_domains));
+    if over.http_proxy_port.is_some() {
+        out.http_proxy_port = over.http_proxy_port;
+    }
+    if over.socks_proxy_port.is_some() {
+        out.socks_proxy_port = over.socks_proxy_port;
     }
     for (k, v) in over.extra {
         out.extra.insert(k, v);
@@ -926,9 +1109,41 @@ pub fn settings_schema() -> Value {
                 "additionalProperties": true,
                 "properties": {
                     "enabled": { "type": "boolean" },
-                    "mode": { "type": "string" },
+                    "mode": {
+                        "type": "string",
+                        "enum": ["read-only", "workspace", "full"]
+                    },
+                    "failIfUnavailable": { "type": "boolean" },
+                    "allowUnsandboxedCommands": { "type": "boolean" },
+                    "allowManagedReadPathsOnly": { "type": "boolean" },
+                    "allowManagedDomainsOnly": { "type": "boolean" },
+                    "excludedCommands": {
+                        "type": "array", "items": { "type": "string" }
+                    },
                     "allowedCommands": {
                         "type": "array", "items": { "type": "string" }
+                    },
+                    "filesystem": {
+                        "type": "object",
+                        "additionalProperties": true,
+                        "properties": {
+                            "allowRead": { "type": "array", "items": { "type": "string" } },
+                            "denyRead": { "type": "array", "items": { "type": "string" } },
+                            "allowWrite": { "type": "array", "items": { "type": "string" } },
+                            "denyWrite": { "type": "array", "items": { "type": "string" } }
+                        }
+                    },
+                    "network": {
+                        "type": "object",
+                        "additionalProperties": true,
+                        "properties": {
+                            "disabled": { "type": "boolean" },
+                            "allowedDomains": {
+                                "type": "array", "items": { "type": "string" }
+                            },
+                            "httpProxyPort": { "type": "integer", "minimum": 0, "maximum": 65535 },
+                            "socksProxyPort": { "type": "integer", "minimum": 0, "maximum": 65535 }
+                        }
                     }
                 }
             },

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1,85 +1,403 @@
-//! Settings management.
+//! Settings management (layered, source-aware).
 //!
-//! Loads configuration from multiple sources and merges them with a defined
-//! precedence order:
-//!   1. Global config (`~/.cc-rust/settings.json`)       -- lowest priority
-//!   2. Project config (`.cc-rust/settings.json` in CWD) -- higher priority
-//!   3. Environment variables                           -- highest priority
+//! # Layered configuration
 //!
-//! The merged result drives `AppState::settings`.
+//! Configuration is merged from the following sources, in **ascending**
+//! priority (higher overrides lower):
+//!
+//! 1. `Managed` — policy-level settings. Windows prefers
+//!    `%ProgramData%\cc-rust\settings.json`; other platforms use
+//!    `/etc/cc-rust/managed-settings.json`. Overridable with
+//!    `CC_RUST_MANAGED_SETTINGS`.
+//! 2. `User` — `{data_root}/settings.json` (i.e. `~/.cc-rust/settings.json`
+//!    or `$CC_RUST_HOME/settings.json`).
+//! 3. `Project` — `.cc-rust/settings.json` in CWD or any ancestor directory.
+//! 4. `Local` — `.cc-rust/settings.local.json` next to the project settings
+//!    (intended for gitignored per-machine overrides).
+//! 5. `Env` — a handful of CLAUDE_* / CC_* environment variables.
+//! 6. `Cli` — command-line flags (applied by the caller, not this module).
+//!
+//! The merge produces an [`EffectiveSettings`] together with a
+//! [`SourceMap`] that records which layer won for each key.
+//!
+//! # Backward compatibility
+//!
+//! The legacy names [`GlobalConfig`], [`ProjectConfig`], [`MergedConfig`],
+//! [`load_global_config`], [`load_project_config`], [`merge_configs`], and
+//! [`load_and_merge`] are preserved so existing callers keep compiling.
+//! New callers should prefer [`load_effective`], [`RawSettings`], and
+//! [`EffectiveSettings`].
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
 
 // ---------------------------------------------------------------------------
-// Config types
+// Source tracking
 // ---------------------------------------------------------------------------
 
-/// Global (user-level) configuration loaded from `~/.cc-rust/settings.json`.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
-pub struct GlobalConfig {
-    /// Preferred model identifier.
+/// Origin of a single configuration value.
+///
+/// Used by [`SourceMap`] so the user can introspect where each effective
+/// value came from (`/config show --effective`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SettingsSource {
+    /// Compiled-in default (no file / env provided a value).
+    Default,
+    /// Managed / policy-level settings.
+    Managed,
+    /// User-level settings (`~/.cc-rust/settings.json`).
+    User,
+    /// Project-level settings (`.cc-rust/settings.json`).
+    Project,
+    /// Project-local overrides (`.cc-rust/settings.local.json`).
+    Local,
+    /// Environment variable override.
+    Env,
+    /// CLI flag override (set by `main.rs` after loading).
+    Cli,
+}
+
+impl SettingsSource {
+    /// Priority ranking — higher wins in a merge.
+    ///
+    /// Exposed so callers (e.g. `/config sources`) can break ties or sort
+    /// by priority order without re-implementing the table.
+    #[allow(dead_code)]
+    pub fn rank(self) -> u8 {
+        match self {
+            SettingsSource::Default => 0,
+            SettingsSource::Managed => 1,
+            SettingsSource::User => 2,
+            SettingsSource::Project => 3,
+            SettingsSource::Local => 4,
+            SettingsSource::Env => 5,
+            SettingsSource::Cli => 6,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SettingsSource::Default => "default",
+            SettingsSource::Managed => "managed",
+            SettingsSource::User => "user",
+            SettingsSource::Project => "project",
+            SettingsSource::Local => "local",
+            SettingsSource::Env => "env",
+            SettingsSource::Cli => "cli",
+        }
+    }
+}
+
+/// Per-key provenance for merged settings. Uses a `BTreeMap` so the output
+/// of `/config show` is deterministic.
+pub type SourceMap = BTreeMap<String, SettingsSource>;
+
+// ---------------------------------------------------------------------------
+// Typed sub-structures for richer settings
+// ---------------------------------------------------------------------------
+
+/// Permissions section of settings.json.
+///
+/// Mirrors the Claude Code TS `PermissionsSettings` shape at a high level.
+/// Missing fields are `None`; empty arrays are treated the same as missing
+/// for merge purposes.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, rename_all = "camelCase")]
+pub struct PermissionsSettings {
+    /// Permission mode. One of: `default`, `ask`, `auto`, `bypass`, `plan`.
+    pub default_mode: Option<String>,
+    /// Tools that are always allowed (patterns).
+    pub allow: Vec<String>,
+    /// Tools that are always asked before execution.
+    pub ask: Vec<String>,
+    /// Tools that are always denied.
+    pub deny: Vec<String>,
+    /// Additional working directories the tools may access.
+    pub additional_directories: Vec<String>,
+    /// Whether `bypass` mode should be allowed at runtime.
+    pub enable_bypass_mode: Option<bool>,
+    /// Whether `auto` mode should be allowed at runtime.
+    pub enable_auto_mode: Option<bool>,
+    /// Unknown fields so forward-compat is preserved.
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+impl PermissionsSettings {
+    pub fn is_effectively_empty(&self) -> bool {
+        self.default_mode.is_none()
+            && self.allow.is_empty()
+            && self.ask.is_empty()
+            && self.deny.is_empty()
+            && self.additional_directories.is_empty()
+            && self.enable_bypass_mode.is_none()
+            && self.enable_auto_mode.is_none()
+            && self.extra.is_empty()
+    }
+}
+
+/// Sandbox section of settings.json.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, rename_all = "camelCase")]
+pub struct SandboxSettings {
+    /// Enable sandbox for shell / tool execution.
+    pub enabled: Option<bool>,
+    /// Sandbox profile / mode identifier.
+    pub mode: Option<String>,
+    /// Per-command allow list.
+    pub allowed_commands: Vec<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Status-line configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, rename_all = "camelCase")]
+pub struct StatusLineSettings {
+    /// Status-line type, e.g. `none`, `minimal`, `command`, `script`.
+    pub r#type: Option<String>,
+    /// Inline command to execute for `command` type.
+    pub command: Option<String>,
+    /// Path to a script for `script` type.
+    pub script: Option<String>,
+    /// Optional format template.
+    pub format: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+/// Spinner-tip configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, rename_all = "camelCase")]
+pub struct SpinnerTipsSettings {
+    pub enabled: Option<bool>,
+    pub interval_ms: Option<u64>,
+    pub custom_tips: Vec<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+// ---------------------------------------------------------------------------
+// RawSettings — on-disk shape of a single settings file
+// ---------------------------------------------------------------------------
+
+/// On-disk shape of a single `settings.json` (or `settings.local.json`,
+/// managed settings, etc.). All fields are optional.
+///
+/// Unknown keys fall into [`RawSettings::extra`] to preserve forward
+/// compatibility.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default, rename_all = "camelCase")]
+pub struct RawSettings {
+    // -- Core identity --------------------------------------------------
     pub model: Option<String>,
-    /// Backend selection ("native" or "codex").
     pub backend: Option<String>,
-    /// Color theme name.
     pub theme: Option<String>,
-    /// Verbose output.
     pub verbose: Option<bool>,
-    /// Permission mode override (e.g. "auto", "bypass").
+
+    // -- Permissions / sandbox -----------------------------------------
+    /// Legacy top-level permission mode (e.g. "auto"). Prefer
+    /// `permissions.defaultMode`. If both are present, nested wins.
     pub permission_mode: Option<String>,
-    /// Tools that are always allowed (list of patterns).
+    /// Legacy flat allowed-tools list. Prefer `permissions.allow`.
     pub allowed_tools: Option<Vec<String>>,
-    /// Custom system prompt to prepend.
-    pub system_prompt: Option<String>,
-    /// Hooks configuration (keyed by hook point).
-    pub hooks: Option<HashMap<String, serde_json::Value>>,
-    /// Whether Claude in Chrome should be enabled by default.
+    pub permissions: Option<PermissionsSettings>,
+    pub sandbox: Option<SandboxSettings>,
+
+    // -- Hooks ----------------------------------------------------------
+    /// Event → config value mapping (deserialized by tools/hooks).
+    pub hooks: Option<HashMap<String, Value>>,
+
+    // -- UI / UX --------------------------------------------------------
+    pub status_line: Option<StatusLineSettings>,
+    pub output_style: Option<String>,
+    pub language: Option<String>,
+    pub voice_enabled: Option<bool>,
+    pub editor_mode: Option<String>,
+    pub view_mode: Option<String>,
+    pub spinner_tips: Option<SpinnerTipsSettings>,
+    pub terminal_progress_bar_enabled: Option<bool>,
+
+    // -- Model / effort -------------------------------------------------
+    pub available_models: Option<Vec<String>>,
+    pub effort_level: Option<String>,
+    pub fast_mode: Option<bool>,
+    pub fast_mode_per_session_opt_in: Option<bool>,
+
+    // -- Modes / integrations ------------------------------------------
+    pub teammate_mode: Option<bool>,
     #[serde(rename = "claudeInChromeDefaultEnabled")]
     pub claude_in_chrome_default_enabled: Option<bool>,
-    /// API key override (not recommended -- prefer env vars).
+
+    // -- Prompts --------------------------------------------------------
+    pub system_prompt: Option<String>,
+
+    // -- Credentials ----------------------------------------------------
+    /// API key override. User-level only; strongly discouraged. Redacted in
+    /// source-map output.
     pub api_key: Option<String>,
-    /// Additional arbitrary settings.
+
+    // -- Arbitrary passthrough ------------------------------------------
     #[serde(flatten)]
-    pub extra: HashMap<String, serde_json::Value>,
+    pub extra: HashMap<String, Value>,
 }
 
-/// Project-level configuration loaded from `.cc-rust/settings.json` in the
-/// working directory (or an ancestor).
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
-pub struct ProjectConfig {
-    /// Preferred model for this project.
-    pub model: Option<String>,
-    /// Backend selection ("native" or "codex").
-    pub backend: Option<String>,
-    /// Color theme for this project.
-    pub theme: Option<String>,
-    /// Verbose output.
-    pub verbose: Option<bool>,
-    /// Permission mode override.
-    pub permission_mode: Option<String>,
-    /// Tools that are always allowed.
-    pub allowed_tools: Option<Vec<String>>,
-    /// Custom system prompt (project-level).
-    pub system_prompt: Option<String>,
-    /// Hooks configuration.
-    pub hooks: Option<HashMap<String, serde_json::Value>>,
-    /// Whether Claude in Chrome should be enabled by default for this project.
-    #[serde(rename = "claudeInChromeDefaultEnabled")]
-    pub claude_in_chrome_default_enabled: Option<bool>,
-    /// Additional arbitrary settings.
-    #[serde(flatten)]
-    pub extra: HashMap<String, serde_json::Value>,
+impl RawSettings {
+    /// Merge `other` **on top of** `self`. Mutates `self` in place and
+    /// records, in `sources`, every key that `other` provided.
+    fn merge_from(&mut self, other: RawSettings, source: SettingsSource, sources: &mut SourceMap) {
+        macro_rules! merge_opt {
+            ($field:ident, $key:expr) => {
+                if let Some(v) = other.$field {
+                    self.$field = Some(v);
+                    sources.insert($key.to_string(), source);
+                }
+            };
+        }
+
+        merge_opt!(model, "model");
+        merge_opt!(backend, "backend");
+        merge_opt!(theme, "theme");
+        merge_opt!(verbose, "verbose");
+        merge_opt!(permission_mode, "permissionMode");
+
+        if let Some(list) = other.allowed_tools {
+            let merged = merge_str_lists(self.allowed_tools.as_deref(), Some(&list));
+            self.allowed_tools = Some(merged);
+            sources.insert("allowedTools".to_string(), source);
+        }
+
+        if let Some(perms) = other.permissions {
+            if !perms.is_effectively_empty() {
+                self.permissions = Some(merge_permissions(self.permissions.take(), perms));
+                sources.insert("permissions".to_string(), source);
+            }
+        }
+
+        merge_opt!(sandbox, "sandbox");
+
+        if let Some(hooks) = other.hooks {
+            let mut merged = self.hooks.take().unwrap_or_default();
+            for (k, v) in hooks {
+                merged.insert(k, v);
+            }
+            self.hooks = Some(merged);
+            sources.insert("hooks".to_string(), source);
+        }
+
+        merge_opt!(status_line, "statusLine");
+        merge_opt!(output_style, "outputStyle");
+        merge_opt!(language, "language");
+        merge_opt!(voice_enabled, "voiceEnabled");
+        merge_opt!(editor_mode, "editorMode");
+        merge_opt!(view_mode, "viewMode");
+        merge_opt!(spinner_tips, "spinnerTips");
+        merge_opt!(
+            terminal_progress_bar_enabled,
+            "terminalProgressBarEnabled"
+        );
+        merge_opt!(available_models, "availableModels");
+        merge_opt!(effort_level, "effortLevel");
+        merge_opt!(fast_mode, "fastMode");
+        merge_opt!(
+            fast_mode_per_session_opt_in,
+            "fastModePerSessionOptIn"
+        );
+        merge_opt!(teammate_mode, "teammateMode");
+        merge_opt!(
+            claude_in_chrome_default_enabled,
+            "claudeInChromeDefaultEnabled"
+        );
+        merge_opt!(system_prompt, "systemPrompt");
+        merge_opt!(api_key, "apiKey");
+
+        for (k, v) in other.extra {
+            self.extra.insert(k.clone(), v);
+            sources.insert(k, source);
+        }
+    }
 }
 
-/// Merged configuration with values resolved from all sources.
+fn merge_permissions(base: Option<PermissionsSettings>, over: PermissionsSettings) -> PermissionsSettings {
+    let mut out = base.unwrap_or_default();
+    if over.default_mode.is_some() {
+        out.default_mode = over.default_mode;
+    }
+    out.allow = merge_str_lists(Some(&out.allow), Some(&over.allow));
+    out.ask = merge_str_lists(Some(&out.ask), Some(&over.ask));
+    out.deny = merge_str_lists(Some(&out.deny), Some(&over.deny));
+    out.additional_directories = merge_str_lists(
+        Some(&out.additional_directories),
+        Some(&over.additional_directories),
+    );
+    if over.enable_bypass_mode.is_some() {
+        out.enable_bypass_mode = over.enable_bypass_mode;
+    }
+    if over.enable_auto_mode.is_some() {
+        out.enable_auto_mode = over.enable_auto_mode;
+    }
+    for (k, v) in over.extra {
+        out.extra.insert(k, v);
+    }
+    out
+}
+
+fn merge_str_lists(base: Option<&[String]>, over: Option<&[String]>) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(b) = base {
+        out.extend_from_slice(b);
+    }
+    if let Some(o) = over {
+        for item in o {
+            if !out.contains(item) {
+                out.push(item.clone());
+            }
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Backward-compat type aliases
+// ---------------------------------------------------------------------------
+
+/// Legacy alias — global/user settings file shape.
+///
+/// Prefer [`RawSettings`] in new code. Kept so that historic call sites
+/// (`use settings::GlobalConfig;`) continue to compile after the refactor.
+#[allow(dead_code)]
+pub type GlobalConfig = RawSettings;
+
+/// Legacy alias — project settings file shape.
+///
+/// Prefer [`RawSettings`] in new code. Kept for the same reason as
+/// [`GlobalConfig`].
+#[allow(dead_code)]
+pub type ProjectConfig = RawSettings;
+
+/// Merged runtime configuration. See [`EffectiveSettings`] for the new,
+/// source-aware form.
+pub type MergedConfig = EffectiveSettings;
+
+// ---------------------------------------------------------------------------
+// EffectiveSettings — runtime-ready, merged form
+// ---------------------------------------------------------------------------
+
+/// Fully-merged, runtime-ready settings.
+///
+/// Fields that have reasonable defaults are fully materialised (e.g.
+/// `verbose: bool` rather than `Option<bool>`). Fields that have no
+/// meaningful default stay `Option`.
+///
+/// Paired with a [`SourceMap`] via [`LoadedSettings`].
 #[derive(Debug, Clone, Default)]
-pub struct MergedConfig {
+pub struct EffectiveSettings {
+    // -- Legacy (consumed by main.rs) ----------------------------------
     pub model: Option<String>,
     pub backend: Option<String>,
     pub theme: Option<String>,
@@ -89,62 +407,159 @@ pub struct MergedConfig {
     pub allowed_tools: Vec<String>,
     #[allow(dead_code)]
     pub system_prompt: Option<String>,
-    pub hooks: HashMap<String, serde_json::Value>,
+    pub hooks: HashMap<String, Value>,
     pub claude_in_chrome_default_enabled: Option<bool>,
     pub api_key: Option<String>,
     #[allow(dead_code)]
-    pub extra: HashMap<String, serde_json::Value>,
+    pub extra: HashMap<String, Value>,
+
+    // -- New typed fields ----------------------------------------------
+    pub permissions: PermissionsSettings,
+    pub sandbox: SandboxSettings,
+    pub status_line: StatusLineSettings,
+    pub spinner_tips: SpinnerTipsSettings,
+    pub output_style: Option<String>,
+    pub language: Option<String>,
+    pub voice_enabled: Option<bool>,
+    pub editor_mode: Option<String>,
+    pub view_mode: Option<String>,
+    pub terminal_progress_bar_enabled: Option<bool>,
+    pub available_models: Vec<String>,
+    pub effort_level: Option<String>,
+    pub fast_mode: Option<bool>,
+    pub fast_mode_per_session_opt_in: Option<bool>,
+    pub teammate_mode: Option<bool>,
+}
+
+impl EffectiveSettings {
+    fn from_raw(raw: RawSettings) -> Self {
+        let mut perms = raw.permissions.unwrap_or_default();
+        // Fold legacy top-level fields into the nested struct so downstream
+        // code only needs to look in one place.
+        if perms.default_mode.is_none() {
+            perms.default_mode = raw.permission_mode.clone();
+        }
+        if let Some(legacy) = raw.allowed_tools.as_ref() {
+            perms.allow = merge_str_lists(Some(&perms.allow), Some(legacy));
+        }
+
+        Self {
+            model: raw.model,
+            backend: raw.backend,
+            theme: raw.theme,
+            verbose: raw.verbose.unwrap_or(false),
+            permission_mode: perms.default_mode.clone().or(raw.permission_mode),
+            allowed_tools: perms.allow.clone(),
+            system_prompt: raw.system_prompt,
+            hooks: raw.hooks.unwrap_or_default(),
+            claude_in_chrome_default_enabled: raw.claude_in_chrome_default_enabled,
+            api_key: raw.api_key,
+            extra: raw.extra,
+            permissions: perms,
+            sandbox: raw.sandbox.unwrap_or_default(),
+            status_line: raw.status_line.unwrap_or_default(),
+            spinner_tips: raw.spinner_tips.unwrap_or_default(),
+            output_style: raw.output_style,
+            language: raw.language,
+            voice_enabled: raw.voice_enabled,
+            editor_mode: raw.editor_mode,
+            view_mode: raw.view_mode,
+            terminal_progress_bar_enabled: raw.terminal_progress_bar_enabled,
+            available_models: raw.available_models.unwrap_or_default(),
+            effort_level: raw.effort_level,
+            fast_mode: raw.fast_mode,
+            fast_mode_per_session_opt_in: raw.fast_mode_per_session_opt_in,
+            teammate_mode: raw.teammate_mode,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
-// Loading functions
+// LoadedSettings — effective + raw layers + source map
 // ---------------------------------------------------------------------------
 
-/// Return the path to the global cc-rust settings directory.
-///
-/// Historically this could fail if the home directory was unresolvable; the
-/// unified [`crate::config::paths::data_root`] now never fails (it falls back
-/// to a temp dir with a one-time warn), so `Result` is preserved only for
-/// source compatibility with existing `?`-using callers.
+/// Result of [`load_effective`]. Holds the merged [`EffectiveSettings`]
+/// and a [`SourceMap`] recording which layer provided each key, plus the
+/// raw per-layer contents for diagnostics.
+#[derive(Debug, Clone, Default)]
+pub struct LoadedSettings {
+    pub effective: EffectiveSettings,
+    pub sources: SourceMap,
+    pub managed: Option<RawSettings>,
+    pub user: Option<RawSettings>,
+    pub project: Option<RawSettings>,
+    pub local: Option<RawSettings>,
+    /// Paths that were actually read (present on disk).
+    pub loaded_paths: Vec<(SettingsSource, PathBuf)>,
+}
+
+impl LoadedSettings {
+    /// Source of a specific key (e.g. `"model"`, `"permissions"`).
+    ///
+    /// Returns [`SettingsSource::Default`] if no layer provided the key.
+    /// Used by `/config sources` and tests; reserved for downstream callers
+    /// that want to inspect provenance without iterating the full map.
+    #[allow(dead_code)]
+    pub fn source_of(&self, key: &str) -> SettingsSource {
+        self.sources
+            .get(key)
+            .copied()
+            .unwrap_or(SettingsSource::Default)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+/// Global cc-rust data directory. Never fails — falls back to a temp dir.
 pub fn global_claude_dir() -> Result<PathBuf> {
     Ok(crate::config::paths::data_root())
 }
 
-/// Load the global configuration from `~/.cc-rust/settings.json`.
-///
-/// Returns `Ok(GlobalConfig::default())` if the file does not exist.
-pub fn load_global_config() -> Result<GlobalConfig> {
-    let dir = global_claude_dir()?;
-    let path = dir.join("settings.json");
-
-    if !path.exists() {
-        return Ok(GlobalConfig::default());
-    }
-
-    let contents = std::fs::read_to_string(&path)
-        .with_context(|| format!("Failed to read {}", path.display()))?;
-
-    let config: GlobalConfig = serde_json::from_str(&contents)
-        .with_context(|| format!("Failed to parse {}", path.display()))?;
-
-    Ok(config)
+/// Path to the user-level settings file.
+pub fn user_settings_path() -> PathBuf {
+    crate::config::paths::data_root().join("settings.json")
 }
 
-/// Load the project configuration from `.cc-rust/settings.json` relative to
-/// `cwd`, or any ancestor directory.
+/// Path to the managed/policy settings file, if one is configured.
 ///
-/// Returns `Ok(ProjectConfig::default())` if no project config is found.
-pub fn load_project_config(cwd: &Path) -> Result<ProjectConfig> {
-    let path = find_project_config(cwd);
-    match path {
-        Some(p) => {
-            let contents = std::fs::read_to_string(&p)
-                .with_context(|| format!("Failed to read {}", p.display()))?;
-            let config: ProjectConfig = serde_json::from_str(&contents)
-                .with_context(|| format!("Failed to parse {}", p.display()))?;
-            Ok(config)
+/// Resolution:
+///   1. `CC_RUST_MANAGED_SETTINGS` env (if non-empty).
+///   2. Windows: `%ProgramData%\cc-rust\settings.json` (or
+///      `C:\ProgramData\cc-rust\settings.json` if the env var is absent).
+///   3. Other: `/etc/cc-rust/managed-settings.json`.
+pub fn managed_settings_path() -> PathBuf {
+    if let Ok(p) = std::env::var("CC_RUST_MANAGED_SETTINGS") {
+        if !p.trim().is_empty() {
+            return PathBuf::from(p);
         }
-        None => Ok(ProjectConfig::default()),
+    }
+    #[cfg(windows)]
+    {
+        let base = std::env::var_os("ProgramData")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("C:\\ProgramData"));
+        base.join("cc-rust").join("settings.json")
+    }
+    #[cfg(not(windows))]
+    {
+        PathBuf::from("/etc/cc-rust/managed-settings.json")
+    }
+}
+
+/// Return the path to the nearest ancestor project settings directory
+/// (`.cc-rust/`) or `None`.
+fn find_project_dir(cwd: &Path) -> Option<PathBuf> {
+    let mut dir = cwd.to_path_buf();
+    loop {
+        let candidate = dir.join(".cc-rust");
+        if candidate.is_dir() {
+            return Some(candidate);
+        }
+        if !dir.pop() {
+            return None;
+        }
     }
 }
 
@@ -162,104 +577,384 @@ fn find_project_config(cwd: &Path) -> Option<PathBuf> {
     }
 }
 
+/// Search for `.cc-rust/settings.local.json`.
+fn find_local_config(cwd: &Path) -> Option<PathBuf> {
+    let mut dir = cwd.to_path_buf();
+    loop {
+        let candidate = dir.join(".cc-rust").join("settings.local.json");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
-// Merge logic
+// Loaders
 // ---------------------------------------------------------------------------
 
-/// Merge global and project configs into a single resolved `MergedConfig`.
+fn load_raw_from(path: &Path) -> Result<Option<RawSettings>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let contents = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read {}", path.display()))?;
+    let raw: RawSettings = serde_json::from_str(&contents)
+        .with_context(|| format!("Failed to parse {}", path.display()))?;
+    Ok(Some(raw))
+}
+
+/// Load the user-level settings. Returns `Ok(RawSettings::default())` if
+/// the file does not exist.
 ///
-/// Project settings override global settings where present. Environment
-/// variables are applied last (highest priority).
+/// Convenience wrapper kept for callers that only want one layer; the full
+/// stack is loaded via [`load_effective`].
+#[allow(dead_code)]
+pub fn load_global_config() -> Result<RawSettings> {
+    Ok(load_raw_from(&user_settings_path())?.unwrap_or_default())
+}
+
+/// Load the project-level settings. Returns defaults if none is found.
+#[allow(dead_code)]
+pub fn load_project_config(cwd: &Path) -> Result<RawSettings> {
+    match find_project_config(cwd) {
+        Some(p) => Ok(load_raw_from(&p)?.unwrap_or_default()),
+        None => Ok(RawSettings::default()),
+    }
+}
+
+/// Load project-local overrides (`.cc-rust/settings.local.json`).
+#[allow(dead_code)]
+pub fn load_local_config(cwd: &Path) -> Result<RawSettings> {
+    match find_local_config(cwd) {
+        Some(p) => Ok(load_raw_from(&p)?.unwrap_or_default()),
+        None => Ok(RawSettings::default()),
+    }
+}
+
+/// Load managed / policy settings, if a managed settings file exists on
+/// disk. Errors reading an existing file are surfaced; a missing file is
+/// treated as "no managed layer".
+#[allow(dead_code)]
+pub fn load_managed_config() -> Result<RawSettings> {
+    Ok(load_raw_from(&managed_settings_path())?.unwrap_or_default())
+}
+
+// ---------------------------------------------------------------------------
+// Merge / env overrides
+// ---------------------------------------------------------------------------
+
+/// Merge exactly two layers (global then project). Preserved for
+/// backward compatibility with earlier call sites.
+#[allow(dead_code)]
 pub fn merge_configs(global: &GlobalConfig, project: &ProjectConfig) -> MergedConfig {
-    let mut merged = MergedConfig {
-        model: project.model.clone().or_else(|| global.model.clone()),
-        backend: project.backend.clone().or_else(|| global.backend.clone()),
-        theme: project.theme.clone().or_else(|| global.theme.clone()),
-        verbose: project.verbose.or(global.verbose).unwrap_or(false),
-        permission_mode: project
-            .permission_mode
-            .clone()
-            .or_else(|| global.permission_mode.clone()),
-        allowed_tools: merge_string_lists(
-            global.allowed_tools.as_deref(),
-            project.allowed_tools.as_deref(),
-        ),
-        system_prompt: project
-            .system_prompt
-            .clone()
-            .or_else(|| global.system_prompt.clone()),
-        hooks: merge_maps(global.hooks.as_ref(), project.hooks.as_ref()),
-        claude_in_chrome_default_enabled: project
-            .claude_in_chrome_default_enabled
-            .or(global.claude_in_chrome_default_enabled),
-        api_key: global.api_key.clone(),
-        extra: merge_maps(Some(&global.extra), Some(&project.extra)),
-    };
-
-    // Apply environment variable overrides.
-    apply_env_overrides(&mut merged);
-
+    let mut acc = RawSettings::default();
+    let mut sources = SourceMap::new();
+    acc.merge_from(global.clone(), SettingsSource::User, &mut sources);
+    acc.merge_from(project.clone(), SettingsSource::Project, &mut sources);
+    let mut merged = EffectiveSettings::from_raw(acc);
+    apply_env_overrides(&mut merged, &mut sources);
     merged
 }
 
-/// Merge two optional string lists by concatenation (global first, project second).
-fn merge_string_lists(global: Option<&[String]>, project: Option<&[String]>) -> Vec<String> {
-    let mut result = Vec::new();
-    if let Some(g) = global {
-        result.extend_from_slice(g);
-    }
-    if let Some(p) = project {
-        for item in p {
-            if !result.contains(item) {
-                result.push(item.clone());
-            }
-        }
-    }
-    result
-}
+/// Apply environment-variable overrides in place.
+fn apply_env_overrides(merged: &mut EffectiveSettings, sources: &mut SourceMap) {
+    let set_src = |key: &str, sources: &mut SourceMap| {
+        sources.insert(key.to_string(), SettingsSource::Env);
+    };
 
-/// Merge two optional maps. Project values override global values for the
-/// same key.
-fn merge_maps(
-    global: Option<&HashMap<String, serde_json::Value>>,
-    project: Option<&HashMap<String, serde_json::Value>>,
-) -> HashMap<String, serde_json::Value> {
-    let mut result = HashMap::new();
-    if let Some(g) = global {
-        result.extend(g.clone());
-    }
-    if let Some(p) = project {
-        result.extend(p.clone());
-    }
-    result
-}
-
-/// Load all config sources and merge them in one call.
-///
-/// Convenience function for the initialization path.
-pub fn load_and_merge(cwd: &str) -> Result<MergedConfig> {
-    let global = load_global_config()?;
-    let project = load_project_config(Path::new(cwd))?;
-    Ok(merge_configs(&global, &project))
-}
-
-/// Apply environment variable overrides to merged config.
-fn apply_env_overrides(merged: &mut MergedConfig) {
     if let Ok(model) = std::env::var("CLAUDE_MODEL") {
         merged.model = Some(model);
+        set_src("model", sources);
     }
     if let Ok(backend) = std::env::var("CC_BACKEND").or_else(|_| std::env::var("CLAUDE_BACKEND")) {
         merged.backend = Some(backend);
+        set_src("backend", sources);
     }
     if let Ok(key) = std::env::var("ANTHROPIC_API_KEY") {
         merged.api_key = Some(key);
+        set_src("apiKey", sources);
     }
     if let Ok(v) = std::env::var("CLAUDE_VERBOSE") {
         merged.verbose = v == "1" || v.eq_ignore_ascii_case("true");
+        set_src("verbose", sources);
     }
     if let Ok(mode) = std::env::var("CLAUDE_PERMISSION_MODE") {
-        merged.permission_mode = Some(mode);
+        merged.permission_mode = Some(mode.clone());
+        merged.permissions.default_mode = Some(mode);
+        set_src("permissionMode", sources);
     }
+    if let Ok(lang) = std::env::var("CLAUDE_LANGUAGE") {
+        merged.language = Some(lang);
+        set_src("language", sources);
+    }
+    if let Ok(style) = std::env::var("CLAUDE_OUTPUT_STYLE") {
+        merged.output_style = Some(style);
+        set_src("outputStyle", sources);
+    }
+    if let Ok(theme) = std::env::var("CLAUDE_THEME") {
+        merged.theme = Some(theme);
+        set_src("theme", sources);
+    }
+}
+
+/// Load the full four-layer stack (managed/user/project/local) plus env.
+///
+/// This is the preferred entry point for new code. The legacy
+/// [`load_and_merge`] wraps this and returns only [`EffectiveSettings`].
+pub fn load_effective(cwd: &Path) -> Result<LoadedSettings> {
+    let mut acc = RawSettings::default();
+    let mut sources = SourceMap::new();
+    let mut loaded_paths = Vec::new();
+    let mut managed = None;
+    let mut user = None;
+    let mut project = None;
+    let mut local = None;
+
+    // 1. managed
+    let managed_path = managed_settings_path();
+    if let Some(raw) = load_raw_from(&managed_path)? {
+        acc.merge_from(raw.clone(), SettingsSource::Managed, &mut sources);
+        managed = Some(raw);
+        loaded_paths.push((SettingsSource::Managed, managed_path));
+    }
+
+    // 2. user
+    let user_path = user_settings_path();
+    if let Some(raw) = load_raw_from(&user_path)? {
+        acc.merge_from(raw.clone(), SettingsSource::User, &mut sources);
+        user = Some(raw);
+        loaded_paths.push((SettingsSource::User, user_path));
+    }
+
+    // 3. project
+    if let Some(p) = find_project_config(cwd) {
+        if let Some(raw) = load_raw_from(&p)? {
+            acc.merge_from(raw.clone(), SettingsSource::Project, &mut sources);
+            project = Some(raw);
+            loaded_paths.push((SettingsSource::Project, p));
+        }
+    }
+
+    // 4. local
+    if let Some(p) = find_local_config(cwd) {
+        if let Some(raw) = load_raw_from(&p)? {
+            acc.merge_from(raw.clone(), SettingsSource::Local, &mut sources);
+            local = Some(raw);
+            loaded_paths.push((SettingsSource::Local, p));
+        }
+    }
+
+    let mut effective = EffectiveSettings::from_raw(acc);
+
+    // 5. env
+    apply_env_overrides(&mut effective, &mut sources);
+
+    Ok(LoadedSettings {
+        effective,
+        sources,
+        managed,
+        user,
+        project,
+        local,
+        loaded_paths,
+    })
+}
+
+/// Convenience wrapper — loads the full stack and returns the merged
+/// runtime view.
+pub fn load_and_merge(cwd: &str) -> Result<MergedConfig> {
+    Ok(load_effective(Path::new(cwd))?.effective)
+}
+
+// ---------------------------------------------------------------------------
+// Write + backup
+// ---------------------------------------------------------------------------
+
+/// Maximum number of backup copies to retain per settings file.
+pub const MAX_SETTINGS_BACKUPS: usize = 5;
+
+/// Serialise `raw` to JSON (pretty) with atomic write + rotating backup.
+///
+/// - Creates parent directories as needed.
+/// - If `path` already exists, it's copied to `{path}.{timestamp}.bak`.
+/// - Old backups beyond [`MAX_SETTINGS_BACKUPS`] are pruned.
+pub fn write_settings_file(path: &Path, raw: &RawSettings) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create directory {}", parent.display()))?;
+    }
+
+    if path.exists() {
+        let ts = chrono::Local::now().format("%Y%m%d-%H%M%S");
+        let bak = path.with_extension(format!("json.{}.bak", ts));
+        if let Err(e) = std::fs::copy(path, &bak) {
+            tracing::warn!(
+                source = %path.display(),
+                target = %bak.display(),
+                error = %e,
+                "failed to copy settings backup"
+            );
+        }
+        prune_backups(path, MAX_SETTINGS_BACKUPS);
+    }
+
+    let pretty = serde_json::to_string_pretty(raw)
+        .context("Failed to serialize settings to JSON")?;
+
+    // Atomic-ish: write to a tmp sibling, then rename.
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, pretty)
+        .with_context(|| format!("Failed to write {}", tmp.display()))?;
+    std::fs::rename(&tmp, path)
+        .with_context(|| format!("Failed to rename {} -> {}", tmp.display(), path.display()))?;
+
+    Ok(())
+}
+
+/// Write to the user-level settings file.
+pub fn write_user_settings(raw: &RawSettings) -> Result<PathBuf> {
+    let path = user_settings_path();
+    write_settings_file(&path, raw)?;
+    Ok(path)
+}
+
+/// Write to `cwd/.cc-rust/settings.json`, creating the directory if needed.
+pub fn write_project_settings(cwd: &Path, raw: &RawSettings) -> Result<PathBuf> {
+    let dir = find_project_dir(cwd).unwrap_or_else(|| cwd.join(".cc-rust"));
+    let path = dir.join("settings.json");
+    write_settings_file(&path, raw)?;
+    Ok(path)
+}
+
+/// Write to `cwd/.cc-rust/settings.local.json`.
+pub fn write_local_settings(cwd: &Path, raw: &RawSettings) -> Result<PathBuf> {
+    let dir = find_project_dir(cwd).unwrap_or_else(|| cwd.join(".cc-rust"));
+    let path = dir.join("settings.local.json");
+    write_settings_file(&path, raw)?;
+    Ok(path)
+}
+
+fn prune_backups(path: &Path, keep: usize) {
+    let Some(parent) = path.parent() else { return };
+    let Some(stem) = path.file_name().map(|n| n.to_string_lossy().into_owned()) else {
+        return;
+    };
+    let prefix = format!("{}.", stem);
+
+    let mut backups: Vec<PathBuf> = Vec::new();
+    let Ok(entries) = std::fs::read_dir(parent) else { return };
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name.starts_with(&prefix) && name.ends_with(".bak") {
+            backups.push(entry.path());
+        }
+    }
+    // Sort newest-first by filename (our timestamp format is sortable).
+    backups.sort_by(|a, b| b.file_name().cmp(&a.file_name()));
+    for old in backups.into_iter().skip(keep) {
+        let _ = std::fs::remove_file(old);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JSON Schema
+// ---------------------------------------------------------------------------
+
+/// Return a JSON Schema (Draft 2020-12) describing the on-disk
+/// `settings.json` shape.
+///
+/// The schema is hand-maintained so the repo can commit it without pulling
+/// in `schemars`. Keep in sync with [`RawSettings`].
+pub fn settings_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://cc-rust/settings.schema.json",
+        "title": "cc-rust settings",
+        "description": "On-disk shape of settings.json (managed/user/project/local).",
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+            "model": { "type": "string" },
+            "backend": { "type": "string", "enum": ["native", "codex"] },
+            "theme": { "type": "string" },
+            "verbose": { "type": "boolean" },
+            "permissionMode": {
+                "type": "string",
+                "enum": ["default", "ask", "auto", "bypass", "plan", "acceptEdits", "dontAsk"]
+            },
+            "allowedTools": { "type": "array", "items": { "type": "string" } },
+            "permissions": {
+                "type": "object",
+                "additionalProperties": true,
+                "properties": {
+                    "defaultMode": {
+                        "type": "string",
+                        "enum": ["default", "ask", "auto", "bypass", "plan", "acceptEdits", "dontAsk"]
+                    },
+                    "allow": { "type": "array", "items": { "type": "string" } },
+                    "ask": { "type": "array", "items": { "type": "string" } },
+                    "deny": { "type": "array", "items": { "type": "string" } },
+                    "additionalDirectories": {
+                        "type": "array", "items": { "type": "string" }
+                    },
+                    "enableBypassMode": { "type": "boolean" },
+                    "enableAutoMode": { "type": "boolean" }
+                }
+            },
+            "sandbox": {
+                "type": "object",
+                "additionalProperties": true,
+                "properties": {
+                    "enabled": { "type": "boolean" },
+                    "mode": { "type": "string" },
+                    "allowedCommands": {
+                        "type": "array", "items": { "type": "string" }
+                    }
+                }
+            },
+            "hooks": { "type": "object", "additionalProperties": true },
+            "statusLine": {
+                "type": "object",
+                "additionalProperties": true,
+                "properties": {
+                    "type": { "type": "string" },
+                    "command": { "type": "string" },
+                    "script": { "type": "string" },
+                    "format": { "type": "string" }
+                }
+            },
+            "outputStyle": { "type": "string" },
+            "language": { "type": "string" },
+            "voiceEnabled": { "type": "boolean" },
+            "editorMode": { "type": "string", "enum": ["normal", "vim"] },
+            "viewMode": { "type": "string" },
+            "spinnerTips": {
+                "type": "object",
+                "additionalProperties": true,
+                "properties": {
+                    "enabled": { "type": "boolean" },
+                    "intervalMs": { "type": "integer", "minimum": 0 },
+                    "customTips": {
+                        "type": "array", "items": { "type": "string" }
+                    }
+                }
+            },
+            "terminalProgressBarEnabled": { "type": "boolean" },
+            "availableModels": {
+                "type": "array", "items": { "type": "string" }
+            },
+            "effortLevel": { "type": "string" },
+            "fastMode": { "type": "boolean" },
+            "fastModePerSessionOptIn": { "type": "boolean" },
+            "teammateMode": { "type": "boolean" },
+            "claudeInChromeDefaultEnabled": { "type": "boolean" },
+            "systemPrompt": { "type": "string" },
+            "apiKey": { "type": "string" }
+        }
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -271,15 +966,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_merge_project_overrides_global() {
-        let global = GlobalConfig {
+    fn project_overrides_global() {
+        let global = RawSettings {
             model: Some("claude-sonnet".into()),
             backend: Some("native".into()),
             theme: Some("dark".into()),
             verbose: Some(false),
             ..Default::default()
         };
-        let project = ProjectConfig {
+        let project = RawSettings {
             model: Some("claude-opus".into()),
             backend: Some("codex".into()),
             verbose: Some(true),
@@ -290,26 +985,183 @@ mod tests {
         let merged = merge_configs(&global, &project);
         assert_eq!(merged.model.as_deref(), Some("claude-opus"));
         assert_eq!(merged.backend.as_deref(), Some("codex"));
-        assert_eq!(merged.theme.as_deref(), Some("dark")); // falls through to global
+        assert_eq!(merged.theme.as_deref(), Some("dark"));
         assert!(merged.verbose);
         assert_eq!(merged.claude_in_chrome_default_enabled, Some(true));
     }
 
     #[test]
-    fn test_merge_allowed_tools_deduplicates() {
-        let tools = merge_string_lists(
-            Some(&["Bash".into(), "FileRead".into()]),
-            Some(&["FileRead".into(), "Grep".into()]),
-        );
+    fn allowed_tools_dedup_merges() {
+        let base: Vec<String> = vec!["Bash".into(), "FileRead".into()];
+        let over: Vec<String> = vec!["FileRead".into(), "Grep".into()];
+        let tools = merge_str_lists(Some(&base), Some(&over));
         assert_eq!(tools, vec!["Bash", "FileRead", "Grep"]);
     }
 
     #[test]
-    fn test_empty_configs_produce_defaults() {
-        let merged = merge_configs(&GlobalConfig::default(), &ProjectConfig::default());
+    fn empty_configs_produce_defaults() {
+        let merged = merge_configs(&RawSettings::default(), &RawSettings::default());
         assert!(merged.model.is_none());
         assert!(merged.backend.is_none());
         assert!(!merged.verbose);
         assert!(merged.allowed_tools.is_empty());
+    }
+
+    #[test]
+    fn permissions_legacy_fallback() {
+        let raw = RawSettings {
+            permission_mode: Some("auto".into()),
+            allowed_tools: Some(vec!["Bash".into()]),
+            ..Default::default()
+        };
+        let eff = EffectiveSettings::from_raw(raw);
+        assert_eq!(eff.permissions.default_mode.as_deref(), Some("auto"));
+        assert_eq!(eff.permissions.allow, vec!["Bash".to_string()]);
+        assert_eq!(eff.permission_mode.as_deref(), Some("auto"));
+    }
+
+    #[test]
+    fn permissions_nested_overrides_legacy() {
+        let raw = RawSettings {
+            permission_mode: Some("auto".into()),
+            permissions: Some(PermissionsSettings {
+                default_mode: Some("bypass".into()),
+                allow: vec!["Grep".into()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let eff = EffectiveSettings::from_raw(raw);
+        assert_eq!(eff.permissions.default_mode.as_deref(), Some("bypass"));
+        assert!(eff.permissions.allow.contains(&"Grep".to_string()));
+    }
+
+    #[test]
+    fn source_map_tracks_layer() {
+        let user = RawSettings {
+            model: Some("sonnet".into()),
+            ..Default::default()
+        };
+        let project = RawSettings {
+            model: Some("opus".into()),
+            theme: Some("dark".into()),
+            ..Default::default()
+        };
+        let mut acc = RawSettings::default();
+        let mut sources = SourceMap::new();
+        acc.merge_from(user, SettingsSource::User, &mut sources);
+        acc.merge_from(project, SettingsSource::Project, &mut sources);
+        assert_eq!(sources.get("model"), Some(&SettingsSource::Project));
+        assert_eq!(sources.get("theme"), Some(&SettingsSource::Project));
+    }
+
+    #[test]
+    fn unknown_keys_land_in_extra() {
+        let raw: RawSettings = serde_json::from_str(
+            r#"{ "model": "opus", "customFlag": true, "anotherNested": {"a":1} }"#,
+        )
+        .unwrap();
+        assert_eq!(raw.model.as_deref(), Some("opus"));
+        assert!(raw.extra.contains_key("customFlag"));
+        assert!(raw.extra.contains_key("anotherNested"));
+    }
+
+    #[test]
+    fn schema_has_known_keys() {
+        let s = settings_schema();
+        let props = s
+            .pointer("/properties")
+            .and_then(|v| v.as_object())
+            .expect("schema has /properties");
+        for key in [
+            "model",
+            "backend",
+            "permissions",
+            "sandbox",
+            "statusLine",
+            "outputStyle",
+            "spinnerTips",
+            "availableModels",
+            "fastMode",
+        ] {
+            assert!(props.contains_key(key), "missing schema key: {}", key);
+        }
+    }
+
+    /// The committed schema file is the canonical doc. This test makes
+    /// sure it never drifts from the runtime [`settings_schema`] output.
+    /// To regenerate the file, run:
+    /// `cargo test schema_file_matches_runtime -- --ignored` (then update).
+    #[test]
+    fn schema_file_matches_runtime() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("docs")
+            .join("schemas")
+            .join("settings.schema.json");
+
+        let on_disk: Value = serde_json::from_str(
+            &std::fs::read_to_string(&path).expect("docs/schemas/settings.schema.json missing"),
+        )
+        .expect("schema file is not valid JSON");
+
+        let runtime = settings_schema();
+
+        // Compare the `properties` object specifically — the human-curated
+        // file may carry additional doc-only metadata but its property
+        // shape must match. (We only assert the property keys are equal.)
+        let on_disk_keys: std::collections::BTreeSet<_> = on_disk
+            .pointer("/properties")
+            .and_then(|v| v.as_object())
+            .map(|m| m.keys().cloned().collect())
+            .unwrap_or_default();
+        let runtime_keys: std::collections::BTreeSet<_> = runtime
+            .pointer("/properties")
+            .and_then(|v| v.as_object())
+            .map(|m| m.keys().cloned().collect())
+            .unwrap_or_default();
+        assert_eq!(
+            on_disk_keys, runtime_keys,
+            "settings.schema.json drift — committed file is missing keys \
+             present in settings_schema(), or vice versa. Update \
+             docs/schemas/settings.schema.json to match.",
+        );
+    }
+
+    #[test]
+    fn write_creates_backup_and_prunes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("settings.json");
+
+        let raw1 = RawSettings {
+            model: Some("claude-a".into()),
+            ..Default::default()
+        };
+        write_settings_file(&path, &raw1).unwrap();
+        assert!(path.exists());
+
+        // Do several more writes separated by one second to get unique
+        // backup timestamps (format is YYYYMMDD-HHMMSS).
+        for i in 0..(MAX_SETTINGS_BACKUPS + 2) {
+            std::thread::sleep(std::time::Duration::from_millis(1100));
+            let raw = RawSettings {
+                model: Some(format!("claude-{}", i)),
+                ..Default::default()
+            };
+            write_settings_file(&path, &raw).unwrap();
+        }
+
+        let entries: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                let n = e.file_name().to_string_lossy().into_owned();
+                n.starts_with("settings.json.") && n.ends_with(".bak")
+            })
+            .collect();
+        assert!(
+            entries.len() <= MAX_SETTINGS_BACKUPS,
+            "too many backups: {}",
+            entries.len()
+        );
     }
 }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -186,14 +186,31 @@ pub fn validate_settings(settings: &SettingsJson) -> Vec<ValidationWarning> {
         .as_ref()
         .or(settings.permission_mode.as_ref());
     if let Some(mode) = permission_mode {
-        let valid = ["default", "ask", "auto", "bypass", "plan"];
-        if !valid.contains(&mode.to_lowercase().as_str()) {
+        let valid = [
+            "default",
+            "ask",
+            "auto",
+            "bypass",
+            "plan",
+            "acceptedits",
+            "dontask",
+        ];
+        if !valid.contains(&mode.to_ascii_lowercase().as_str()) {
             warnings.push(ValidationWarning {
                 field: "permissionMode".to_string(),
                 message: format!(
                     "Unknown permission mode '{}'. Known modes: {}.",
                     mode,
-                    valid.join(", ")
+                    [
+                        "default",
+                        "ask",
+                        "auto",
+                        "bypass",
+                        "plan",
+                        "acceptEdits",
+                        "dontAsk"
+                    ]
+                    .join(", ")
                 ),
                 severity: WarningSeverity::Error,
             });
@@ -353,8 +370,9 @@ mod tests {
             ..Default::default()
         };
         let warnings = validate_settings(&settings);
-        assert!(warnings.iter().any(|w| w.field == "permissionMode"
-            && w.severity == WarningSeverity::Error));
+        assert!(warnings
+            .iter()
+            .any(|w| w.field == "permissionMode" && w.severity == WarningSeverity::Error));
     }
 
     #[test]
@@ -365,5 +383,26 @@ mod tests {
         };
         let warnings = validate_settings(&settings);
         assert!(warnings.iter().any(|w| w.field == "editorMode"));
+    }
+
+    #[test]
+    fn test_validate_settings_accepts_new_permission_modes() {
+        let settings = SettingsJson {
+            permission_mode: Some("acceptEdits".into()),
+            permissions: crate::config::settings::PermissionsSettings {
+                default_mode: Some("dontAsk".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let warnings = validate_settings(&settings);
+        assert!(
+            !warnings.iter().any(|w| w.field == "permissionMode"),
+            "expected new permission modes to validate cleanly, got {:?}",
+            warnings
+                .iter()
+                .map(|w| (&w.field, &w.message))
+                .collect::<Vec<_>>()
+        );
     }
 }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -244,6 +244,22 @@ pub fn validate_settings(settings: &SettingsJson) -> Vec<ValidationWarning> {
         }
     }
 
+    // Validate sandbox mode
+    if let Some(mode) = &settings.sandbox.mode {
+        let valid = ["read-only", "workspace", "full"];
+        if !valid.contains(&mode.to_lowercase().as_str()) {
+            warnings.push(ValidationWarning {
+                field: "sandbox.mode".to_string(),
+                message: format!(
+                    "Unknown sandbox mode '{}'. Known modes: {}.",
+                    mode,
+                    valid.join(", ")
+                ),
+                severity: WarningSeverity::Error,
+            });
+        }
+    }
+
     warnings
 }
 

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -179,6 +179,54 @@ pub fn validate_settings(settings: &SettingsJson) -> Vec<ValidationWarning> {
         }
     }
 
+    // Validate permission mode (legacy + nested)
+    let permission_mode = settings
+        .permissions
+        .default_mode
+        .as_ref()
+        .or(settings.permission_mode.as_ref());
+    if let Some(mode) = permission_mode {
+        let valid = ["default", "ask", "auto", "bypass", "plan"];
+        if !valid.contains(&mode.to_lowercase().as_str()) {
+            warnings.push(ValidationWarning {
+                field: "permissionMode".to_string(),
+                message: format!(
+                    "Unknown permission mode '{}'. Known modes: {}.",
+                    mode,
+                    valid.join(", ")
+                ),
+                severity: WarningSeverity::Error,
+            });
+        }
+    }
+
+    // Validate editor mode
+    if let Some(mode) = &settings.editor_mode {
+        let valid = ["normal", "vim"];
+        if !valid.contains(&mode.to_lowercase().as_str()) {
+            warnings.push(ValidationWarning {
+                field: "editorMode".to_string(),
+                message: format!(
+                    "Unknown editor mode '{}'. Known modes: {}.",
+                    mode,
+                    valid.join(", ")
+                ),
+                severity: WarningSeverity::Warning,
+            });
+        }
+    }
+
+    // Validate language code looks like BCP-47 / a short identifier.
+    if let Some(lang) = &settings.language {
+        if lang.trim().is_empty() {
+            warnings.push(ValidationWarning {
+                field: "language".to_string(),
+                message: "Language code is set but empty.".into(),
+                severity: WarningSeverity::Warning,
+            });
+        }
+    }
+
     warnings
 }
 
@@ -242,9 +290,7 @@ mod tests {
     fn test_validate_settings_bad_model() {
         let settings = SettingsJson {
             model: Some("totally invalid model".to_string()),
-            backend: None,
-            theme: None,
-            verbose: None,
+            ..Default::default()
         };
         let warnings = validate_settings(&settings);
         assert!(!warnings.is_empty());
@@ -256,9 +302,7 @@ mod tests {
     fn test_validate_settings_empty_model() {
         let settings = SettingsJson {
             model: Some("".to_string()),
-            backend: None,
-            theme: None,
-            verbose: None,
+            ..Default::default()
         };
         let warnings = validate_settings(&settings);
         assert!(!warnings.is_empty());
@@ -268,10 +312,8 @@ mod tests {
     #[test]
     fn test_validate_settings_unknown_theme() {
         let settings = SettingsJson {
-            model: None,
-            backend: None,
             theme: Some("cyberpunk".to_string()),
-            verbose: None,
+            ..Default::default()
         };
         let warnings = validate_settings(&settings);
         assert_eq!(warnings.len(), 1);
@@ -286,6 +328,7 @@ mod tests {
             backend: Some("codex".to_string()),
             theme: Some("dark".to_string()),
             verbose: Some(true),
+            ..Default::default()
         };
         let warnings = validate_settings(&settings);
         assert!(warnings.is_empty());
@@ -294,14 +337,33 @@ mod tests {
     #[test]
     fn test_validate_settings_bad_backend() {
         let settings = SettingsJson {
-            model: None,
             backend: Some("mystery".to_string()),
-            theme: None,
-            verbose: None,
+            ..Default::default()
         };
         let warnings = validate_settings(&settings);
         assert!(!warnings.is_empty());
         assert_eq!(warnings[0].field, "backend");
         assert_eq!(warnings[0].severity, WarningSeverity::Error);
+    }
+
+    #[test]
+    fn test_validate_settings_bad_permission_mode() {
+        let settings = SettingsJson {
+            permission_mode: Some("nope".into()),
+            ..Default::default()
+        };
+        let warnings = validate_settings(&settings);
+        assert!(warnings.iter().any(|w| w.field == "permissionMode"
+            && w.severity == WarningSeverity::Error));
+    }
+
+    #[test]
+    fn test_validate_settings_bad_editor_mode() {
+        let settings = SettingsJson {
+            editor_mode: Some("emacs".into()),
+            ..Default::default()
+        };
+        let warnings = validate_settings(&settings);
+        assert!(warnings.iter().any(|w| w.field == "editorMode"));
     }
 }

--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -288,11 +288,7 @@ mod tests {
         let _ = SESSION_ID.set("test-session".to_string());
         let path = event_log_path().expect("session_id should be set by now");
         let s = path.to_string_lossy().replace('\\', "/");
-        assert!(
-            s.contains("/runs/"),
-            "expected path under runs/, got {}",
-            s
-        );
+        assert!(s.contains("/runs/"), "expected path under runs/, got {}", s);
         assert!(
             s.ends_with("/subagent-events.ndjson"),
             "expected subagent-events.ndjson filename, got {}",

--- a/src/engine/lifecycle/deps.rs
+++ b/src/engine/lifecycle/deps.rs
@@ -579,7 +579,9 @@ impl QueryDeps for QueryEngineDeps {
                             match decision.to_lowercase().as_str() {
                                 "allow" => {
                                     // Emit permission.resolved(allow) audit event
-                                    use crate::observability::{AuditLevel, EventKind, Outcome, Stage};
+                                    use crate::observability::{
+                                        AuditLevel, EventKind, Outcome, Stage,
+                                    };
                                     perm_audit_ctx.emit(
                                         EventKind::PermissionResolved,
                                         Stage::Permission,
@@ -608,7 +610,9 @@ impl QueryDeps for QueryEngineDeps {
                                 _ => {
                                     // Emit permission.resolved(denied) audit event
                                     {
-                                        use crate::observability::{AuditLevel, EventKind, Outcome, Stage};
+                                        use crate::observability::{
+                                            AuditLevel, EventKind, Outcome, Stage,
+                                        };
                                         perm_audit_ctx.emit(
                                             EventKind::PermissionResolved,
                                             Stage::Permission,

--- a/src/ipc/callbacks.rs
+++ b/src/ipc/callbacks.rs
@@ -34,10 +34,7 @@ pub fn install_permission_callback(
     sink: FrontendSink,
 ) {
     let callback: crate::types::tool::PermissionCallback = Arc::new(
-        move |tool_use_id: String,
-              tool_name: String,
-              description: String,
-              options: Vec<String>| {
+        move |tool_use_id: String, tool_name: String, description: String, options: Vec<String>| {
             let pending = pending.clone();
             let sink = sink.clone();
             Box::pin(async move {

--- a/src/ipc/protocol/mod.rs
+++ b/src/ipc/protocol/mod.rs
@@ -159,9 +159,7 @@ pub enum BackendMessage {
         level: String,
     },
     /// Replace the full visible conversation history in the frontend.
-    ConversationReplaced {
-        messages: Vec<ConversationMessage>,
-    },
+    ConversationReplaced { messages: Vec<ConversationMessage> },
     /// Token usage update.
     UsageUpdate {
         input_tokens: u64,

--- a/src/ipc/sink.rs
+++ b/src/ipc/sink.rs
@@ -33,8 +33,8 @@ impl FrontendSink {
     pub fn send_many(&self, msgs: impl IntoIterator<Item = BackendMessage>) -> io::Result<()> {
         let mut stdout = io::stdout().lock();
         for msg in msgs {
-            let json = serde_json::to_string(&msg)
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            let json =
+                serde_json::to_string(&msg).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
             writeln!(stdout, "{}", json)?;
         }
         stdout.flush()

--- a/src/main.rs
+++ b/src/main.rs
@@ -437,14 +437,21 @@ async fn run_full_init(cli: Cli) -> anyhow::Result<ExitCode> {
         }
     }
 
-    // B.1: Load settings (parallel-ready)
-    let merged_config = settings::load_and_merge(&cwd)?;
+    // B.1: Load layered settings (managed/user/project/local + env).
+    let loaded_settings = settings::load_effective(std::path::Path::new(&cwd))?;
+    let merged_config = loaded_settings.effective.clone();
     debug!(
         model = ?merged_config.model,
         permission_mode = ?merged_config.permission_mode,
         backend = ?merged_config.backend,
+        layers = loaded_settings.loaded_paths.len(),
         "settings loaded",
     );
+    if !loaded_settings.loaded_paths.is_empty() {
+        for (src, path) in &loaded_settings.loaded_paths {
+            debug!(source = src.as_str(), path = %path.display(), "settings layer");
+        }
+    }
     let backend = crate::engine::codex_exec::normalize_backend(merged_config.backend.as_deref());
 
     // B.2: Determine permission mode
@@ -642,30 +649,54 @@ async fn run_full_init(cli: Cli) -> anyhow::Result<ExitCode> {
             }
         });
 
+    // Mark CLI overrides (model / verbose) in the source map so /config show
+    // reports them correctly.
+    let mut sources = loaded_settings.sources.clone();
+    if cli.model.is_some() {
+        sources.insert("model".into(), settings::SettingsSource::Cli);
+    }
+    if cli.verbose {
+        sources.insert("verbose".into(), settings::SettingsSource::Cli);
+    }
+    if cli.permission_mode.is_some() {
+        sources.insert("permissionMode".into(), settings::SettingsSource::Cli);
+    }
+
     let app_state = AppState {
         settings: SettingsJson {
             model: Some(model.clone()),
             backend: Some(backend.clone()),
             theme: merged_config.theme.clone(),
             verbose: Some(cli.verbose),
+            permission_mode: merged_config.permission_mode.clone(),
+            permissions: merged_config.permissions.clone(),
+            sandbox: merged_config.sandbox.clone(),
+            status_line: merged_config.status_line.clone(),
+            spinner_tips: merged_config.spinner_tips.clone(),
+            output_style: merged_config.output_style.clone(),
+            language: merged_config.language.clone(),
+            voice_enabled: merged_config.voice_enabled,
+            editor_mode: merged_config.editor_mode.clone(),
+            view_mode: merged_config.view_mode.clone(),
+            terminal_progress_bar_enabled: merged_config.terminal_progress_bar_enabled,
+            available_models: merged_config.available_models.clone(),
+            effort_level: merged_config.effort_level.clone(),
+            fast_mode: merged_config.fast_mode,
+            fast_mode_per_session_opt_in: merged_config.fast_mode_per_session_opt_in,
+            teammate_mode: merged_config.teammate_mode,
+            claude_in_chrome_default_enabled: merged_config.claude_in_chrome_default_enabled,
+            sources,
         },
         verbose: cli.verbose,
         main_loop_model: model.clone(),
         main_loop_backend: backend.clone(),
-        tool_permission_context: ToolPermissionContext {
-            mode: permission_mode.clone(),
-            additional_working_directories: HashMap::new(),
-            always_allow_rules: HashMap::new(),
-            always_deny_rules: HashMap::new(),
-            always_ask_rules: HashMap::new(),
-            session_allow_rules: HashMap::new(),
-            is_bypass_permissions_mode_available: true,
-            is_auto_mode_available: Some(true),
-            pre_plan_mode: None,
-        },
+        tool_permission_context: build_tool_permission_context(
+            permission_mode.clone(),
+            &loaded_settings,
+        ),
         thinking_enabled: None,
-        fast_mode: false,
-        effort_value: None,
+        fast_mode: merged_config.fast_mode.unwrap_or(false),
+        effort_value: merged_config.effort_level.clone(),
         team_context: None,
         hooks: merged_config.hooks.clone(),
         kairos_active: false,
@@ -1070,10 +1101,80 @@ fn chrome_requested(cli: &Cli, config_default: Option<bool>) -> bool {
 /// Resolve the permission mode from CLI arg or config.
 fn resolve_permission_mode(cli_mode: Option<&str>, config_mode: Option<&str>) -> PermissionMode {
     let mode_str = cli_mode.or(config_mode).unwrap_or("default");
-    match mode_str.to_lowercase().as_str() {
-        "auto" => PermissionMode::Auto,
-        "bypass" => PermissionMode::Bypass,
-        "plan" => PermissionMode::Plan,
-        _ => PermissionMode::Default,
+    PermissionMode::parse(mode_str)
+}
+
+/// Build the [`ToolPermissionContext`] from layered settings.
+///
+/// Pulls allow/ask/deny lists from `EffectiveSettings::permissions` and
+/// folds them into per-source rule maps tagged with the source of the
+/// settings layer that provided them. `enableBypassMode` /
+/// `enableAutoMode` from settings gate the corresponding modes at runtime.
+fn build_tool_permission_context(
+    mode: PermissionMode,
+    loaded: &settings::LoadedSettings,
+) -> ToolPermissionContext {
+    use settings::SettingsSource;
+
+    let merged = &loaded.effective;
+
+    let mut always_allow_rules: HashMap<String, Vec<String>> = HashMap::new();
+    let mut always_deny_rules: HashMap<String, Vec<String>> = HashMap::new();
+    let mut always_ask_rules: HashMap<String, Vec<String>> = HashMap::new();
+    let mut additional_working_directories = HashMap::new();
+
+    let push_rules = |map: &mut HashMap<String, Vec<String>>, source: SettingsSource, items: &[String]| {
+        if items.is_empty() {
+            return;
+        }
+        map.entry(source.as_str().to_string())
+            .or_default()
+            .extend(items.iter().cloned());
+    };
+
+    // Pull each layer's rules into the right bucket. We iterate from
+    // lowest -> highest priority so /permissions show prints them in a
+    // stable order; the matcher itself treats sources uniformly.
+    let layers: [(SettingsSource, Option<&crate::config::settings::RawSettings>); 4] = [
+        (SettingsSource::Managed, loaded.managed.as_ref()),
+        (SettingsSource::User, loaded.user.as_ref()),
+        (SettingsSource::Project, loaded.project.as_ref()),
+        (SettingsSource::Local, loaded.local.as_ref()),
+    ];
+
+    for (src, raw_opt) in layers {
+        let Some(raw) = raw_opt else { continue };
+        if let Some(perms) = raw.permissions.as_ref() {
+            push_rules(&mut always_allow_rules, src, &perms.allow);
+            push_rules(&mut always_deny_rules, src, &perms.deny);
+            push_rules(&mut always_ask_rules, src, &perms.ask);
+            for dir in &perms.additional_directories {
+                additional_working_directories.insert(
+                    dir.clone(),
+                    crate::types::tool::AdditionalWorkingDirectory {
+                        path: dir.clone(),
+                        read_only: false,
+                    },
+                );
+            }
+        }
+        if let Some(legacy) = raw.allowed_tools.as_ref() {
+            push_rules(&mut always_allow_rules, src, legacy);
+        }
+    }
+
+    ToolPermissionContext {
+        mode,
+        additional_working_directories,
+        always_allow_rules,
+        always_deny_rules,
+        always_ask_rules,
+        session_allow_rules: HashMap::new(),
+        is_bypass_permissions_mode_available: merged
+            .permissions
+            .enable_bypass_mode
+            .unwrap_or(true),
+        is_auto_mode_available: Some(merged.permissions.enable_auto_mode.unwrap_or(true)),
+        pre_plan_mode: None,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod config;
 mod engine;
 mod permissions;
 mod query;
+mod sandbox;
 mod session;
 mod tools;
 mod types;
@@ -199,6 +200,12 @@ struct Cli {
     /// browser tool surface via MCP.
     #[arg(long = "claude-in-chrome-mcp", hide = true)]
     claude_in_chrome_mcp: bool,
+
+    /// Disable all network access for the current session. Forwarded to
+    /// [`crate::sandbox::SandboxPolicy`] so shell subprocesses and WebFetch
+    /// are both blocked.
+    #[arg(long = "no-network")]
+    no_network: bool,
 
     /// Launch web UI mode (HTTP server with chat interface).
     #[arg(long)]
@@ -384,9 +391,8 @@ fn main() -> ExitCode {
             .and_then(|cfg| cfg.claude_in_chrome_default_enabled);
         let chrome_wanted = chrome_requested(&cli, chrome_config_default);
         if chrome_wanted {
-            browser_servers.insert(
-                crate::browser::common::CLAUDE_IN_CHROME_MCP_SERVER_NAME.to_string(),
-            );
+            browser_servers
+                .insert(crate::browser::common::CLAUDE_IN_CHROME_MCP_SERVER_NAME.to_string());
         }
         crate::browser::detection::install_browser_servers(browser_servers);
 
@@ -581,9 +587,8 @@ async fn run_full_init(cli: Cli) -> anyhow::Result<ExitCode> {
         // this early means the system prompt, permissions, and /mcp list all
         // already know the capability is expected.
         if chrome_wanted {
-            browser_servers.insert(
-                crate::browser::common::CLAUDE_IN_CHROME_MCP_SERVER_NAME.to_string(),
-            );
+            browser_servers
+                .insert(crate::browser::common::CLAUDE_IN_CHROME_MCP_SERVER_NAME.to_string());
         }
         if !browser_servers.is_empty() {
             info!(
@@ -661,6 +666,13 @@ async fn run_full_init(cli: Cli) -> anyhow::Result<ExitCode> {
     if cli.permission_mode.is_some() {
         sources.insert("permissionMode".into(), settings::SettingsSource::Cli);
     }
+    // --no-network is a CLI-level override that forces network.disabled=true
+    // on the sandbox section for the remainder of the session.
+    let mut effective_sandbox = merged_config.sandbox.clone();
+    if cli.no_network {
+        effective_sandbox.network.disabled = Some(true);
+        sources.insert("sandbox".into(), settings::SettingsSource::Cli);
+    }
 
     let app_state = AppState {
         settings: SettingsJson {
@@ -670,7 +682,7 @@ async fn run_full_init(cli: Cli) -> anyhow::Result<ExitCode> {
             verbose: Some(cli.verbose),
             permission_mode: merged_config.permission_mode.clone(),
             permissions: merged_config.permissions.clone(),
-            sandbox: merged_config.sandbox.clone(),
+            sandbox: effective_sandbox,
             status_line: merged_config.status_line.clone(),
             spinner_tips: merged_config.spinner_tips.clone(),
             output_style: merged_config.output_style.clone(),
@@ -827,17 +839,9 @@ async fn run_full_init(cli: Cli) -> anyhow::Result<ExitCode> {
 
         match AuditSink::init(engine.session_id.as_str(), &meta, audit_config) {
             Ok(sink) => {
-                let ctx = AuditContext::new(
-                    engine.session_id.as_str(),
-                    source_mode,
-                    sink,
-                );
+                let ctx = AuditContext::new(engine.session_id.as_str(), source_mode, sink);
                 // Emit session.start
-                ctx.emit_simple(
-                    EventKind::SessionStart,
-                    Stage::Session,
-                    Outcome::Started,
-                );
+                ctx.emit_simple(EventKind::SessionStart, Stage::Session, Outcome::Started);
                 engine.set_audit_context(ctx);
                 debug!("audit sink initialized for session {}", engine.session_id);
             }
@@ -1123,19 +1127,23 @@ fn build_tool_permission_context(
     let mut always_ask_rules: HashMap<String, Vec<String>> = HashMap::new();
     let mut additional_working_directories = HashMap::new();
 
-    let push_rules = |map: &mut HashMap<String, Vec<String>>, source: SettingsSource, items: &[String]| {
-        if items.is_empty() {
-            return;
-        }
-        map.entry(source.as_str().to_string())
-            .or_default()
-            .extend(items.iter().cloned());
-    };
+    let push_rules =
+        |map: &mut HashMap<String, Vec<String>>, source: SettingsSource, items: &[String]| {
+            if items.is_empty() {
+                return;
+            }
+            map.entry(source.as_str().to_string())
+                .or_default()
+                .extend(items.iter().cloned());
+        };
 
     // Pull each layer's rules into the right bucket. We iterate from
     // lowest -> highest priority so /permissions show prints them in a
     // stable order; the matcher itself treats sources uniformly.
-    let layers: [(SettingsSource, Option<&crate::config::settings::RawSettings>); 4] = [
+    let layers: [(
+        SettingsSource,
+        Option<&crate::config::settings::RawSettings>,
+    ); 4] = [
         (SettingsSource::Managed, loaded.managed.as_ref()),
         (SettingsSource::User, loaded.user.as_ref()),
         (SettingsSource::Project, loaded.project.as_ref()),
@@ -1170,10 +1178,7 @@ fn build_tool_permission_context(
         always_deny_rules,
         always_ask_rules,
         session_allow_rules: HashMap::new(),
-        is_bypass_permissions_mode_available: merged
-            .permissions
-            .enable_bypass_mode
-            .unwrap_or(true),
+        is_bypass_permissions_mode_available: merged.permissions.enable_bypass_mode.unwrap_or(true),
         is_auto_mode_available: Some(merged.permissions.enable_auto_mode.unwrap_or(true)),
         pre_plan_mode: None,
     }

--- a/src/observability/context.rs
+++ b/src/observability/context.rs
@@ -244,10 +244,7 @@ mod tests {
     fn child_turn_clears_downstream_ids() {
         let ctx = AuditContext::noop("sess_01");
         let submit_ctx = ctx.with_submit();
-        let turn_ctx = submit_ctx
-            .with_turn()
-            .with_request()
-            .with_tool_use("tu_01");
+        let turn_ctx = submit_ctx.with_turn().with_request().with_tool_use("tu_01");
 
         // New turn should clear request, message, tool_use
         let new_turn = turn_ctx.with_turn();

--- a/src/observability/sink.rs
+++ b/src/observability/sink.rs
@@ -130,8 +130,8 @@ impl AuditSink {
 
         // Write meta.json
         let meta_path = runs_dir.join("meta.json");
-        let meta_json = serde_json::to_string_pretty(meta)
-            .context("Failed to serialize session meta")?;
+        let meta_json =
+            serde_json::to_string_pretty(meta).context("Failed to serialize session meta")?;
         std::fs::write(&meta_path, meta_json)
             .with_context(|| format!("Failed to write {}", meta_path.display()))?;
 

--- a/src/permissions/bash_matcher.rs
+++ b/src/permissions/bash_matcher.rs
@@ -99,7 +99,10 @@ fn strip_wrappers(command: &str) -> StripResult {
         // Skip env var assignments: `FOO=bar BAZ=qux cargo build`
         if words[idx].contains('=') && !words[idx].starts_with('-') {
             let before = words[idx].split('=').next().unwrap_or("");
-            if before.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+            if before
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_')
+            {
                 idx += 1;
                 continue;
             }
@@ -149,7 +152,8 @@ fn strip_wrappers(command: &str) -> StripResult {
         if ARG_FORWARDERS.iter().any(|s| *s == head) {
             idx += 1;
             // `timeout` consumes a duration argument; `xargs` may take flags.
-            while idx < words.len() && (words[idx].starts_with('-') || is_duration_token(&words[idx]))
+            while idx < words.len()
+                && (words[idx].starts_with('-') || is_duration_token(&words[idx]))
             {
                 idx += 1;
             }
@@ -301,10 +305,7 @@ mod tests {
     #[test]
     fn pattern_glob_matches_token() {
         assert!(bash_pattern_matches("cargo *", "cargo test --release"));
-        assert!(bash_pattern_matches(
-            "*test*",
-            "FOO=1 cargo test --release"
-        ));
+        assert!(bash_pattern_matches("*test*", "FOO=1 cargo test --release"));
         assert!(!bash_pattern_matches("cargo *", "rm -rf /"));
     }
 

--- a/src/permissions/bash_matcher.rs
+++ b/src/permissions/bash_matcher.rs
@@ -1,0 +1,330 @@
+//! Bash-specific permission matcher.
+//!
+//! Permission rules like `Bash(git diff:*)`, `Bash(prefix:git)`,
+//! `Bash(cargo test*)` need to evaluate against the *meaningful* command
+//! tokens of a shell invocation, not just the first whitespace-separated
+//! word. That requires:
+//!
+//! 1. **Compound command tokenisation** — split on `&&`, `||`, `;`, `|`,
+//!    `&`, and newlines so a rule that allows `git status` doesn't
+//!    accidentally allow `git status && rm -rf /`.
+//! 2. **Wrapper stripping** — peel off `sudo`, `nohup`, `nice`, `time`,
+//!    `env A=B`, `xargs`, `bash -c`, `sh -c` so a rule on `cargo` matches
+//!    `sudo nohup cargo build` and a `bash -c "git status"` rule matches.
+//! 3. **Pattern matching** — exact / glob / `prefix:` semantics applied
+//!    to each surviving sub-command.
+//!
+//! Living in a dedicated module keeps the BashTool free of permission
+//! concerns and lets us unit-test the matcher in isolation.
+
+use crate::permissions::rules::glob_match_public;
+use crate::utils::bash::{extract_command_name, parse_command, split_compound_command};
+
+/// Wrapper executables whose first non-flag argument is the command we
+/// actually want to permission-check.
+const PROCESS_WRAPPERS: &[&str] = &[
+    "sudo", "doas", "nohup", "nice", "ionice", "time", "stdbuf", "command", "exec",
+];
+
+/// Wrappers that take `-c <script>` and run the script in a fresh shell.
+/// We extract the script and re-tokenise it.
+const SHELL_DASH_C: &[&str] = &["bash", "sh", "zsh", "ksh", "dash"];
+
+/// Wrappers that prefix a command line: their first non-flag argument is
+/// the command we want to inspect (e.g. `xargs cargo test`).
+const ARG_FORWARDERS: &[&str] = &["xargs", "watch", "timeout", "parallel"];
+
+/// Tokenise a shell command into the set of "interesting" sub-commands
+/// for permission purposes.
+///
+/// Always returns at least one entry (the original command, trimmed) so
+/// callers don't need a special empty-vec branch.
+pub fn extract_command_tokens(command: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut frontier: Vec<String> = split_compound_command(command);
+    if frontier.is_empty() {
+        frontier.push(command.trim().to_string());
+    }
+
+    while let Some(raw) = frontier.pop() {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        // Some wrappers (`bash -c "git status && pwd"`) wrap a whole new
+        // compound script. After stripping, we may need to re-tokenise.
+        match strip_wrappers(trimmed) {
+            StripResult::Inner(inner) => {
+                // Wrapped script — re-feed through the splitter, then loop.
+                let nested = split_compound_command(&inner);
+                if nested.is_empty() {
+                    out.push(inner);
+                } else {
+                    for n in nested {
+                        frontier.push(n);
+                    }
+                }
+            }
+            StripResult::Plain(cmd) => {
+                if !out.contains(&cmd) {
+                    out.push(cmd);
+                }
+            }
+        }
+    }
+
+    if out.is_empty() {
+        out.push(command.trim().to_string());
+    }
+    out
+}
+
+/// Result of stripping a wrapper from one sub-command.
+enum StripResult {
+    /// A plain command (wrapper layers removed).
+    Plain(String),
+    /// A wrapped script that needs to be re-tokenised by the caller.
+    Inner(String),
+}
+
+fn strip_wrappers(command: &str) -> StripResult {
+    let words = match parse_command(command) {
+        Ok(w) => w,
+        Err(_) => return StripResult::Plain(command.to_string()),
+    };
+    let mut idx = 0;
+    while idx < words.len() {
+        let head = basename(&words[idx]);
+        // Skip env var assignments: `FOO=bar BAZ=qux cargo build`
+        if words[idx].contains('=') && !words[idx].starts_with('-') {
+            let before = words[idx].split('=').next().unwrap_or("");
+            if before.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+                idx += 1;
+                continue;
+            }
+        }
+        // `env [opts] NAME=val ... CMD ...`
+        if head == "env" {
+            idx += 1;
+            while idx < words.len() {
+                let w = &words[idx];
+                if w.starts_with('-') || (w.contains('=') && !w.starts_with('-')) {
+                    idx += 1;
+                } else {
+                    break;
+                }
+            }
+            continue;
+        }
+        // `sh -c "<script>"` / `bash -c ...` — extract the script and ask
+        // the caller to re-tokenise.
+        if SHELL_DASH_C.iter().any(|s| *s == head) {
+            // Look for `-c <script>`
+            let mut j = idx + 1;
+            while j < words.len() {
+                if words[j] == "-c" && j + 1 < words.len() {
+                    return StripResult::Inner(words[j + 1].clone());
+                }
+                if words[j].starts_with('-') {
+                    j += 1;
+                    continue;
+                }
+                // First positional argument is the script (POSIX `sh script`).
+                return StripResult::Plain(words[j..].join(" "));
+            }
+            // sh with no script — treat as the bare shell.
+            return StripResult::Plain(words[idx..].join(" "));
+        }
+        // Generic process wrapper — drop and continue with the rest.
+        if PROCESS_WRAPPERS.iter().any(|s| *s == head) {
+            idx += 1;
+            // Skip wrapper-specific flags (anything starting with `-`).
+            while idx < words.len() && words[idx].starts_with('-') {
+                idx += 1;
+            }
+            continue;
+        }
+        // Argument forwarder: `xargs cmd ...` / `timeout 30 cmd ...`.
+        if ARG_FORWARDERS.iter().any(|s| *s == head) {
+            idx += 1;
+            // `timeout` consumes a duration argument; `xargs` may take flags.
+            while idx < words.len() && (words[idx].starts_with('-') || is_duration_token(&words[idx]))
+            {
+                idx += 1;
+            }
+            continue;
+        }
+        // Reached the actual command.
+        return StripResult::Plain(words[idx..].join(" "));
+    }
+    StripResult::Plain(command.to_string())
+}
+
+fn basename(arg: &str) -> &str {
+    let raw = std::path::Path::new(arg)
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or(arg);
+    raw
+}
+
+fn is_duration_token(s: &str) -> bool {
+    // Accept `30`, `30s`, `2m`, `1.5h` style.
+    let mut chars = s.chars();
+    let mut saw_digit = false;
+    while let Some(c) = chars.next() {
+        if c.is_ascii_digit() || c == '.' {
+            saw_digit = true;
+        } else if matches!(c, 's' | 'm' | 'h' | 'd') && chars.next().is_none() {
+            return saw_digit;
+        } else {
+            return false;
+        }
+    }
+    saw_digit
+}
+
+/// Apply a `Bash(...)` rule pattern to a full command string.
+///
+/// `pattern` is the inner text of `Bash(<pattern>)`:
+///   - `prefix:foo`    — matches if any token's first word equals or
+///                       begins with `foo`.
+///   - `<exact>`       — exact match against any token after wrapper
+///                       stripping.
+///   - `<glob with *>` — glob match against any token (or the joined
+///                       compound command).
+///   - empty / `*`     — matches everything (any Bash command).
+///
+/// Returns true iff the pattern matches the command.
+pub fn bash_pattern_matches(pattern: &str, command: &str) -> bool {
+    let pat = pattern.trim();
+    if pat.is_empty() || pat == "*" {
+        return true;
+    }
+
+    let tokens = extract_command_tokens(command);
+
+    if let Some(prefix) = pat.strip_prefix("prefix:") {
+        let prefix = prefix.trim();
+        return tokens.iter().any(|tok| {
+            let head = extract_command_name(tok).unwrap_or_default();
+            head == prefix || tok.starts_with(prefix)
+        });
+    }
+
+    if pat.contains('*') {
+        // Whole-command glob first, then per-token to keep `Bash(cargo *)`
+        // working against `cargo test`.
+        if glob_match_public(command, pat) {
+            return true;
+        }
+        return tokens.iter().any(|t| glob_match_public(t, pat));
+    }
+
+    // Exact match: against any sub-command, or its first word.
+    tokens.iter().any(|t| {
+        if t == pat {
+            return true;
+        }
+        let head = extract_command_name(t).unwrap_or_default();
+        head == pat
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tokenises_simple_command() {
+        let toks = extract_command_tokens("git status");
+        assert_eq!(toks, vec!["git status"]);
+    }
+
+    #[test]
+    fn tokenises_compound() {
+        let toks = extract_command_tokens("git status && rm -rf /");
+        assert!(toks.iter().any(|t| t.starts_with("git status")));
+        assert!(toks.iter().any(|t| t.starts_with("rm")));
+    }
+
+    #[test]
+    fn tokenises_pipe_and_semicolon() {
+        let toks = extract_command_tokens("ls | grep foo; cargo test");
+        assert!(toks.iter().any(|t| t.contains("ls")));
+        assert!(toks.iter().any(|t| t.starts_with("cargo")));
+    }
+
+    #[test]
+    fn strips_sudo_wrapper() {
+        let toks = extract_command_tokens("sudo cargo build");
+        assert!(toks.contains(&"cargo build".to_string()));
+    }
+
+    #[test]
+    fn strips_env_assignments() {
+        let toks = extract_command_tokens("FOO=bar BAZ=qux cargo test --release");
+        assert!(
+            toks.iter().any(|t| t.starts_with("cargo test")),
+            "tokens were {:?}",
+            toks
+        );
+    }
+
+    #[test]
+    fn strips_bash_dash_c_and_re_tokenises() {
+        let toks = extract_command_tokens(r#"bash -c "git status && pwd""#);
+        assert!(toks.iter().any(|t| t.starts_with("git status")));
+        assert!(toks.iter().any(|t| t == "pwd"));
+    }
+
+    #[test]
+    fn strips_xargs_and_timeout() {
+        let toks = extract_command_tokens("timeout 30 cargo test");
+        assert!(toks.contains(&"cargo test".to_string()));
+        let toks = extract_command_tokens("xargs -n1 cargo build");
+        assert!(toks.contains(&"cargo build".to_string()));
+    }
+
+    #[test]
+    fn pattern_prefix_matches_after_strip() {
+        assert!(bash_pattern_matches("prefix:cargo", "sudo cargo build"));
+        assert!(bash_pattern_matches("prefix:git", "git status && rm -rf /"));
+        assert!(!bash_pattern_matches("prefix:git", "cargo test"));
+    }
+
+    #[test]
+    fn pattern_glob_matches_token() {
+        assert!(bash_pattern_matches("cargo *", "cargo test --release"));
+        assert!(bash_pattern_matches(
+            "*test*",
+            "FOO=1 cargo test --release"
+        ));
+        assert!(!bash_pattern_matches("cargo *", "rm -rf /"));
+    }
+
+    #[test]
+    fn pattern_exact_matches_any_subcommand() {
+        assert!(bash_pattern_matches("git", "git status && pwd"));
+        assert!(bash_pattern_matches("pwd", "git status && pwd"));
+        assert!(!bash_pattern_matches("ls", "git status && pwd"));
+    }
+
+    #[test]
+    fn pattern_wildcard_matches_anything() {
+        assert!(bash_pattern_matches("*", "rm -rf /"));
+        assert!(bash_pattern_matches("", "rm -rf /"));
+    }
+
+    #[test]
+    fn deny_via_compound_token() {
+        // The point of compound tokenisation: a deny rule on `rm` MUST
+        // catch the second arm of an `&&`.
+        assert!(bash_pattern_matches("rm", "git status && rm -rf /tmp/x"));
+    }
+}

--- a/src/permissions/decision.rs
+++ b/src/permissions/decision.rs
@@ -94,10 +94,7 @@ impl HookPermissionDecision {
     /// public surface of `HookPermissionDecision`.
     #[allow(dead_code)]
     pub fn is_noop(&self) -> bool {
-        !self.allow
-            && self.deny.is_none()
-            && self.ask.is_none()
-            && self.updated_input.is_none()
+        !self.allow && self.deny.is_none() && self.ask.is_none() && self.updated_input.is_none()
     }
 }
 
@@ -305,8 +302,12 @@ pub fn has_permissions_to_use_tool_with_hook(
     if let Some((source, pattern)) =
         check_pattern_rules(tool_name, effective_input, &ctx.always_ask_rules)
     {
-        let message = descriptive_permission_message(tool_name)
-            .unwrap_or_else(|| format!("Ask rule '{}' (source={}) requires confirmation.", pattern, source));
+        let message = descriptive_permission_message(tool_name).unwrap_or_else(|| {
+            format!(
+                "Ask rule '{}' (source={}) requires confirmation.",
+                pattern, source
+            )
+        });
         return PermissionDecision {
             behavior: PermissionBehavior::Ask,
             updated_input: updated_input.clone(),
@@ -650,13 +651,8 @@ mod tests {
             source: Some("PreToolUse:audit".into()),
             ..Default::default()
         };
-        let decision = has_permissions_to_use_tool_with_hook(
-            "Bash",
-            &Value::Null,
-            &ctx,
-            Some(&hook),
-            None,
-        );
+        let decision =
+            has_permissions_to_use_tool_with_hook("Bash", &Value::Null, &ctx, Some(&hook), None);
         assert_eq!(decision.behavior, PermissionBehavior::Deny);
         assert!(decision.message.unwrap().contains("PolicyViolation"));
     }
@@ -670,13 +666,8 @@ mod tests {
             allow: true,
             ..Default::default()
         };
-        let decision = has_permissions_to_use_tool_with_hook(
-            "Bash",
-            &Value::Null,
-            &ctx,
-            Some(&hook),
-            None,
-        );
+        let decision =
+            has_permissions_to_use_tool_with_hook("Bash", &Value::Null, &ctx, Some(&hook), None);
         // Per spec: deny rule wins over hook allow.
         assert_eq!(decision.behavior, PermissionBehavior::Deny);
     }
@@ -690,13 +681,8 @@ mod tests {
             allow: true,
             ..Default::default()
         };
-        let decision = has_permissions_to_use_tool_with_hook(
-            "Bash",
-            &Value::Null,
-            &ctx,
-            Some(&hook),
-            None,
-        );
+        let decision =
+            has_permissions_to_use_tool_with_hook("Bash", &Value::Null, &ctx, Some(&hook), None);
         // Per spec: ask rule wins over hook allow.
         assert_eq!(decision.behavior, PermissionBehavior::Ask);
     }
@@ -709,13 +695,8 @@ mod tests {
             source: Some("PreToolUse:trustedAgent".into()),
             ..Default::default()
         };
-        let decision = has_permissions_to_use_tool_with_hook(
-            "Bash",
-            &Value::Null,
-            &ctx,
-            Some(&hook),
-            None,
-        );
+        let decision =
+            has_permissions_to_use_tool_with_hook("Bash", &Value::Null, &ctx, Some(&hook), None);
         assert_eq!(decision.behavior, PermissionBehavior::Allow);
     }
 
@@ -729,13 +710,8 @@ mod tests {
             ..Default::default()
         };
         let original = serde_json::json!({"command": "rm -rf /"});
-        let decision = has_permissions_to_use_tool_with_hook(
-            "Bash",
-            &original,
-            &ctx,
-            Some(&hook),
-            None,
-        );
+        let decision =
+            has_permissions_to_use_tool_with_hook("Bash", &original, &ctx, Some(&hook), None);
         assert_eq!(decision.behavior, PermissionBehavior::Allow);
         assert_eq!(decision.updated_input.as_ref(), Some(&modified));
     }
@@ -785,12 +761,8 @@ mod tests {
             "session".into(),
             vec!["mcp__computer-use__screenshot".into()],
         );
-        let decision = has_permissions_to_use_tool(
-            "mcp__computer-use__screenshot",
-            &Value::Null,
-            &ctx,
-            None,
-        );
+        let decision =
+            has_permissions_to_use_tool("mcp__computer-use__screenshot", &Value::Null, &ctx, None);
         assert_eq!(decision.behavior, PermissionBehavior::Allow);
         if let PermissionDecisionReason::Rule { source, .. } = &decision.reason {
             assert_eq!(source, "session");
@@ -810,12 +782,8 @@ mod tests {
             "session".into(),
             vec!["mcp__computer-use__left_click".into()],
         );
-        let decision = has_permissions_to_use_tool(
-            "mcp__computer-use__left_click",
-            &Value::Null,
-            &ctx,
-            None,
-        );
+        let decision =
+            has_permissions_to_use_tool("mcp__computer-use__left_click", &Value::Null, &ctx, None);
         assert_eq!(decision.behavior, PermissionBehavior::Deny);
     }
 
@@ -841,12 +809,8 @@ mod tests {
     #[test]
     fn test_cu_screenshot_permission_message() {
         let ctx = default_ctx();
-        let decision = has_permissions_to_use_tool(
-            "mcp__computer-use__screenshot",
-            &Value::Null,
-            &ctx,
-            None,
-        );
+        let decision =
+            has_permissions_to_use_tool("mcp__computer-use__screenshot", &Value::Null, &ctx, None);
         assert_eq!(decision.behavior, PermissionBehavior::Ask);
         let msg = decision.message.unwrap();
         assert!(msg.contains("screenshot"));

--- a/src/permissions/decision.rs
+++ b/src/permissions/decision.rs
@@ -2,40 +2,30 @@
 //!
 //! Corresponds to: LIFECYCLE_STATE_MACHINE.md §7 (Phase F)
 //!
-//! Decision flow:
-//!   Phase 1a: Unconditional rules (tool name only)
-//!     - toolAlwaysAllowedRule → allow
-//!     - getDenyRuleForTool → deny
-//!     - getAskRuleForTool → ask
+//! Decision flow (deny > ask > allow per spec):
+//!   Phase 1a: Hook deny — pre-tool hooks may force deny.
+//!   Phase 1b: Unconditional rules + pattern rules at sources Managed/User/Project/Local.
+//!             Deny rules win first; ask rules force a prompt; allow rules
+//!             pre-approve.
+//!   Phase 2:  Hook ask / hook allow — applied AFTER deny/ask rules but
+//!             BEFORE the mode fallback so a hook can pre-approve a tool
+//!             that would otherwise prompt.
+//!   Phase 3:  Session-level grants (transient).
+//!   Phase 4:  Mode fallback — Default/Plan ask, Auto/Bypass allow,
+//!             AcceptEdits allows file-edit tools, DontAsk silently denies.
 //!
-//!   Phase 1b: Pattern matching rules (tool name + parameters)
-//!     - preparePermissionMatcher(input) → Matcher
-//!     - Check allow/deny/ask rules with matcher
-//!
-//!   Phase 2: Hook interception
-//!     - executePermissionRequestHooks()
-//!     - Can return: allow / deny / modified permission context
-//!
-//!   Phase 3: Mode check
-//!     - BypassPermissions → allow
-//!     - DontAsk → deny (silent)
-//!     - Default/Plan → interactive prompt
-//!     - Auto → classifier (stub)
-//!
-//! Rule sources (priority descending):
-//!   1. policySettings (enterprise)
-//!   2. projectSettings (.cc-rust/settings.json)
-//!   3. userSettings (~/.cc-rust/settings.json)
-//!   4. localSettings (repo-specific)
-//!   5. cliArg (command-line)
-//!   6. session (session-level grants)
-
-#![allow(unused)]
+//! Rule sources (priority descending — used by `/permissions show` only;
+//! the rule engine treats them uniformly):
+//!   1. Managed (enterprise / policy)
+//!   2. Project (.cc-rust/settings.json)
+//!   3. Local   (.cc-rust/settings.local.json)
+//!   4. User    (~/.cc-rust/settings.json)
+//!   5. CLI     (--permission-mode et al.)
+//!   6. Session (transient grants)
 
 use serde_json::Value;
-use tracing::{debug, warn};
 
-use super::rules::{self, PermissionCheckResult};
+use super::rules;
 use crate::types::tool::{PermissionMode, ToolPermissionContext, ToolPermissionRulesBySource};
 
 // ---------------------------------------------------------------------------
@@ -65,15 +55,50 @@ pub enum PermissionBehavior {
 
 /// How a permission decision was reached (for audit/debugging).
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub enum PermissionDecisionReason {
     /// Matched a rule from a specific source.
     Rule { source: String, pattern: String },
     /// A hook made the decision.
-    Hook { hook_name: String },
+    Hook { detail: String },
     /// The permission mode determined the outcome.
     Mode { mode: String },
     /// Pattern matching on tool input.
     PatternMatch { tool: String, pattern: String },
+}
+
+/// Result a hook contributed to the central decision flow.
+///
+/// Built from [`crate::tools::hooks::PreToolHookResult`] in `pipeline.rs`
+/// and threaded through [`has_permissions_to_use_tool`] so a hook can
+/// allow / deny / ask / modify input *without* skipping the rule engine.
+#[derive(Debug, Clone, Default)]
+pub struct HookPermissionDecision {
+    /// Hook said "force allow this tool".
+    pub allow: bool,
+    /// Hook said "deny" (string is the reason).
+    pub deny: Option<String>,
+    /// Hook said "ask the user" (string is the prompt message).
+    pub ask: Option<String>,
+    /// Hook supplied a modified input value to use.
+    pub updated_input: Option<Value>,
+    /// Identifier for the contributing hook (`PreToolUse:<matcher>` etc).
+    pub source: Option<String>,
+}
+
+impl HookPermissionDecision {
+    /// True if the hook contributed nothing actionable.
+    ///
+    /// Used by callers (and tests) that want to short-circuit when a
+    /// hook plug returns an empty result; intentionally part of the
+    /// public surface of `HookPermissionDecision`.
+    #[allow(dead_code)]
+    pub fn is_noop(&self) -> bool {
+        !self.allow
+            && self.deny.is_none()
+            && self.ask.is_none()
+            && self.updated_input.is_none()
+    }
 }
 
 /// Denial tracking state for Auto mode.
@@ -87,6 +112,11 @@ pub struct DenialTracker {
 
 impl DenialTracker {
     /// Record a denial. Returns true if fallback to interactive should happen.
+    ///
+    /// Public for downstream callers (auto-mode classifier shim) and
+    /// covered by tests; cargo's non-test build can't see test usage so
+    /// silence the warning.
+    #[allow(dead_code)]
     pub fn record_denial(&mut self) -> bool {
         self.consecutive_denials += 1;
         self.total_denials += 1;
@@ -112,9 +142,6 @@ impl DenialTracker {
 // ---------------------------------------------------------------------------
 
 /// Generate a human-readable permission message for Computer Use tools.
-///
-/// Instead of the generic "Allow tool 'mcp__computer-use__screenshot'?",
-/// this produces clear descriptions like "Allow reading the screen (screenshot)?".
 fn cu_permission_message(tool_name: &str) -> Option<String> {
     use crate::computer_use::detection::{classify_risk, extract_cu_action, CuRiskLevel};
 
@@ -147,23 +174,15 @@ fn cu_permission_message(tool_name: &str) -> Option<String> {
     Some(format!("Allow {} {}?", description, risk_tag))
 }
 
-/// Resolve the best permission-prompt message for a tool, preferring the
-/// most specific source:
-///   1. Computer Use (exact `mcp__computer-use__*` prefix)
-///   2. Browser MCP (heuristic by action basename OR server flagged browserMcp)
-///   3. None — caller uses the generic "Allow tool 'X'?" fallback.
 fn descriptive_permission_message(tool_name: &str) -> Option<String> {
     if let Some(m) = cu_permission_message(tool_name) {
         return Some(m);
     }
 
-    // Browser heuristic on action basename
     if let Some(m) = crate::browser::permissions::browser_permission_message(tool_name) {
         return Some(m);
     }
 
-    // Config-flagged server: even if the action basename isn't in the known
-    // browser list, give it a browser-styled prompt with an "other" category.
     if let Some(rest) = tool_name.strip_prefix("mcp__") {
         if let Some((server, action)) = rest.split_once("__") {
             if crate::browser::detection::is_browser_server(server) {
@@ -185,19 +204,15 @@ fn descriptive_permission_message(tool_name: &str) -> Option<String> {
 // Permission matcher (Phase 1b: pattern matching)
 // ---------------------------------------------------------------------------
 
-/// Prepare a permission matcher for a tool invocation.
-///
-/// Corresponds to TypeScript: `preparePermissionMatcher(input)`
-///
-/// For Bash: matches the command prefix.
-/// For file tools: matches the file path.
-/// For other tools: no pattern matching.
+/// Prepare a permission matcher for a tool invocation. Used only by the
+/// session-grant pass below — full pattern matching for Bash / Read / etc.
+/// is delegated to [`super::rules::rule_matches`].
 fn prepare_matcher(tool_name: &str, input: &Value) -> Option<String> {
     match tool_name {
-        "Bash" => input.get("command").and_then(|v| v.as_str()).map(|cmd| {
-            // Extract the first word (command prefix) for matching
-            cmd.split_whitespace().next().unwrap_or("").to_string()
-        }),
+        "Bash" => input
+            .get("command")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
         "Read" | "Write" | "Edit" => input
             .get("file_path")
             .and_then(|v| v.as_str())
@@ -210,45 +225,15 @@ fn prepare_matcher(tool_name: &str, input: &Value) -> Option<String> {
     }
 }
 
-/// Check if a pattern rule matches a matcher value.
-///
-/// Pattern rules in TypeScript can be:
-/// - `Bash(prefix:git)` → matches commands starting with "git"
-/// - `Read(/tmp/*)` → matches file paths under /tmp/
-/// - Plain tool name → matches unconditionally
-fn pattern_rule_matches(rule: &str, tool_name: &str, matcher: Option<&str>) -> bool {
-    // Check for pattern syntax: ToolName(pattern)
-    if let Some(inner_start) = rule.find('(') {
-        if let Some(inner_end) = rule.rfind(')') {
-            let rule_tool = &rule[..inner_start];
-            if rule_tool != tool_name {
-                return false;
-            }
-            let pattern = &rule[inner_start + 1..inner_end];
-
-            // prefix: matching
-            if let Some(prefix_val) = pattern.strip_prefix("prefix:") {
-                return matcher.map_or(false, |m| m.starts_with(prefix_val));
-            }
-
-            // Glob-style matching
-            return matcher.map_or(false, |m| rules::glob_match_public(m, pattern));
-        }
-    }
-
-    // Plain tool name match
-    rule == tool_name
-}
-
 /// Check pattern rules against all sources.
 fn check_pattern_rules(
     tool_name: &str,
-    matcher: Option<&str>,
+    input: &Value,
     rules_by_source: &ToolPermissionRulesBySource,
 ) -> Option<(String, String)> {
     for (source, patterns) in rules_by_source.iter() {
         for pattern in patterns {
-            if pattern_rule_matches(pattern, tool_name, matcher) {
+            if rules::rule_matches(tool_name, input, pattern) {
                 return Some((source.clone(), pattern.clone()));
             }
         }
@@ -269,89 +254,125 @@ pub fn has_permissions_to_use_tool(
     ctx: &ToolPermissionContext,
     denial_tracker: Option<&mut DenialTracker>,
 ) -> PermissionDecision {
-    // ── Phase 1a: Unconditional rules (tool name only) ──────────────
-    let simple_check = rules::check_tool_permission(tool_name, input, ctx);
-    match simple_check {
-        PermissionCheckResult::Allow => {
+    has_permissions_to_use_tool_with_hook(tool_name, input, ctx, None, denial_tracker)
+}
+
+/// Like [`has_permissions_to_use_tool`] but folds in a hook-supplied
+/// decision per the precedence documented at the top of this module.
+pub fn has_permissions_to_use_tool_with_hook(
+    tool_name: &str,
+    input: &Value,
+    ctx: &ToolPermissionContext,
+    hook: Option<&HookPermissionDecision>,
+    denial_tracker: Option<&mut DenialTracker>,
+) -> PermissionDecision {
+    let updated_input = hook.and_then(|h| h.updated_input.clone());
+
+    // ── Phase 1a: Hook deny — short-circuit even before deny rules.
+    // (Hook deny is treated as policy: it cannot be overridden.)
+    if let Some(h) = hook {
+        if let Some(reason) = &h.deny {
+            return PermissionDecision {
+                behavior: PermissionBehavior::Deny,
+                updated_input,
+                message: Some(reason.clone()),
+                reason: PermissionDecisionReason::Hook {
+                    detail: h.source.clone().unwrap_or_else(|| "PreToolUse".into()),
+                },
+            };
+        }
+    }
+
+    // Pick the input the rest of the flow sees.
+    let effective_input: &Value = updated_input.as_ref().unwrap_or(input);
+
+    // ── Phase 1b: Deny rules.
+    if let Some((source, pattern)) =
+        check_pattern_rules(tool_name, effective_input, &ctx.always_deny_rules)
+    {
+        return PermissionDecision {
+            behavior: PermissionBehavior::Deny,
+            updated_input: updated_input.clone(),
+            message: Some(format!("Denied by rule: {} (source={})", pattern, source)),
+            reason: PermissionDecisionReason::PatternMatch {
+                tool: tool_name.into(),
+                pattern,
+            },
+        };
+    }
+
+    // ── Phase 1c: Ask rules — force a prompt regardless of allow rules.
+    if let Some((source, pattern)) =
+        check_pattern_rules(tool_name, effective_input, &ctx.always_ask_rules)
+    {
+        let message = descriptive_permission_message(tool_name)
+            .unwrap_or_else(|| format!("Ask rule '{}' (source={}) requires confirmation.", pattern, source));
+        return PermissionDecision {
+            behavior: PermissionBehavior::Ask,
+            updated_input: updated_input.clone(),
+            message: Some(message),
+            reason: PermissionDecisionReason::PatternMatch {
+                tool: tool_name.into(),
+                pattern,
+            },
+        };
+    }
+
+    // ── Phase 1d: Allow rules.
+    if let Some((source, pattern)) =
+        check_pattern_rules(tool_name, effective_input, &ctx.always_allow_rules)
+    {
+        if let Some(tracker) = denial_tracker {
+            tracker.record_allow();
+        }
+        return PermissionDecision {
+            behavior: PermissionBehavior::Allow,
+            updated_input: updated_input.clone(),
+            message: None,
+            reason: PermissionDecisionReason::Rule { source, pattern },
+        };
+    }
+
+    // ── Phase 2: Hook ask / hook allow.
+    if let Some(h) = hook {
+        if let Some(prompt) = &h.ask {
+            return PermissionDecision {
+                behavior: PermissionBehavior::Ask,
+                updated_input: updated_input.clone(),
+                message: Some(prompt.clone()),
+                reason: PermissionDecisionReason::Hook {
+                    detail: h.source.clone().unwrap_or_else(|| "PreToolUse".into()),
+                },
+            };
+        }
+        if h.allow {
             if let Some(tracker) = denial_tracker {
                 tracker.record_allow();
             }
             return PermissionDecision {
                 behavior: PermissionBehavior::Allow,
-                updated_input: None,
+                updated_input: updated_input.clone(),
                 message: None,
-                reason: PermissionDecisionReason::Rule {
-                    source: "unconditional".into(),
-                    pattern: tool_name.into(),
+                reason: PermissionDecisionReason::Hook {
+                    detail: h.source.clone().unwrap_or_else(|| "PreToolUse".into()),
                 },
             };
-        }
-        PermissionCheckResult::Deny { reason } => {
-            return PermissionDecision {
-                behavior: PermissionBehavior::Deny,
-                updated_input: None,
-                message: Some(reason.clone()),
-                reason: PermissionDecisionReason::Rule {
-                    source: "unconditional".into(),
-                    pattern: reason,
-                },
-            };
-        }
-        PermissionCheckResult::Ask { .. } => {
-            // Fall through to pattern matching
         }
     }
 
-    // ── Phase 1b: Pattern matching rules ────────────────────────────
-    let matcher = prepare_matcher(tool_name, input);
-    let matcher_ref = matcher.as_deref();
-
-    // Check allow patterns
-    if let Some((source, pattern)) =
-        check_pattern_rules(tool_name, matcher_ref, &ctx.always_allow_rules)
-    {
+    // ── Phase 3: Session-level grants ───────────────────────────────────
+    let matcher_for_session = prepare_matcher(tool_name, effective_input);
+    if let Some((_source, pattern)) = check_pattern_rules_via_matcher(
+        tool_name,
+        matcher_for_session.as_deref(),
+        &ctx.session_allow_rules,
+    ) {
         if let Some(tracker) = denial_tracker {
             tracker.record_allow();
         }
         return PermissionDecision {
             behavior: PermissionBehavior::Allow,
-            updated_input: None,
-            message: None,
-            reason: PermissionDecisionReason::PatternMatch {
-                tool: tool_name.into(),
-                pattern,
-            },
-        };
-    }
-
-    // Check deny patterns
-    if let Some((source, pattern)) =
-        check_pattern_rules(tool_name, matcher_ref, &ctx.always_deny_rules)
-    {
-        return PermissionDecision {
-            behavior: PermissionBehavior::Deny,
-            updated_input: None,
-            message: Some(format!("Denied by pattern: {}", pattern)),
-            reason: PermissionDecisionReason::PatternMatch {
-                tool: tool_name.into(),
-                pattern,
-            },
-        };
-    }
-
-    // ── Phase 1c: Session-level grants ───────────────────────────────
-    // Session grants are checked after persistent rules but before mode
-    // fallback. They are transient (cleared when the session ends) and
-    // are the preferred destination for Computer Use "always allow".
-    if let Some((_source, pattern)) =
-        check_pattern_rules(tool_name, matcher_ref, &ctx.session_allow_rules)
-    {
-        if let Some(tracker) = denial_tracker {
-            tracker.record_allow();
-        }
-        return PermissionDecision {
-            behavior: PermissionBehavior::Allow,
-            updated_input: None,
+            updated_input: updated_input.clone(),
             message: None,
             reason: PermissionDecisionReason::Rule {
                 source: "session".into(),
@@ -360,10 +381,7 @@ pub fn has_permissions_to_use_tool(
         };
     }
 
-    // ── Phase 2: Hook interception ──────────────────────────────────
-    // Phase 1 stub: no hooks, fall through to mode check
-
-    // ── Phase 3: Mode check ─────────────────────────────────────────
+    // ── Phase 4: Mode fallback ──────────────────────────────────────────
     match ctx.mode {
         PermissionMode::Bypass => {
             if let Some(tracker) = denial_tracker {
@@ -371,7 +389,7 @@ pub fn has_permissions_to_use_tool(
             }
             PermissionDecision {
                 behavior: PermissionBehavior::Allow,
-                updated_input: None,
+                updated_input,
                 message: None,
                 reason: PermissionDecisionReason::Mode {
                     mode: "bypass".into(),
@@ -379,13 +397,11 @@ pub fn has_permissions_to_use_tool(
             }
         }
         PermissionMode::Auto => {
-            // Auto mode: allow by default, but check denial tracker
             if let Some(tracker) = denial_tracker {
                 if tracker.should_fallback_to_interactive() {
-                    // Fallback to interactive prompting
                     return PermissionDecision {
                         behavior: PermissionBehavior::Ask,
-                        updated_input: None,
+                        updated_input,
                         message: Some(format!(
                             "Auto mode fallback: {} consecutive denials",
                             tracker.consecutive_denials
@@ -399,7 +415,7 @@ pub fn has_permissions_to_use_tool(
             }
             PermissionDecision {
                 behavior: PermissionBehavior::Allow,
-                updated_input: None,
+                updated_input,
                 message: None,
                 reason: PermissionDecisionReason::Mode {
                     mode: "auto".into(),
@@ -407,13 +423,12 @@ pub fn has_permissions_to_use_tool(
             }
         }
         PermissionMode::Plan => {
-            // Plan mode: ask for confirmation
             let message = descriptive_permission_message(tool_name).unwrap_or_else(|| {
                 format!("Tool '{}' requires confirmation in plan mode.", tool_name)
             });
             PermissionDecision {
                 behavior: PermissionBehavior::Ask,
-                updated_input: None,
+                updated_input,
                 message: Some(message),
                 reason: PermissionDecisionReason::Mode {
                     mode: "plan".into(),
@@ -421,19 +436,89 @@ pub fn has_permissions_to_use_tool(
             }
         }
         PermissionMode::Default => {
-            // Default mode: ask for confirmation (CU/browser tools get descriptive messages)
             let message = descriptive_permission_message(tool_name)
                 .unwrap_or_else(|| format!("Allow tool '{}'?", tool_name));
             PermissionDecision {
                 behavior: PermissionBehavior::Ask,
-                updated_input: None,
+                updated_input,
                 message: Some(message),
                 reason: PermissionDecisionReason::Mode {
                     mode: "default".into(),
                 },
             }
         }
+        PermissionMode::AcceptEdits => {
+            if rules::is_edit_tool(tool_name) {
+                if let Some(tracker) = denial_tracker {
+                    tracker.record_allow();
+                }
+                PermissionDecision {
+                    behavior: PermissionBehavior::Allow,
+                    updated_input,
+                    message: None,
+                    reason: PermissionDecisionReason::Mode {
+                        mode: "acceptEdits".into(),
+                    },
+                }
+            } else {
+                let message = descriptive_permission_message(tool_name)
+                    .unwrap_or_else(|| format!("Allow tool '{}'?", tool_name));
+                PermissionDecision {
+                    behavior: PermissionBehavior::Ask,
+                    updated_input,
+                    message: Some(message),
+                    reason: PermissionDecisionReason::Mode {
+                        mode: "acceptEdits".into(),
+                    },
+                }
+            }
+        }
+        PermissionMode::DontAsk => PermissionDecision {
+            behavior: PermissionBehavior::Deny,
+            updated_input,
+            message: Some(format!(
+                "Permission mode 'dontAsk': '{}' silently denied (add an allow rule to permit).",
+                tool_name
+            )),
+            reason: PermissionDecisionReason::Mode {
+                mode: "dontAsk".into(),
+            },
+        },
     }
+}
+
+/// Match session-grant patterns using a lightweight matcher (no
+/// per-tool argument parsing — sessions store tool names verbatim).
+fn check_pattern_rules_via_matcher(
+    tool_name: &str,
+    matcher: Option<&str>,
+    rules_by_source: &ToolPermissionRulesBySource,
+) -> Option<(String, String)> {
+    for (source, patterns) in rules_by_source.iter() {
+        for pattern in patterns {
+            if pattern_rule_matches_simple(pattern, tool_name, matcher) {
+                return Some((source.clone(), pattern.clone()));
+            }
+        }
+    }
+    None
+}
+
+fn pattern_rule_matches_simple(rule: &str, tool_name: &str, matcher: Option<&str>) -> bool {
+    if let Some(inner_start) = rule.find('(') {
+        if let Some(inner_end) = rule.rfind(')') {
+            let rule_tool = &rule[..inner_start];
+            if rule_tool != tool_name {
+                return false;
+            }
+            let pattern = &rule[inner_start + 1..inner_end];
+            if let Some(prefix_val) = pattern.strip_prefix("prefix:") {
+                return matcher.is_some_and(|m| m.starts_with(prefix_val));
+            }
+            return matcher.is_some_and(|m| rules::glob_match_public(m, pattern));
+        }
+    }
+    rule == tool_name
 }
 
 // ---------------------------------------------------------------------------
@@ -509,20 +594,166 @@ mod tests {
             .insert("user".into(), vec!["Bash(prefix:git)".into()]);
         let input = serde_json::json!({"command": "rm -rf /"});
         let decision = has_permissions_to_use_tool("Bash", &input, &ctx, None);
-        // Should fall through to mode check (default → ask)
         assert_eq!(decision.behavior, PermissionBehavior::Ask);
     }
 
     #[test]
+    fn test_compound_command_caught_by_deny() {
+        let mut ctx = default_ctx();
+        ctx.always_deny_rules
+            .insert("policy".into(), vec!["Bash(rm)".into()]);
+        ctx.always_allow_rules
+            .insert("user".into(), vec!["Bash(prefix:git)".into()]);
+        let input = serde_json::json!({"command": "git status && rm -rf /tmp/x"});
+        let decision = has_permissions_to_use_tool("Bash", &input, &ctx, None);
+        assert_eq!(decision.behavior, PermissionBehavior::Deny);
+    }
+
+    #[test]
+    fn test_ask_overrides_allow_in_decision() {
+        let mut ctx = default_ctx();
+        ctx.always_allow_rules
+            .insert("user".into(), vec!["Read".into()]);
+        ctx.always_ask_rules
+            .insert("project".into(), vec!["Read".into()]);
+        let decision = has_permissions_to_use_tool("Read", &Value::Null, &ctx, None);
+        assert_eq!(decision.behavior, PermissionBehavior::Ask);
+    }
+
+    #[test]
+    fn test_accept_edits_mode_allows_edit_tools() {
+        let mut ctx = default_ctx();
+        ctx.mode = PermissionMode::AcceptEdits;
+        let decision = has_permissions_to_use_tool("Edit", &Value::Null, &ctx, None);
+        assert_eq!(decision.behavior, PermissionBehavior::Allow);
+        let decision = has_permissions_to_use_tool("Bash", &Value::Null, &ctx, None);
+        assert_eq!(decision.behavior, PermissionBehavior::Ask);
+    }
+
+    #[test]
+    fn test_dont_ask_mode_silent_deny() {
+        let mut ctx = default_ctx();
+        ctx.mode = PermissionMode::DontAsk;
+        let decision = has_permissions_to_use_tool("Bash", &Value::Null, &ctx, None);
+        assert_eq!(decision.behavior, PermissionBehavior::Deny);
+    }
+
+    // -- Hook decision tests --
+
+    #[test]
+    fn test_hook_deny_overrides_allow_rule() {
+        let mut ctx = default_ctx();
+        ctx.always_allow_rules
+            .insert("user".into(), vec!["Bash".into()]);
+        let hook = HookPermissionDecision {
+            deny: Some("PolicyViolation".into()),
+            source: Some("PreToolUse:audit".into()),
+            ..Default::default()
+        };
+        let decision = has_permissions_to_use_tool_with_hook(
+            "Bash",
+            &Value::Null,
+            &ctx,
+            Some(&hook),
+            None,
+        );
+        assert_eq!(decision.behavior, PermissionBehavior::Deny);
+        assert!(decision.message.unwrap().contains("PolicyViolation"));
+    }
+
+    #[test]
+    fn test_deny_rule_still_blocks_hook_allow() {
+        let mut ctx = default_ctx();
+        ctx.always_deny_rules
+            .insert("policy".into(), vec!["Bash".into()]);
+        let hook = HookPermissionDecision {
+            allow: true,
+            ..Default::default()
+        };
+        let decision = has_permissions_to_use_tool_with_hook(
+            "Bash",
+            &Value::Null,
+            &ctx,
+            Some(&hook),
+            None,
+        );
+        // Per spec: deny rule wins over hook allow.
+        assert_eq!(decision.behavior, PermissionBehavior::Deny);
+    }
+
+    #[test]
+    fn test_ask_rule_still_overrides_hook_allow() {
+        let mut ctx = default_ctx();
+        ctx.always_ask_rules
+            .insert("project".into(), vec!["Bash".into()]);
+        let hook = HookPermissionDecision {
+            allow: true,
+            ..Default::default()
+        };
+        let decision = has_permissions_to_use_tool_with_hook(
+            "Bash",
+            &Value::Null,
+            &ctx,
+            Some(&hook),
+            None,
+        );
+        // Per spec: ask rule wins over hook allow.
+        assert_eq!(decision.behavior, PermissionBehavior::Ask);
+    }
+
+    #[test]
+    fn test_hook_allow_lifts_default_ask() {
+        let ctx = default_ctx();
+        let hook = HookPermissionDecision {
+            allow: true,
+            source: Some("PreToolUse:trustedAgent".into()),
+            ..Default::default()
+        };
+        let decision = has_permissions_to_use_tool_with_hook(
+            "Bash",
+            &Value::Null,
+            &ctx,
+            Some(&hook),
+            None,
+        );
+        assert_eq!(decision.behavior, PermissionBehavior::Allow);
+    }
+
+    #[test]
+    fn test_hook_modifies_input() {
+        let ctx = default_ctx();
+        let modified = serde_json::json!({"command": "ls -la"});
+        let hook = HookPermissionDecision {
+            allow: true,
+            updated_input: Some(modified.clone()),
+            ..Default::default()
+        };
+        let original = serde_json::json!({"command": "rm -rf /"});
+        let decision = has_permissions_to_use_tool_with_hook(
+            "Bash",
+            &original,
+            &ctx,
+            Some(&hook),
+            None,
+        );
+        assert_eq!(decision.behavior, PermissionBehavior::Allow);
+        assert_eq!(decision.updated_input.as_ref(), Some(&modified));
+    }
+
+    #[test]
+    fn test_hook_decision_is_noop_when_empty() {
+        let h = HookPermissionDecision::default();
+        assert!(h.is_noop());
+    }
+
+    // -- Auto mode + tracker --
+
+    #[test]
     fn test_auto_mode_denial_tracker_fallback() {
         let mut tracker = DenialTracker::default();
-
-        // Record 3 consecutive denials
         tracker.record_denial();
         tracker.record_denial();
         tracker.record_denial();
-
-        // After 3 consecutive denials, should_fallback_to_interactive is true
         assert!(tracker.should_fallback_to_interactive());
     }
 
@@ -540,13 +771,12 @@ mod tests {
         tracker.record_denial();
         tracker.record_denial();
         assert_eq!(tracker.consecutive_denials, 2);
-
         tracker.record_allow();
         assert_eq!(tracker.consecutive_denials, 0);
-        assert_eq!(tracker.total_denials, 2); // total doesn't reset
+        assert_eq!(tracker.total_denials, 2);
     }
 
-    // ── Session-level grant tests ──────────────────────────────────
+    // -- Session grants --
 
     #[test]
     fn test_session_grant_allows_tool() {
@@ -555,10 +785,13 @@ mod tests {
             "session".into(),
             vec!["mcp__computer-use__screenshot".into()],
         );
-        let decision =
-            has_permissions_to_use_tool("mcp__computer-use__screenshot", &Value::Null, &ctx, None);
+        let decision = has_permissions_to_use_tool(
+            "mcp__computer-use__screenshot",
+            &Value::Null,
+            &ctx,
+            None,
+        );
         assert_eq!(decision.behavior, PermissionBehavior::Allow);
-        // Should report session as the source
         if let PermissionDecisionReason::Rule { source, .. } = &decision.reason {
             assert_eq!(source, "session");
         } else {
@@ -569,18 +802,20 @@ mod tests {
     #[test]
     fn test_session_grant_does_not_override_deny_rules() {
         let mut ctx = default_ctx();
-        // Deny rule takes priority
         ctx.always_deny_rules.insert(
             "policy".into(),
             vec!["mcp__computer-use__left_click".into()],
         );
-        // Session grant should not override
         ctx.session_allow_rules.insert(
             "session".into(),
             vec!["mcp__computer-use__left_click".into()],
         );
-        let decision =
-            has_permissions_to_use_tool("mcp__computer-use__left_click", &Value::Null, &ctx, None);
+        let decision = has_permissions_to_use_tool(
+            "mcp__computer-use__left_click",
+            &Value::Null,
+            &ctx,
+            None,
+        );
         assert_eq!(decision.behavior, PermissionBehavior::Deny);
     }
 
@@ -601,25 +836,21 @@ mod tests {
         assert!(!ctx.has_session_grant("mcp__computer-use__screenshot"));
     }
 
-    // ── CU permission message tests ────────────────────────────────
+    // -- CU permission message --
 
     #[test]
     fn test_cu_screenshot_permission_message() {
         let ctx = default_ctx();
-        let decision =
-            has_permissions_to_use_tool("mcp__computer-use__screenshot", &Value::Null, &ctx, None);
+        let decision = has_permissions_to_use_tool(
+            "mcp__computer-use__screenshot",
+            &Value::Null,
+            &ctx,
+            None,
+        );
         assert_eq!(decision.behavior, PermissionBehavior::Ask);
         let msg = decision.message.unwrap();
-        assert!(
-            msg.contains("screenshot"),
-            "CU screenshot message should mention screenshot: {}",
-            msg
-        );
-        assert!(
-            msg.contains("medium risk"),
-            "CU screenshot should be medium risk: {}",
-            msg
-        );
+        assert!(msg.contains("screenshot"));
+        assert!(msg.contains("medium risk"));
     }
 
     #[test]
@@ -633,16 +864,8 @@ mod tests {
         );
         assert_eq!(decision.behavior, PermissionBehavior::Ask);
         let msg = decision.message.unwrap();
-        assert!(
-            msg.contains("click"),
-            "CU click message should mention click: {}",
-            msg
-        );
-        assert!(
-            msg.contains("HIGH RISK"),
-            "CU click should be HIGH RISK: {}",
-            msg
-        );
+        assert!(msg.contains("click"));
+        assert!(msg.contains("HIGH RISK"));
     }
 
     #[test]
@@ -655,7 +878,7 @@ mod tests {
             None,
         );
         let msg = decision.message.unwrap();
-        assert!(msg.contains("keyboard"), "type_text message: {}", msg);
+        assert!(msg.contains("keyboard"));
     }
 
     #[test]

--- a/src/permissions/mod.rs
+++ b/src/permissions/mod.rs
@@ -5,6 +5,7 @@
 // Dangerous command detection: rm -rf, git push --force, etc.
 // Decision state machine: full flow from rules → hooks → mode
 
+pub mod bash_matcher;
 pub mod dangerous;
 pub mod decision;
 pub mod path_validation;

--- a/src/permissions/rules.rs
+++ b/src/permissions/rules.rs
@@ -1,15 +1,26 @@
 //! Permission rule matching engine.
 //!
-//! Evaluates tool permission rules in priority order:
-//! 1. Deny rules (blanket deny -> deny with message)
-//! 2. Allow rules (if matched -> allow)
-//! 3. Ask rules (if matched -> ask)
-//! 4. Default: depends on mode (Default -> ask, Auto -> allow, Bypass -> allow)
+//! Evaluates tool permission rules in priority order, matching the
+//! precedence documented in `docs/claude-code-configuration/permissions.md`:
+//!
+//!   1. **Deny** rules (highest priority, blocks even if allow matches)
+//!   2. **Ask**  rules (force a prompt even when allow matches)
+//!   3. **Allow** rules (pre-approve)
+//!   4. Permission-mode fallback (Default → Ask, Auto → Allow, ...)
+//!
+//! `Bash` patterns are dispatched through [`crate::permissions::bash_matcher`]
+//! so compound commands and process wrappers participate in matching.
 
+use crate::permissions::bash_matcher;
 use crate::types::tool::{PermissionMode, ToolPermissionContext, ToolPermissionRulesBySource};
 use serde_json::Value;
 
 /// Result of a permission check against the rule engine.
+///
+/// Retained as a stable internal API for tests and for callers that want
+/// the rule-engine result without the full hook + mode flow (which lives
+/// in [`crate::permissions::decision`]).
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub enum PermissionCheckResult {
     /// Tool execution is allowed.
@@ -21,66 +32,89 @@ pub enum PermissionCheckResult {
     Ask { message: String },
 }
 
-/// Check whether a tool invocation is permitted given the current permission context.
+/// Tools whose execution counts as an "edit" for [`PermissionMode::AcceptEdits`].
+const EDIT_TOOLS: &[&str] = &[
+    "Write",
+    "Edit",
+    "MultiEdit",
+    "FileWrite",
+    "FileEdit",
+    "FileMultiEdit",
+    "NotebookEdit",
+    "ApplyPatch",
+    "ApplyDiff",
+];
+
+/// True when a tool counts as a file-system edit for accept-edits semantics.
+pub fn is_edit_tool(tool_name: &str) -> bool {
+    EDIT_TOOLS.iter().any(|t| *t == tool_name)
+}
+
+/// Check whether a tool invocation is permitted given the current context.
 ///
-/// Evaluation order:
-/// 1. Deny rules (highest priority -- any match blocks execution)
-/// 2. Allow rules (if matched, tool is permitted)
-/// 3. Ask rules (if matched, prompt the user)
-/// 4. Fallback based on permission mode
+/// Returns the rule-based decision only — caller is responsible for the
+/// hook overlay and mode fallback (see [`crate::permissions::decision`]).
+#[allow(dead_code)]
 pub fn check_tool_permission(
     tool_name: &str,
-    _input: &Value,
+    input: &Value,
     ctx: &ToolPermissionContext,
 ) -> PermissionCheckResult {
-    // --- Phase 1: Check deny rules ---
-    if let Some(reason) = match_rules_any_source(tool_name, &ctx.always_deny_rules) {
+    // 1. Deny rules
+    if let Some(reason) = match_rules_any_source(tool_name, input, &ctx.always_deny_rules) {
         return PermissionCheckResult::Deny {
             reason: if reason.is_empty() {
                 format!("Tool '{}' is denied by policy.", tool_name)
             } else {
-                reason
+                format!("Denied by rule: {}", reason)
             },
         };
     }
 
-    // --- Phase 2: Check allow rules ---
-    if match_rules_any_source(tool_name, &ctx.always_allow_rules).is_some() {
+    // 2. Ask rules (forced prompt — wins over allow per the spec)
+    if let Some(rule) = match_rules_any_source(tool_name, input, &ctx.always_ask_rules) {
+        return PermissionCheckResult::Ask {
+            message: if rule.is_empty() {
+                format!("Permission required for tool '{}'.", tool_name)
+            } else {
+                format!("Ask rule matched: {}", rule)
+            },
+        };
+    }
+
+    // 3. Allow rules
+    if match_rules_any_source(tool_name, input, &ctx.always_allow_rules).is_some() {
         return PermissionCheckResult::Allow;
     }
 
-    // --- Phase 3: Check ask rules ---
-    if let Some(msg) = match_rules_any_source(tool_name, &ctx.always_ask_rules) {
-        return PermissionCheckResult::Ask {
-            message: if msg.is_empty() {
-                format!("Permission required for tool '{}'.", tool_name)
-            } else {
-                msg
-            },
-        };
-    }
-
-    // --- Phase 4: Fallback by mode ---
+    // 4. Mode fallback
     match ctx.mode {
         PermissionMode::Default => PermissionCheckResult::Ask {
             message: format!("Allow tool '{}'?", tool_name),
         },
-        PermissionMode::Auto => {
-            // In auto mode we allow by default -- a real implementation would
-            // invoke the safety classifier here.
-            PermissionCheckResult::Allow
-        }
+        PermissionMode::Auto => PermissionCheckResult::Allow,
         PermissionMode::Bypass => PermissionCheckResult::Allow,
-        PermissionMode::Plan => {
-            // Plan mode: only read-only tools are allowed; the caller should
-            // gate on Tool::is_read_only(). We conservatively ask.
-            PermissionCheckResult::Ask {
-                message: format!(
-                    "Tool '{}' requires confirmation in plan mode (read-only).",
-                    tool_name
-                ),
+        PermissionMode::Plan => PermissionCheckResult::Ask {
+            message: format!(
+                "Tool '{}' requires confirmation in plan mode (read-only).",
+                tool_name
+            ),
+        },
+        PermissionMode::AcceptEdits => {
+            if is_edit_tool(tool_name) {
+                PermissionCheckResult::Allow
+            } else {
+                PermissionCheckResult::Ask {
+                    message: format!("Allow tool '{}'?", tool_name),
+                }
             }
         }
+        PermissionMode::DontAsk => PermissionCheckResult::Deny {
+            reason: format!(
+                "Permission mode 'dontAsk' silently denies '{}': add an allow rule to permit it.",
+                tool_name
+            ),
+        },
     }
 }
 
@@ -88,16 +122,17 @@ pub fn check_tool_permission(
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-/// Iterate all sources in a rule set and return Some(matched_rule) if any rule
-/// matches `tool_name`. The returned string is the raw rule text (may be empty
-/// for blanket rules).
+/// Iterate all sources in a rule set and return Some(matched_rule) if any
+/// rule matches (`tool_name`, `input`).
+#[allow(dead_code)]
 fn match_rules_any_source(
     tool_name: &str,
+    input: &Value,
     rules_by_source: &ToolPermissionRulesBySource,
 ) -> Option<String> {
     for (_source, rules) in rules_by_source.iter() {
         for rule in rules {
-            if rule_matches(tool_name, rule) {
+            if rule_matches(tool_name, input, rule) {
                 return Some(rule.clone());
             }
         }
@@ -105,44 +140,118 @@ fn match_rules_any_source(
     None
 }
 
-/// Check if a single rule pattern matches a tool name.
+/// Check if a single rule pattern matches a tool invocation.
 ///
-/// Matching strategies (in order):
-/// 1. Exact match: `"Bash"` matches `"Bash"`
-/// 2. Prefix match: `"mcp__server"` matches `"mcp__server__tool"`
-/// 3. Glob-style wildcard: `"mcp__*"` matches `"mcp__anything"`
-fn rule_matches(tool_name: &str, rule: &str) -> bool {
-    // Exact match
+/// Supports four shapes:
+///   1. Exact tool name: `"Bash"` or `"Read"`.
+///   2. Tool prefix: `"mcp__server"` matches `"mcp__server__tool"`.
+///   3. Glob: `"mcp__*"` matches `"mcp__anything"`.
+///   4. Specifier: `"Bash(pattern)"`, `"Read(/tmp/*)"`, etc. — the inner
+///      pattern is dispatched per-tool via [`specifier_matches`].
+pub(crate) fn rule_matches(tool_name: &str, input: &Value, rule: &str) -> bool {
+    // Specifier form: ToolName(pattern)
+    if let Some(open) = rule.find('(') {
+        if rule.ends_with(')') {
+            let rule_tool = &rule[..open];
+            if !tool_name_matches(tool_name, rule_tool) {
+                return false;
+            }
+            let pattern = &rule[open + 1..rule.len() - 1];
+            return specifier_matches(tool_name, input, pattern);
+        }
+    }
+
+    tool_name_matches(tool_name, rule)
+}
+
+/// Match a rule's tool-name component (no specifier) against a tool name.
+fn tool_name_matches(tool_name: &str, rule: &str) -> bool {
     if tool_name == rule {
         return true;
     }
-
-    // If the rule contains a `*`, treat it as a glob pattern.
     if rule.contains('*') {
         return glob_match(tool_name, rule);
     }
-
-    // Prefix match (e.g. "mcp__server" matches "mcp__server__tool")
     if tool_name.starts_with(rule) {
-        // Only match at a boundary (the next char after the prefix should be
-        // `_`, `/`, or end-of-string).
         let rest = &tool_name[rule.len()..];
         if rest.is_empty() || rest.starts_with('_') || rest.starts_with('/') {
             return true;
         }
     }
-
     false
 }
 
-/// Minimal glob matching that supports `*` as a wildcard for any sequence of
-/// characters. This is intentionally simple -- we only need to support the
-/// patterns used in Claude Code's permission rules (e.g. `"mcp__*"`,
-/// `"Bash(*)"`, `"*"`).
+/// Match a `ToolName(pattern)` specifier against the tool's input.
+fn specifier_matches(tool_name: &str, input: &Value, pattern: &str) -> bool {
+    match tool_name {
+        "Bash" => {
+            let cmd = input
+                .get("command")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            bash_matcher::bash_pattern_matches(pattern, cmd)
+        }
+        "Read" | "Write" | "Edit" | "MultiEdit" | "NotebookEdit" => {
+            let path = input
+                .get("file_path")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            text_specifier_matches(pattern, path)
+        }
+        "Glob" => {
+            let pat = input
+                .get("pattern")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            text_specifier_matches(pattern, pat)
+        }
+        "WebFetch" | "WebSearch" => {
+            let url = input
+                .get("url")
+                .or_else(|| input.get("query"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            text_specifier_matches(pattern, url)
+        }
+        "Agent" => {
+            let agent_type = input
+                .get("subagent_type")
+                .or_else(|| input.get("agent_type"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            text_specifier_matches(pattern, agent_type)
+        }
+        _ if tool_name.starts_with("mcp__") => {
+            text_specifier_matches(pattern, tool_name)
+        }
+        _ => {
+            // Generic specifier: stringify input and glob-match.
+            let s = input.to_string();
+            text_specifier_matches(pattern, &s)
+        }
+    }
+}
+
+fn text_specifier_matches(pattern: &str, value: &str) -> bool {
+    let pat = pattern.trim();
+    if pat.is_empty() || pat == "*" {
+        return true;
+    }
+    if let Some(prefix) = pat.strip_prefix("prefix:") {
+        return value.starts_with(prefix);
+    }
+    if pat.contains('*') {
+        return glob_match(value, pat);
+    }
+    value == pat
+}
+
+/// Minimal glob matching that supports `*` as a wildcard for any sequence
+/// of characters. This is intentionally simple — we only need to support
+/// the patterns used in Claude Code's permission rules.
 ///
-/// Also exposed as `glob_match_public` for use in the decision module.
+/// Also exposed as `glob_match_public` for use in [`crate::permissions::bash_matcher`].
 fn glob_match(text: &str, pattern: &str) -> bool {
-    // Split pattern by `*` -- all literal segments must appear in order.
     let segments: Vec<&str> = pattern.split('*').collect();
 
     if segments.is_empty() {
@@ -157,7 +266,6 @@ fn glob_match(text: &str, pattern: &str) -> bool {
         }
 
         if let Some(found) = text[pos..].find(segment) {
-            // First segment must match at the start if the pattern doesn't start with `*`.
             if i == 0 && !pattern.starts_with('*') && found != 0 {
                 return false;
             }
@@ -167,7 +275,6 @@ fn glob_match(text: &str, pattern: &str) -> bool {
         }
     }
 
-    // Last segment must match at the end if the pattern doesn't end with `*`.
     if !pattern.ends_with('*') {
         if let Some(last_seg) = segments.last() {
             if !last_seg.is_empty() && !text.ends_with(last_seg) {
@@ -191,6 +298,7 @@ pub fn glob_match_public(text: &str, pattern: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
     use std::collections::HashMap;
 
     fn default_ctx() -> ToolPermissionContext {
@@ -209,14 +317,18 @@ mod tests {
 
     #[test]
     fn test_exact_match() {
-        assert!(rule_matches("Bash", "Bash"));
-        assert!(!rule_matches("BashTool", "Bash"));
+        assert!(rule_matches("Bash", &Value::Null, "Bash"));
+        assert!(!rule_matches("BashTool", &Value::Null, "Bash"));
     }
 
     #[test]
     fn test_prefix_match() {
-        assert!(rule_matches("mcp__server__tool", "mcp__server"));
-        assert!(!rule_matches("mcp__serverX", "mcp__server"));
+        assert!(rule_matches(
+            "mcp__server__tool",
+            &Value::Null,
+            "mcp__server"
+        ));
+        assert!(!rule_matches("mcp__serverX", &Value::Null, "mcp__server"));
     }
 
     #[test]
@@ -237,6 +349,21 @@ mod tests {
 
         let result = check_tool_permission("Bash", &Value::Null, &ctx);
         assert!(matches!(result, PermissionCheckResult::Deny { .. }));
+    }
+
+    #[test]
+    fn test_ask_overrides_allow() {
+        // New precedence: ask wins over allow.
+        let mut ctx = default_ctx();
+        ctx.always_allow_rules
+            .insert("user".into(), vec!["Bash".into()]);
+        ctx.always_ask_rules
+            .insert("project".into(), vec!["Bash".into()]);
+        let result = check_tool_permission("Bash", &Value::Null, &ctx);
+        assert!(
+            matches!(result, PermissionCheckResult::Ask { .. }),
+            "ask must override allow per spec"
+        );
     }
 
     #[test]
@@ -270,5 +397,77 @@ mod tests {
         ctx.mode = PermissionMode::Auto;
         let result = check_tool_permission("SomeTool", &Value::Null, &ctx);
         assert!(matches!(result, PermissionCheckResult::Allow));
+    }
+
+    #[test]
+    fn test_accept_edits_allows_edit_tools() {
+        let mut ctx = default_ctx();
+        ctx.mode = PermissionMode::AcceptEdits;
+        assert!(matches!(
+            check_tool_permission("Edit", &Value::Null, &ctx),
+            PermissionCheckResult::Allow
+        ));
+        assert!(matches!(
+            check_tool_permission("Write", &Value::Null, &ctx),
+            PermissionCheckResult::Allow
+        ));
+        // Non-edit tool still asks.
+        assert!(matches!(
+            check_tool_permission("Bash", &Value::Null, &ctx),
+            PermissionCheckResult::Ask { .. }
+        ));
+    }
+
+    #[test]
+    fn test_dont_ask_denies_silently() {
+        let mut ctx = default_ctx();
+        ctx.mode = PermissionMode::DontAsk;
+        let r = check_tool_permission("AnyTool", &Value::Null, &ctx);
+        assert!(matches!(r, PermissionCheckResult::Deny { .. }));
+    }
+
+    #[test]
+    fn test_dont_ask_respects_allow_rules() {
+        let mut ctx = default_ctx();
+        ctx.mode = PermissionMode::DontAsk;
+        ctx.always_allow_rules
+            .insert("user".into(), vec!["Read".into()]);
+        let r = check_tool_permission("Read", &Value::Null, &ctx);
+        assert!(matches!(r, PermissionCheckResult::Allow));
+    }
+
+    // -- specifier tests --
+
+    #[test]
+    fn test_bash_specifier_compound_deny_via_token() {
+        let input = json!({"command": "git status && rm -rf /tmp/x"});
+        assert!(rule_matches("Bash", &input, "Bash(rm)"));
+        assert!(rule_matches("Bash", &input, "Bash(prefix:rm)"));
+    }
+
+    #[test]
+    fn test_bash_specifier_with_wrapper() {
+        let input = json!({"command": "sudo cargo build"});
+        assert!(rule_matches("Bash", &input, "Bash(prefix:cargo)"));
+    }
+
+    #[test]
+    fn test_read_specifier_glob() {
+        let input = json!({"file_path": "/tmp/foo.log"});
+        assert!(rule_matches("Read", &input, "Read(/tmp/*)"));
+        assert!(!rule_matches("Read", &input, "Read(/etc/*)"));
+    }
+
+    #[test]
+    fn test_webfetch_specifier_glob() {
+        let input = json!({"url": "https://api.example.com/v1/foo"});
+        assert!(rule_matches("WebFetch", &input, "WebFetch(https://api.example.com/*)"));
+    }
+
+    #[test]
+    fn test_agent_specifier_exact() {
+        let input = json!({"subagent_type": "Explore"});
+        assert!(rule_matches("Agent", &input, "Agent(Explore)"));
+        assert!(!rule_matches("Agent", &input, "Agent(Plan)"));
     }
 }

--- a/src/permissions/rules.rs
+++ b/src/permissions/rules.rs
@@ -185,10 +185,7 @@ fn tool_name_matches(tool_name: &str, rule: &str) -> bool {
 fn specifier_matches(tool_name: &str, input: &Value, pattern: &str) -> bool {
     match tool_name {
         "Bash" => {
-            let cmd = input
-                .get("command")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
+            let cmd = input.get("command").and_then(|v| v.as_str()).unwrap_or("");
             bash_matcher::bash_pattern_matches(pattern, cmd)
         }
         "Read" | "Write" | "Edit" | "MultiEdit" | "NotebookEdit" => {
@@ -199,10 +196,7 @@ fn specifier_matches(tool_name: &str, input: &Value, pattern: &str) -> bool {
             text_specifier_matches(pattern, path)
         }
         "Glob" => {
-            let pat = input
-                .get("pattern")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
+            let pat = input.get("pattern").and_then(|v| v.as_str()).unwrap_or("");
             text_specifier_matches(pattern, pat)
         }
         "WebFetch" | "WebSearch" => {
@@ -221,9 +215,7 @@ fn specifier_matches(tool_name: &str, input: &Value, pattern: &str) -> bool {
                 .unwrap_or("");
             text_specifier_matches(pattern, agent_type)
         }
-        _ if tool_name.starts_with("mcp__") => {
-            text_specifier_matches(pattern, tool_name)
-        }
+        _ if tool_name.starts_with("mcp__") => text_specifier_matches(pattern, tool_name),
         _ => {
             // Generic specifier: stringify input and glob-match.
             let s = input.to_string();
@@ -461,7 +453,11 @@ mod tests {
     #[test]
     fn test_webfetch_specifier_glob() {
         let input = json!({"url": "https://api.example.com/v1/foo"});
-        assert!(rule_matches("WebFetch", &input, "WebFetch(https://api.example.com/*)"));
+        assert!(rule_matches(
+            "WebFetch",
+            &input,
+            "WebFetch(https://api.example.com/*)"
+        ));
     }
 
     #[test]

--- a/src/sandbox/availability.rs
+++ b/src/sandbox/availability.rs
@@ -1,0 +1,154 @@
+//! Detect whether the OS-level sandbox primitive is usable on this host.
+//!
+//! Results:
+//! - Linux (and WSL2): looks for `bwrap` on `$PATH`
+//! - macOS: looks for `/usr/bin/sandbox-exec`
+//! - Windows: always `Unavailable` for now (Restricted Token support TBD)
+//!
+//! Called once per sandbox construction and cached in
+//! [`crate::sandbox::SandboxPolicy`].
+
+#![allow(dead_code)]
+// The `Available` variant, `is_available`, and `Mechanism::WindowsRestrictedToken`
+// are only constructed on some targets — Windows builds see them as dead even
+// though Linux/macOS builds use them. Allowing dead_code here keeps the enum
+// exhaustive for pattern matching on every platform.
+
+use std::sync::OnceLock;
+
+/// Outcome of the availability probe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Availability {
+    /// OS primitive is ready to use. Carries the concrete mechanism for UI.
+    Available(Mechanism),
+    /// OS primitive is not usable. Contains a human-readable reason.
+    Unavailable {
+        platform: &'static str,
+        reason: String,
+    },
+}
+
+/// Which OS-level primitive is wired up.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mechanism {
+    /// Linux / WSL2 bubblewrap (`bwrap`).
+    Bubblewrap,
+    /// macOS Seatbelt (`sandbox-exec`).
+    Seatbelt,
+    /// Windows Restricted Token + Job Object (future work).
+    WindowsRestrictedToken,
+}
+
+impl Mechanism {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Mechanism::Bubblewrap => "bubblewrap",
+            Mechanism::Seatbelt => "sandbox-exec (Seatbelt)",
+            Mechanism::WindowsRestrictedToken => "Windows Restricted Token + Job Object",
+        }
+    }
+}
+
+impl Availability {
+    pub fn is_available(&self) -> bool {
+        matches!(self, Availability::Available(_))
+    }
+
+    pub fn mechanism(&self) -> Option<Mechanism> {
+        match self {
+            Availability::Available(m) => Some(*m),
+            _ => None,
+        }
+    }
+
+    pub fn describe(&self) -> String {
+        match self {
+            Availability::Available(m) => {
+                format!("OS-level sandbox available via {}", m.as_str())
+            }
+            Availability::Unavailable { platform, reason } => {
+                format!("OS-level sandbox unavailable on {}: {}", platform, reason)
+            }
+        }
+    }
+}
+
+static CACHED: OnceLock<Availability> = OnceLock::new();
+
+/// Detect availability, caching the result for the lifetime of the process.
+///
+/// The check itself is cheap (a `which`-style lookup), but we still cache
+/// to guarantee a stable answer across repeated sandbox constructions.
+pub fn detect_availability() -> Availability {
+    CACHED.get_or_init(probe).clone()
+}
+
+fn probe() -> Availability {
+    #[cfg(target_os = "linux")]
+    {
+        match which::which("bwrap") {
+            Ok(_) => Availability::Available(Mechanism::Bubblewrap),
+            Err(e) => Availability::Unavailable {
+                platform: "linux",
+                reason: format!(
+                    "'bwrap' not found on PATH ({}). Install bubblewrap (e.g. \
+                     `apt-get install bubblewrap socat`) to enable OS-level \
+                     sandboxing.",
+                    e
+                ),
+            },
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let p = std::path::Path::new("/usr/bin/sandbox-exec");
+        if p.exists() {
+            Availability::Available(Mechanism::Seatbelt)
+        } else {
+            Availability::Unavailable {
+                platform: "macos",
+                reason: "/usr/bin/sandbox-exec not found (Seatbelt is a system \
+                         binary and should be present on all macOS versions; \
+                         report this as a bug)"
+                    .into(),
+            }
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        Availability::Unavailable {
+            platform: "windows",
+            reason: "Windows Restricted Token + Job Object support is not \
+                     wired up yet. Rust-level policy checks still apply; OS-level \
+                     enforcement is deferred to a follow-up (issue #8)."
+                .into(),
+        }
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        Availability::Unavailable {
+            platform: "unknown",
+            reason: "no sandbox back-end is implemented for this platform".into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_returns_stable_answer() {
+        let a = detect_availability();
+        let b = detect_availability();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn describe_is_non_empty() {
+        assert!(!detect_availability().describe().is_empty());
+    }
+}

--- a/src/sandbox/errors.rs
+++ b/src/sandbox/errors.rs
@@ -1,0 +1,116 @@
+//! Sandbox error types.
+//!
+//! Distinguishes "the sandbox blocked this" from "the command itself
+//! failed" — callers (BashTool, WebFetchTool) surface the former as a
+//! policy error and the latter as an ordinary non-zero exit.
+
+#![allow(dead_code)]
+// Several SandboxError variants are part of the public policy surface but
+// are only constructed from the yet-to-land path-based enforcement pass in
+// BashTool/PowerShellTool (issue #8 follow-up work). Keeping them now lets
+// downstream code pattern-match exhaustively without churn later.
+
+use std::fmt;
+use std::path::PathBuf;
+
+/// Reason a command or request was rejected by the sandbox.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SandboxError {
+    /// Sandbox mode forbids writes and the command needs to write.
+    ReadOnlyModeDeniesWrite { path: PathBuf },
+    /// Path matched a `denyWrite` entry.
+    WriteDenied { path: PathBuf, rule: String },
+    /// Path matched a `denyRead` entry and no `allowRead` re-allow.
+    ReadDenied { path: PathBuf, rule: String },
+    /// Write destination is outside the workspace and no `allowWrite` entry
+    /// covers it.
+    WriteOutsideWorkspace { path: PathBuf },
+    /// Network access is globally disabled (`sandbox.network.disabled=true`
+    /// or `--no-network`).
+    NetworkDisabled,
+    /// Domain is not in the `allowedDomains` list.
+    DomainNotAllowed { host: String },
+    /// `sandbox.failIfUnavailable=true` and the OS primitive is missing.
+    PrimitiveUnavailable {
+        platform: &'static str,
+        detail: String,
+    },
+    /// Command matched `excludedCommands`, meaning it cannot be sandboxed
+    /// and `sandbox.allowUnsandboxedCommands=false` rejected the fallback.
+    EscapeHatchDisabled { command: String },
+    /// Free-form policy violation — fallback variant for callers emitting
+    /// custom messages.
+    Policy { message: String },
+}
+
+impl fmt::Display for SandboxError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SandboxError::ReadOnlyModeDeniesWrite { path } => write!(
+                f,
+                "sandbox: read-only mode denies write to {}",
+                path.display()
+            ),
+            SandboxError::WriteDenied { path, rule } => write!(
+                f,
+                "sandbox: write to {} denied by rule '{}'",
+                path.display(),
+                rule
+            ),
+            SandboxError::ReadDenied { path, rule } => write!(
+                f,
+                "sandbox: read of {} denied by rule '{}'",
+                path.display(),
+                rule
+            ),
+            SandboxError::WriteOutsideWorkspace { path } => write!(
+                f,
+                "sandbox: write to {} is outside the workspace and has no allowWrite entry",
+                path.display()
+            ),
+            SandboxError::NetworkDisabled => f.write_str("sandbox: network access is disabled"),
+            SandboxError::DomainNotAllowed { host } => write!(
+                f,
+                "sandbox: host '{}' is not in sandbox.network.allowedDomains",
+                host
+            ),
+            SandboxError::PrimitiveUnavailable { platform, detail } => write!(
+                f,
+                "sandbox: OS-level sandbox primitive unavailable on {} ({}). \
+                 Set sandbox.failIfUnavailable=false to fall back to unsandboxed \
+                 execution, or install the required tooling.",
+                platform, detail
+            ),
+            SandboxError::EscapeHatchDisabled { command } => write!(
+                f,
+                "sandbox: command '{}' cannot be sandboxed and \
+                 sandbox.allowUnsandboxedCommands=false rejects the fallback",
+                command
+            ),
+            SandboxError::Policy { message } => write!(f, "sandbox: {}", message),
+        }
+    }
+}
+
+impl std::error::Error for SandboxError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_has_sandbox_prefix() {
+        let e = SandboxError::NetworkDisabled;
+        assert!(e.to_string().starts_with("sandbox:"));
+    }
+
+    #[test]
+    fn display_includes_path() {
+        let e = SandboxError::WriteDenied {
+            path: PathBuf::from("/etc/passwd"),
+            rule: "denyWrite".into(),
+        };
+        assert!(e.to_string().contains("/etc/passwd"));
+        assert!(e.to_string().contains("denyWrite"));
+    }
+}

--- a/src/sandbox/filesystem.rs
+++ b/src/sandbox/filesystem.rs
@@ -1,0 +1,336 @@
+//! Path matching for sandbox filesystem rules.
+//!
+//! Supports the three prefix conventions from Claude Code sandbox spec:
+//! - `/absolute/path` — absolute path
+//! - `~/relative` — relative to `$HOME`
+//! - `./relative` or bare `relative` — relative to the project root (or
+//!   the enclosing `~/.cc-rust/` for user settings)
+//!
+//! We also accept the legacy `//absolute/path` form for backward
+//! compatibility, matching the TS implementation.
+
+#![allow(dead_code)]
+// [`check_write`] / [`check_read`] are the Rust-level policy enforcement
+// surface. On Linux/macOS the OS primitive (bubblewrap / sandbox-exec) does
+// the real enforcement, so these methods only run in tests today. They stay
+// public because the Windows back-end (issue #8 follow-up) and the
+// `/sandbox` command's path-preview feature call them.
+
+use std::path::{Path, PathBuf};
+
+/// Decision produced by [`PathResolver::check_write`] /
+/// [`PathResolver::check_read`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FsDecision {
+    /// Access is permitted.
+    Allowed,
+    /// Access is denied; `reason` identifies the matching rule.
+    Denied { reason: String },
+}
+
+/// Resolve sandbox path rules relative to a workspace root and `$HOME`.
+///
+/// Constructed once per tool invocation with the effective settings in
+/// hand, then queried per-path.
+#[derive(Debug, Clone)]
+pub struct PathResolver {
+    workspace: PathBuf,
+    home: Option<PathBuf>,
+    /// Extra workspace roots (from `permissions.additionalDirectories` and
+    /// `addDir` session grants).
+    extra_workspaces: Vec<PathBuf>,
+    allow_write: Vec<PathBuf>,
+    deny_write: Vec<PathBuf>,
+    allow_read: Vec<PathBuf>,
+    deny_read: Vec<PathBuf>,
+}
+
+impl PathResolver {
+    pub fn new(workspace: PathBuf) -> Self {
+        Self {
+            workspace,
+            home: dirs::home_dir(),
+            extra_workspaces: Vec::new(),
+            allow_write: Vec::new(),
+            deny_write: Vec::new(),
+            allow_read: Vec::new(),
+            deny_read: Vec::new(),
+        }
+    }
+
+    pub fn with_home(mut self, home: Option<PathBuf>) -> Self {
+        self.home = home;
+        self
+    }
+
+    pub fn add_extra_workspace(&mut self, dir: PathBuf) {
+        self.extra_workspaces.push(dir);
+    }
+
+    pub fn add_allow_write(&mut self, raw: &str) {
+        if let Some(p) = self.resolve_raw(raw) {
+            self.allow_write.push(p);
+        }
+    }
+    pub fn add_deny_write(&mut self, raw: &str) {
+        if let Some(p) = self.resolve_raw(raw) {
+            self.deny_write.push(p);
+        }
+    }
+    pub fn add_allow_read(&mut self, raw: &str) {
+        if let Some(p) = self.resolve_raw(raw) {
+            self.allow_read.push(p);
+        }
+    }
+    pub fn add_deny_read(&mut self, raw: &str) {
+        if let Some(p) = self.resolve_raw(raw) {
+            self.deny_read.push(p);
+        }
+    }
+
+    pub fn workspace(&self) -> &Path {
+        &self.workspace
+    }
+
+    pub fn allow_write_paths(&self) -> &[PathBuf] {
+        &self.allow_write
+    }
+    pub fn deny_write_paths(&self) -> &[PathBuf] {
+        &self.deny_write
+    }
+    pub fn allow_read_paths(&self) -> &[PathBuf] {
+        &self.allow_read
+    }
+    pub fn deny_read_paths(&self) -> &[PathBuf] {
+        &self.deny_read
+    }
+    pub fn extra_workspaces(&self) -> &[PathBuf] {
+        &self.extra_workspaces
+    }
+
+    /// Resolve a raw path-pattern string into an absolute path.
+    ///
+    /// Returns `None` only if the path is empty or has no resolvable root
+    /// (e.g. `~/...` when `$HOME` is unknown). Unknown forms default to
+    /// workspace-relative, matching the spec.
+    fn resolve_raw(&self, raw: &str) -> Option<PathBuf> {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+
+        // `~/...` — relative to home
+        if let Some(rest) = trimmed.strip_prefix("~/") {
+            return self.home.as_ref().map(|h| h.join(rest));
+        }
+        if trimmed == "~" {
+            return self.home.clone();
+        }
+
+        // `//abs` — legacy absolute form
+        if let Some(rest) = trimmed.strip_prefix("//") {
+            return Some(PathBuf::from("/").join(rest));
+        }
+
+        // Absolute path (unix `/...` or windows drive like `C:\`)
+        let p = PathBuf::from(trimmed);
+        if p.is_absolute() {
+            return Some(p);
+        }
+
+        // `./...` or bare — project-relative
+        let stripped = trimmed.strip_prefix("./").unwrap_or(trimmed);
+        Some(self.workspace.join(stripped))
+    }
+
+    /// Check whether a write to `path` is allowed under the current policy.
+    ///
+    /// Order of evaluation (first match wins):
+    /// 1. `denyWrite` → denied
+    /// 2. `allowWrite` → allowed (overrides workspace check)
+    /// 3. Inside workspace or extra_workspaces → allowed
+    /// 4. Otherwise → denied ("outside workspace")
+    ///
+    /// Works on logical paths only; does NOT touch the filesystem.
+    pub fn check_write(&self, path: &Path) -> FsDecision {
+        let normalized = normalize(path);
+        for deny in &self.deny_write {
+            if is_within(&normalized, deny) {
+                return FsDecision::Denied {
+                    reason: format!("denyWrite {}", deny.display()),
+                };
+            }
+        }
+        for allow in &self.allow_write {
+            if is_within(&normalized, allow) {
+                return FsDecision::Allowed;
+            }
+        }
+        if is_within(&normalized, &self.workspace) {
+            return FsDecision::Allowed;
+        }
+        for extra in &self.extra_workspaces {
+            if is_within(&normalized, extra) {
+                return FsDecision::Allowed;
+            }
+        }
+        FsDecision::Denied {
+            reason: format!("outside workspace {}", self.workspace.display()),
+        }
+    }
+
+    /// Check whether a read of `path` is allowed.
+    ///
+    /// Order of evaluation:
+    /// 1. `allowRead` → allowed (overrides `denyRead` by spec)
+    /// 2. `denyRead` → denied
+    /// 3. Otherwise → allowed (default)
+    pub fn check_read(&self, path: &Path) -> FsDecision {
+        let normalized = normalize(path);
+        for allow in &self.allow_read {
+            if is_within(&normalized, allow) {
+                return FsDecision::Allowed;
+            }
+        }
+        for deny in &self.deny_read {
+            if is_within(&normalized, deny) {
+                return FsDecision::Denied {
+                    reason: format!("denyRead {}", deny.display()),
+                };
+            }
+        }
+        FsDecision::Allowed
+    }
+}
+
+/// Lexical normalization — resolves `.` and `..` without touching the
+/// filesystem. Symlinks are NOT resolved, matching the spec's behavior of
+/// path matching.
+fn normalize(path: &Path) -> PathBuf {
+    let mut out = Vec::new();
+    for c in path.components() {
+        match c {
+            std::path::Component::ParentDir => {
+                if !out.is_empty() {
+                    out.pop();
+                }
+            }
+            std::path::Component::CurDir => {}
+            other => out.push(other),
+        }
+    }
+    out.iter().collect()
+}
+
+fn is_within(path: &Path, dir: &Path) -> bool {
+    let dir_norm = normalize(dir);
+    path.starts_with(&dir_norm)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn resolver() -> PathResolver {
+        PathResolver::new(PathBuf::from("/proj")).with_home(Some(PathBuf::from("/home/alice")))
+    }
+
+    #[test]
+    fn resolve_absolute() {
+        let r = resolver();
+        assert_eq!(r.resolve_raw("/tmp/x"), Some(PathBuf::from("/tmp/x")));
+        assert_eq!(r.resolve_raw("//tmp/x"), Some(PathBuf::from("/tmp/x")));
+    }
+
+    #[test]
+    fn resolve_home() {
+        let r = resolver();
+        assert_eq!(
+            r.resolve_raw("~/.kube"),
+            Some(PathBuf::from("/home/alice/.kube"))
+        );
+    }
+
+    #[test]
+    fn resolve_project_relative() {
+        let r = resolver();
+        assert_eq!(r.resolve_raw("./out"), Some(PathBuf::from("/proj/out")));
+        assert_eq!(r.resolve_raw("out"), Some(PathBuf::from("/proj/out")));
+        assert_eq!(r.resolve_raw("."), Some(PathBuf::from("/proj")));
+    }
+
+    #[test]
+    fn check_write_workspace_allowed() {
+        let r = resolver();
+        assert_eq!(
+            r.check_write(Path::new("/proj/src/main.rs")),
+            FsDecision::Allowed
+        );
+    }
+
+    #[test]
+    fn check_write_outside_denied() {
+        let r = resolver();
+        let d = r.check_write(Path::new("/etc/passwd"));
+        assert!(matches!(d, FsDecision::Denied { .. }));
+    }
+
+    #[test]
+    fn allow_write_overrides_outside() {
+        let mut r = resolver();
+        r.add_allow_write("/tmp/build");
+        assert_eq!(
+            r.check_write(Path::new("/tmp/build/x")),
+            FsDecision::Allowed
+        );
+        let d = r.check_write(Path::new("/tmp/other/x"));
+        assert!(matches!(d, FsDecision::Denied { .. }));
+    }
+
+    #[test]
+    fn deny_write_overrides_workspace() {
+        let mut r = resolver();
+        r.add_deny_write("/proj/sensitive");
+        let d = r.check_write(Path::new("/proj/sensitive/a.rs"));
+        assert!(matches!(d, FsDecision::Denied { .. }));
+    }
+
+    #[test]
+    fn deny_read_default_denies() {
+        let mut r = resolver();
+        r.add_deny_read("~/");
+        let d = r.check_read(Path::new("/home/alice/secrets"));
+        assert!(matches!(d, FsDecision::Denied { .. }));
+    }
+
+    #[test]
+    fn allow_read_reopens_deny_read() {
+        let mut r = resolver();
+        r.add_deny_read("~/");
+        r.add_allow_read("."); // = /proj, but also re-allow something inside ~
+        r.add_allow_read("~/public");
+        assert_eq!(
+            r.check_read(Path::new("/home/alice/public/readme.md")),
+            FsDecision::Allowed
+        );
+        // Still denied outside the re-allow
+        let d = r.check_read(Path::new("/home/alice/secrets/key"));
+        assert!(matches!(d, FsDecision::Denied { .. }));
+    }
+
+    #[test]
+    fn normalize_handles_parent_dirs() {
+        assert_eq!(normalize(Path::new("/a/b/../c")), PathBuf::from("/a/c"));
+        assert_eq!(normalize(Path::new("/a/./b")), PathBuf::from("/a/b"));
+    }
+
+    #[test]
+    fn extra_workspace_allows_writes() {
+        let mut r = resolver();
+        r.add_extra_workspace(PathBuf::from("/shared/libs"));
+        assert_eq!(
+            r.check_write(Path::new("/shared/libs/utils.rs")),
+            FsDecision::Allowed
+        );
+    }
+}

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -1,0 +1,45 @@
+//! Sandbox runtime — OS-level isolation + Rust-level policy checks for
+//! shell subprocesses and WebFetch.
+//!
+//! Corresponds to: issue #8 + `docs/claude-code-configuration/sandboxing.md`.
+//!
+//! # Layout
+//!
+//! - [`mode`] — [`SandboxMode`] enum (`read-only`, `workspace`, `full`)
+//! - [`policy`] — [`SandboxPolicy`] assembled from `SandboxSettings` +
+//!   permission rules
+//! - [`runner`] — [`SandboxRunner`] trait, factory, and platform back-ends
+//! - [`filesystem`] — path resolution + `allow/deny` matching
+//! - [`network`] — domain allowlist matching
+//! - [`availability`] — detects whether the OS primitive (bubblewrap,
+//!   sandbox-exec, Windows Restricted Token) is usable on this host
+//!
+//! # Status per platform
+//!
+//! | Platform | OS-level enforcement |
+//! |----------|---------------------|
+//! | Linux / WSL2 | bubblewrap wrapper (when `bwrap` is on `$PATH`) |
+//! | macOS | `sandbox-exec` (Seatbelt) wrapper |
+//! | Windows | Rust-level policy checks only; OS-level enforcement TBD |
+//!
+//! On every platform, path-based allow/deny checks and network-domain checks
+//! run **in-process before spawn** as a best-effort second line of defence,
+//! even when the OS primitive isn't available. `sandbox.failIfUnavailable`
+//! controls whether the missing OS primitive is a hard error.
+
+pub mod availability;
+pub mod errors;
+pub mod filesystem;
+pub mod mode;
+pub mod network;
+pub mod policy;
+pub mod runner;
+
+// Re-export only what the rest of the crate consumes. Deeper entry points
+// (e.g. `SandboxPolicyBuilder` for tests) can still reach the submodules
+// directly via `crate::sandbox::policy::SandboxPolicyBuilder`.
+pub use availability::{Availability, Mechanism};
+pub use errors::SandboxError;
+pub use mode::SandboxMode;
+pub use network::NetworkDecision;
+pub use runner::{make_runner, policy_from_app_state};

--- a/src/sandbox/mode.rs
+++ b/src/sandbox/mode.rs
@@ -1,0 +1,111 @@
+//! Sandbox modes — `read-only`, `workspace`, `full` (disabled).
+
+use std::fmt;
+use std::str::FromStr;
+
+/// Sandbox mode controlling the default level of isolation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SandboxMode {
+    /// All filesystem writes are blocked (no subprocess write access).
+    /// Reads follow the default allow/deny rules.
+    ReadOnly,
+    /// Writes allowed within the working directory (and any explicit
+    /// `sandbox.filesystem.allowWrite` entries); reads allowed broadly
+    /// unless explicitly denied.
+    Workspace,
+    /// Sandbox disabled; commands run unrestricted. Equivalent to
+    /// `enabled: false`. Kept explicit so users can pin the intent.
+    Full,
+}
+
+impl SandboxMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SandboxMode::ReadOnly => "read-only",
+            SandboxMode::Workspace => "workspace",
+            SandboxMode::Full => "full",
+        }
+    }
+
+    /// Default mode applied when `sandbox.enabled = true` but `sandbox.mode`
+    /// is unset.
+    pub fn default_enabled() -> Self {
+        SandboxMode::Workspace
+    }
+
+    pub fn allows_writes(self) -> bool {
+        matches!(self, SandboxMode::Workspace | SandboxMode::Full)
+    }
+
+    pub fn is_active(self) -> bool {
+        !matches!(self, SandboxMode::Full)
+    }
+}
+
+impl fmt::Display for SandboxMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for SandboxMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "read-only" | "readonly" | "ro" => Ok(SandboxMode::ReadOnly),
+            "workspace" | "ws" => Ok(SandboxMode::Workspace),
+            "full" | "off" | "disabled" | "none" => Ok(SandboxMode::Full),
+            other => Err(format!(
+                "unknown sandbox mode '{}'; expected read-only | workspace | full",
+                other
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_round_trip() {
+        for mode in [
+            SandboxMode::ReadOnly,
+            SandboxMode::Workspace,
+            SandboxMode::Full,
+        ] {
+            let parsed: SandboxMode = mode.as_str().parse().unwrap();
+            assert_eq!(parsed, mode);
+        }
+    }
+
+    #[test]
+    fn parse_aliases() {
+        assert_eq!(
+            "ReadOnly".parse::<SandboxMode>().unwrap(),
+            SandboxMode::ReadOnly
+        );
+        assert_eq!("ws".parse::<SandboxMode>().unwrap(), SandboxMode::Workspace);
+        assert_eq!("off".parse::<SandboxMode>().unwrap(), SandboxMode::Full);
+    }
+
+    #[test]
+    fn parse_unknown() {
+        assert!("sudo".parse::<SandboxMode>().is_err());
+    }
+
+    #[test]
+    fn allows_writes() {
+        assert!(!SandboxMode::ReadOnly.allows_writes());
+        assert!(SandboxMode::Workspace.allows_writes());
+        assert!(SandboxMode::Full.allows_writes());
+    }
+
+    #[test]
+    fn is_active() {
+        assert!(SandboxMode::ReadOnly.is_active());
+        assert!(SandboxMode::Workspace.is_active());
+        assert!(!SandboxMode::Full.is_active());
+    }
+}

--- a/src/sandbox/network.rs
+++ b/src/sandbox/network.rs
@@ -1,0 +1,161 @@
+//! Network policy — domain allowlist + `--no-network` gating.
+//!
+//! Shared by [`crate::tools::web_fetch`] and the shell sandboxes.
+
+use super::errors::SandboxError;
+
+/// Outcome of a network check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NetworkDecision {
+    Allowed,
+    Denied(SandboxError),
+}
+
+/// Compiled network policy.
+#[derive(Debug, Clone, Default)]
+pub struct NetworkPolicy {
+    /// If `true`, all outbound requests are blocked.
+    pub disabled: bool,
+    /// If non-empty, only hosts matching one of these patterns are allowed.
+    ///
+    /// Patterns:
+    /// - Bare hostname → exact match
+    /// - `*.example.com` → matches `x.example.com` and `example.com` itself
+    /// - `example.com` → matches `example.com` AND its subdomains
+    ///   (matches the Claude Code spec behavior)
+    pub allowed_domains: Vec<String>,
+}
+
+impl NetworkPolicy {
+    pub fn check_host(&self, host: &str) -> NetworkDecision {
+        if self.disabled {
+            return NetworkDecision::Denied(SandboxError::NetworkDisabled);
+        }
+        if self.allowed_domains.is_empty() {
+            return NetworkDecision::Allowed;
+        }
+        let host = host.trim().trim_end_matches('.').to_ascii_lowercase();
+        for pattern in &self.allowed_domains {
+            if matches_domain(&host, pattern) {
+                return NetworkDecision::Allowed;
+            }
+        }
+        NetworkDecision::Denied(SandboxError::DomainNotAllowed { host })
+    }
+
+    /// Convenience check for full URLs. Extracts the host and delegates.
+    pub fn check_url(&self, url: &str) -> NetworkDecision {
+        if self.disabled {
+            return NetworkDecision::Denied(SandboxError::NetworkDisabled);
+        }
+        match ::url::Url::parse(url) {
+            Ok(u) => match u.host_str() {
+                Some(h) => self.check_host(h),
+                None => NetworkDecision::Denied(SandboxError::Policy {
+                    message: format!("URL has no host: {}", url),
+                }),
+            },
+            Err(_) => NetworkDecision::Denied(SandboxError::Policy {
+                message: format!("invalid URL: {}", url),
+            }),
+        }
+    }
+}
+
+fn matches_domain(host: &str, pattern: &str) -> bool {
+    let pat = pattern.trim().trim_end_matches('.').to_ascii_lowercase();
+    if pat.is_empty() {
+        return false;
+    }
+    if let Some(rest) = pat.strip_prefix("*.") {
+        // `*.example.com` → matches `foo.example.com` and `example.com`
+        return host == rest || host.ends_with(&format!(".{}", rest));
+    }
+    // Bare `example.com` → matches itself + subdomains
+    host == pat || host.ends_with(&format!(".{}", pat))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_denies_everything() {
+        let p = NetworkPolicy {
+            disabled: true,
+            ..Default::default()
+        };
+        assert!(matches!(
+            p.check_host("example.com"),
+            NetworkDecision::Denied(SandboxError::NetworkDisabled)
+        ));
+    }
+
+    #[test]
+    fn empty_list_allows_everything() {
+        let p = NetworkPolicy::default();
+        assert_eq!(p.check_host("any.example.com"), NetworkDecision::Allowed);
+    }
+
+    #[test]
+    fn bare_domain_matches_self_and_subs() {
+        let p = NetworkPolicy {
+            disabled: false,
+            allowed_domains: vec!["example.com".into()],
+        };
+        assert_eq!(p.check_host("example.com"), NetworkDecision::Allowed);
+        assert_eq!(p.check_host("api.example.com"), NetworkDecision::Allowed);
+        assert!(matches!(
+            p.check_host("evil.net"),
+            NetworkDecision::Denied(_)
+        ));
+    }
+
+    #[test]
+    fn wildcard_matches_subdomains() {
+        let p = NetworkPolicy {
+            disabled: false,
+            allowed_domains: vec!["*.example.com".into()],
+        };
+        assert_eq!(p.check_host("x.example.com"), NetworkDecision::Allowed);
+        assert_eq!(p.check_host("example.com"), NetworkDecision::Allowed);
+        assert!(matches!(
+            p.check_host("other.net"),
+            NetworkDecision::Denied(_)
+        ));
+    }
+
+    #[test]
+    fn host_matching_is_case_insensitive() {
+        let p = NetworkPolicy {
+            disabled: false,
+            allowed_domains: vec!["EXAMPLE.com".into()],
+        };
+        assert_eq!(p.check_host("Example.Com"), NetworkDecision::Allowed);
+    }
+
+    #[test]
+    fn url_check_uses_host() {
+        let p = NetworkPolicy {
+            disabled: false,
+            allowed_domains: vec!["example.com".into()],
+        };
+        assert_eq!(
+            p.check_url("https://api.example.com/x"),
+            NetworkDecision::Allowed
+        );
+        assert!(matches!(
+            p.check_url("https://evil.net/"),
+            NetworkDecision::Denied(_)
+        ));
+    }
+
+    #[test]
+    fn url_check_rejects_invalid_url() {
+        let p = NetworkPolicy::default();
+        assert!(matches!(
+            p.check_url("not a url"),
+            NetworkDecision::Denied(_)
+        ));
+    }
+}

--- a/src/sandbox/policy.rs
+++ b/src/sandbox/policy.rs
@@ -1,0 +1,315 @@
+//! Effective sandbox policy — merged from [`crate::config::settings::SandboxSettings`]
+//! plus permission rules, then cached on [`crate::types::app_state::AppState`].
+//!
+//! Policy assembly is deliberately decoupled from settings parsing so
+//! callers (CLI `--no-network`, `/sandbox` command, session-level
+//! overrides) can mutate the effective policy without re-serializing
+//! settings.
+
+use std::path::PathBuf;
+
+use crate::config::settings::SandboxSettings;
+
+use super::availability::{detect_availability, Availability};
+use super::filesystem::PathResolver;
+use super::mode::SandboxMode;
+use super::network::NetworkPolicy;
+
+/// Fully-resolved sandbox policy — ready for enforcement.
+#[derive(Debug, Clone)]
+pub struct SandboxPolicy {
+    pub enabled: bool,
+    pub mode: SandboxMode,
+    pub fail_if_unavailable: bool,
+    pub allow_unsandboxed_commands: bool,
+    pub excluded_commands: Vec<String>,
+    pub allowed_commands: Vec<String>,
+    pub paths: PathResolver,
+    pub network: NetworkPolicy,
+    pub availability: Availability,
+}
+
+impl Default for SandboxPolicy {
+    fn default() -> Self {
+        SandboxPolicyBuilder::new(PathBuf::from(".")).build()
+    }
+}
+
+impl SandboxPolicy {
+    /// Is the sandbox enabled *and* active (non-`full`)?
+    pub fn is_active(&self) -> bool {
+        self.enabled && self.mode.is_active()
+    }
+
+    /// Is `cmd` in the `excludedCommands` list?
+    ///
+    /// Matches:
+    /// - `docker` → matches `docker` and `docker run ...`
+    /// - `docker *` → same as `docker` (prefix on argv)
+    /// - `make test` → matches `make test` and `make test -j4`
+    pub fn is_excluded_command(&self, cmd: &str) -> bool {
+        command_matches_any(cmd, &self.excluded_commands)
+    }
+
+    /// Is `cmd` in the `allowedCommands` pre-approval list?
+    ///
+    /// Exposed on the public policy surface so the permission-decision flow
+    /// can auto-approve sandboxed commands in `workspace` mode. The current
+    /// cc-rust binary doesn't call it yet; the hook is deferred to a
+    /// follow-up that wires `allowedCommands` into `permissions::decision`.
+    #[allow(dead_code)]
+    pub fn is_allowed_command(&self, cmd: &str) -> bool {
+        command_matches_any(cmd, &self.allowed_commands)
+    }
+}
+
+/// Shared matcher used by `excludedCommands` and `allowedCommands`.
+///
+/// A rule matches when `cmd`:
+/// - equals the rule, OR
+/// - starts with `rule ` (space-separated prefix)
+///
+/// The trailing `*` / ` *` in a rule is stripped before matching — they
+/// mean the same thing as the bare rule here.
+fn command_matches_any(cmd: &str, rules: &[String]) -> bool {
+    let cmd = cmd.trim();
+    if cmd.is_empty() {
+        return false;
+    }
+    for rule in rules {
+        let r = rule
+            .trim()
+            .trim_end_matches('*')
+            .trim_end()
+            .to_string();
+        if r.is_empty() {
+            continue;
+        }
+        if cmd == r || cmd.starts_with(&format!("{} ", r)) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Build a [`SandboxPolicy`] from raw settings + runtime overrides.
+pub struct SandboxPolicyBuilder {
+    workspace: PathBuf,
+    settings: SandboxSettings,
+    /// From CLI `--no-network` flag.
+    force_no_network: bool,
+    /// From `permissions.additionalDirectories` and session `addDir` grants.
+    extra_workspaces: Vec<PathBuf>,
+    /// Merged deny-read rules sourced from `Read(...)` permission denies.
+    perm_deny_reads: Vec<String>,
+    /// Merged deny-write rules sourced from `Edit(...)` permission denies.
+    perm_deny_writes: Vec<String>,
+}
+
+impl SandboxPolicyBuilder {
+    pub fn new(workspace: PathBuf) -> Self {
+        Self {
+            workspace,
+            settings: SandboxSettings::default(),
+            force_no_network: false,
+            extra_workspaces: Vec::new(),
+            perm_deny_reads: Vec::new(),
+            perm_deny_writes: Vec::new(),
+        }
+    }
+
+    pub fn settings(mut self, settings: SandboxSettings) -> Self {
+        self.settings = settings;
+        self
+    }
+
+    pub fn no_network(mut self, on: bool) -> Self {
+        self.force_no_network = on;
+        self
+    }
+
+    pub fn extra_workspaces(mut self, dirs: Vec<PathBuf>) -> Self {
+        self.extra_workspaces = dirs;
+        self
+    }
+
+    pub fn permission_deny_reads(mut self, rules: Vec<String>) -> Self {
+        self.perm_deny_reads = rules;
+        self
+    }
+
+    pub fn permission_deny_writes(mut self, rules: Vec<String>) -> Self {
+        self.perm_deny_writes = rules;
+        self
+    }
+
+    pub fn build(self) -> SandboxPolicy {
+        let Self {
+            workspace,
+            settings,
+            force_no_network,
+            extra_workspaces,
+            perm_deny_reads,
+            perm_deny_writes,
+        } = self;
+
+        let enabled = settings.enabled.unwrap_or(false);
+        let mode = settings
+            .mode
+            .as_deref()
+            .and_then(|s| s.parse::<SandboxMode>().ok())
+            .unwrap_or(SandboxMode::default_enabled());
+        // If enabled=false, force mode=Full so callers can just read `.mode`.
+        let effective_mode = if enabled { mode } else { SandboxMode::Full };
+
+        let mut paths = PathResolver::new(workspace);
+        for extra in extra_workspaces {
+            paths.add_extra_workspace(extra);
+        }
+        for raw in &settings.filesystem.allow_write {
+            paths.add_allow_write(raw);
+        }
+        for raw in &settings.filesystem.deny_write {
+            paths.add_deny_write(raw);
+        }
+        for raw in &settings.filesystem.allow_read {
+            paths.add_allow_read(raw);
+        }
+        for raw in &settings.filesystem.deny_read {
+            paths.add_deny_read(raw);
+        }
+        for raw in &perm_deny_writes {
+            paths.add_deny_write(raw);
+        }
+        for raw in &perm_deny_reads {
+            paths.add_deny_read(raw);
+        }
+
+        let network = NetworkPolicy {
+            disabled: force_no_network || settings.network.disabled.unwrap_or(false),
+            allowed_domains: settings.network.allowed_domains.clone(),
+        };
+
+        let availability = detect_availability();
+
+        SandboxPolicy {
+            enabled,
+            mode: effective_mode,
+            fail_if_unavailable: settings.fail_if_unavailable.unwrap_or(false),
+            allow_unsandboxed_commands: settings.allow_unsandboxed_commands.unwrap_or(true),
+            excluded_commands: settings.excluded_commands.clone(),
+            allowed_commands: settings.allowed_commands.clone(),
+            paths,
+            network,
+            availability,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::settings::{SandboxFilesystemSettings, SandboxNetworkSettings};
+
+    #[test]
+    fn default_is_inactive() {
+        let p = SandboxPolicyBuilder::new(PathBuf::from("/proj")).build();
+        assert!(!p.is_active());
+        assert_eq!(p.mode, SandboxMode::Full);
+    }
+
+    #[test]
+    fn enabled_defaults_to_workspace() {
+        let p = SandboxPolicyBuilder::new(PathBuf::from("/proj"))
+            .settings(SandboxSettings {
+                enabled: Some(true),
+                ..Default::default()
+            })
+            .build();
+        assert!(p.is_active());
+        assert_eq!(p.mode, SandboxMode::Workspace);
+    }
+
+    #[test]
+    fn explicit_mode_wins() {
+        let p = SandboxPolicyBuilder::new(PathBuf::from("/proj"))
+            .settings(SandboxSettings {
+                enabled: Some(true),
+                mode: Some("read-only".into()),
+                ..Default::default()
+            })
+            .build();
+        assert_eq!(p.mode, SandboxMode::ReadOnly);
+    }
+
+    #[test]
+    fn no_network_cli_flag_overrides() {
+        let p = SandboxPolicyBuilder::new(PathBuf::from("/proj"))
+            .no_network(true)
+            .build();
+        assert!(p.network.disabled);
+    }
+
+    #[test]
+    fn allow_write_paths_resolve() {
+        let p = SandboxPolicyBuilder::new(PathBuf::from("/proj"))
+            .settings(SandboxSettings {
+                enabled: Some(true),
+                filesystem: SandboxFilesystemSettings {
+                    allow_write: vec!["./build".into(), "/tmp/cache".into()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .build();
+        let allow = p.paths.allow_write_paths();
+        assert!(allow.contains(&PathBuf::from("/proj/build")));
+        assert!(allow.contains(&PathBuf::from("/tmp/cache")));
+    }
+
+    #[test]
+    fn excluded_command_matches_by_name() {
+        let p = SandboxPolicyBuilder::new(PathBuf::from("/proj"))
+            .settings(SandboxSettings {
+                enabled: Some(true),
+                excluded_commands: vec!["docker".into(), "watchman *".into()],
+                ..Default::default()
+            })
+            .build();
+        assert!(p.is_excluded_command("docker run hello"));
+        assert!(p.is_excluded_command("docker"));
+        assert!(p.is_excluded_command("watchman status"));
+        assert!(!p.is_excluded_command("doc"));
+        assert!(!p.is_excluded_command("ls"));
+    }
+
+    #[test]
+    fn allowed_command_distinct_from_excluded() {
+        let p = SandboxPolicyBuilder::new(PathBuf::from("/proj"))
+            .settings(SandboxSettings {
+                enabled: Some(true),
+                allowed_commands: vec!["make test".into()],
+                ..Default::default()
+            })
+            .build();
+        assert!(p.is_allowed_command("make test"));
+        assert!(p.is_allowed_command("make test -j4"));
+        assert!(!p.is_allowed_command("make install"));
+    }
+
+    #[test]
+    fn network_settings_wire_through() {
+        let p = SandboxPolicyBuilder::new(PathBuf::from("/proj"))
+            .settings(SandboxSettings {
+                enabled: Some(true),
+                network: SandboxNetworkSettings {
+                    allowed_domains: vec!["github.com".into()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .build();
+        assert!(!p.network.disabled);
+        assert_eq!(p.network.allowed_domains, vec!["github.com".to_string()]);
+    }
+}

--- a/src/sandbox/runner.rs
+++ b/src/sandbox/runner.rs
@@ -1,0 +1,496 @@
+//! [`SandboxRunner`] trait + concrete back-ends.
+//!
+//! Callers (`BashTool`, `PowerShellTool`) use the runner to wrap a
+//! `tokio::process::Command` with OS-level isolation (bubblewrap on Linux,
+//! sandbox-exec on macOS) before spawn.
+//!
+//! On platforms that don't have a usable primitive the runner returns an
+//! "unsupported" back-end that passes the command through untouched — which,
+//! per `sandbox.failIfUnavailable`, either produces a log-level warning or
+//! a hard [`SandboxError::PrimitiveUnavailable`].
+
+use std::path::PathBuf;
+
+use tokio::process::Command;
+
+use super::availability::Mechanism;
+use super::errors::SandboxError;
+use super::policy::SandboxPolicy;
+
+/// A command pre-assembled for sandboxed execution.
+///
+/// Instead of spawning directly, the runner hands back the assembled
+/// [`Command`] plus metadata so callers can log the chosen mechanism,
+/// inspect the resolved argv, etc.
+#[derive(Debug)]
+pub struct PreparedCommand {
+    pub cmd: Command,
+    /// Mechanism actually used (or `None` when the command runs unsandboxed).
+    /// Kept on the public surface so `/sandbox`, observability, and future
+    /// diagnostics can report the chosen back-end; not every call site
+    /// inspects it today.
+    #[allow(dead_code)]
+    pub mechanism: Option<Mechanism>,
+    /// Human-readable summary (e.g. "bubblewrap read-only" or "unsandboxed").
+    pub description: String,
+}
+
+/// Common interface implemented by each platform back-end.
+pub trait SandboxRunner: Send + Sync {
+    /// Wrap `inner` with this runner's isolation mechanism.
+    ///
+    /// `inner` is the already-built `tokio::process::Command` for the shell
+    /// invocation. Back-ends may mutate it (e.g. prepending `bwrap ...
+    /// --` arguments) and return a [`PreparedCommand`].
+    ///
+    /// Return [`SandboxError::PrimitiveUnavailable`] when the primitive is
+    /// missing and `policy.fail_if_unavailable=true`.
+    fn prepare(
+        &self,
+        inner: Command,
+        policy: &SandboxPolicy,
+        workdir: &std::path::Path,
+    ) -> Result<PreparedCommand, SandboxError>;
+}
+
+/// Build the appropriate runner for the current platform + policy state.
+///
+/// Returns `None` when the sandbox is disabled entirely (`mode=full` or
+/// `enabled=false`) so callers can short-circuit without pretending to
+/// sandbox.
+pub fn make_runner(policy: &SandboxPolicy) -> Option<Box<dyn SandboxRunner>> {
+    if !policy.is_active() {
+        return None;
+    }
+    match policy.availability.mechanism() {
+        Some(Mechanism::Bubblewrap) => Some(Box::new(BubblewrapRunner)),
+        Some(Mechanism::Seatbelt) => Some(Box::new(SeatbeltRunner)),
+        Some(Mechanism::WindowsRestrictedToken) | None => Some(Box::new(UnsupportedRunner)),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bubblewrap runner (Linux / WSL2)
+// ---------------------------------------------------------------------------
+
+pub struct BubblewrapRunner;
+
+impl SandboxRunner for BubblewrapRunner {
+    fn prepare(
+        &self,
+        mut inner: Command,
+        policy: &SandboxPolicy,
+        workdir: &std::path::Path,
+    ) -> Result<PreparedCommand, SandboxError> {
+        let mechanism = Mechanism::Bubblewrap;
+        let write_ok = policy.mode.allows_writes();
+
+        // Extract everything we need from the inner command as owned data
+        // so we can construct the wrapped command without borrow conflicts.
+        let (program, args, envs, cwd) = extract_command_parts(&mut inner);
+
+        // Build the `bwrap` argv.
+        let mut bwrap_args: Vec<std::ffi::OsString> = Vec::new();
+        bwrap_args.push("--die-with-parent".into());
+        bwrap_args.push("--unshare-user-try".into());
+        bwrap_args.push("--unshare-ipc".into());
+        bwrap_args.push("--unshare-pid".into());
+        bwrap_args.push("--unshare-uts".into());
+        bwrap_args.push("--unshare-cgroup-try".into());
+        bwrap_args.push("--proc".into());
+        bwrap_args.push("/proc".into());
+        bwrap_args.push("--dev".into());
+        bwrap_args.push("/dev".into());
+        bwrap_args.push("--tmpfs".into());
+        bwrap_args.push("/tmp".into());
+
+        // Bind / read-only — broad read access, matching the spec default.
+        bwrap_args.push("--ro-bind".into());
+        bwrap_args.push("/".into());
+        bwrap_args.push("/".into());
+
+        // Bind workspace RW (or read-only when mode is ReadOnly)
+        let bind_flag: std::ffi::OsString = if write_ok {
+            "--bind".into()
+        } else {
+            "--ro-bind".into()
+        };
+        bwrap_args.push(bind_flag.clone());
+        bwrap_args.push(workdir.as_os_str().to_os_string());
+        bwrap_args.push(workdir.as_os_str().to_os_string());
+
+        // Extra workspaces (always RW when write_ok).
+        for extra in policy.paths.extra_workspaces() {
+            bwrap_args.push(bind_flag.clone());
+            bwrap_args.push(extra.as_os_str().to_os_string());
+            bwrap_args.push(extra.as_os_str().to_os_string());
+        }
+
+        // Additional allowWrite paths get RW bind mounts when write_ok.
+        if write_ok {
+            for p in policy.paths.allow_write_paths() {
+                bwrap_args.push("--bind-try".into());
+                bwrap_args.push(p.as_os_str().to_os_string());
+                bwrap_args.push(p.as_os_str().to_os_string());
+            }
+        }
+
+        // Block network access when disabled.
+        if policy.network.disabled {
+            bwrap_args.push("--unshare-net".into());
+        }
+
+        // Mount denyWrite paths as read-only *overlays* if they exist.
+        for p in policy.paths.deny_write_paths() {
+            bwrap_args.push("--ro-bind-try".into());
+            bwrap_args.push(p.as_os_str().to_os_string());
+            bwrap_args.push(p.as_os_str().to_os_string());
+        }
+
+        // Chdir to the workspace inside the sandbox.
+        bwrap_args.push("--chdir".into());
+        bwrap_args.push(workdir.as_os_str().to_os_string());
+
+        // End of bwrap flags — the command to run follows.
+        bwrap_args.push("--".into());
+        bwrap_args.push(program);
+        bwrap_args.extend(args);
+
+        // Swap the command: run bwrap with our new argv, keeping env/stdio.
+        let mut wrapped = Command::new("bwrap");
+        wrapped.args(&bwrap_args);
+        apply_envs(&mut wrapped, &envs);
+        if let Some(dir) = cwd.as_deref() {
+            wrapped.current_dir(dir);
+        }
+
+        let description = format!(
+            "bubblewrap {} (workdir={})",
+            policy.mode.as_str(),
+            workdir.display()
+        );
+        Ok(PreparedCommand {
+            cmd: wrapped,
+            mechanism: Some(mechanism),
+            description,
+        })
+    }
+}
+
+/// Extract the program, args, envs, and current_dir from a `tokio::process::Command`
+/// as owned data so the caller can rebuild it.
+fn extract_command_parts(
+    inner: &mut Command,
+) -> (
+    std::ffi::OsString,
+    Vec<std::ffi::OsString>,
+    Vec<(std::ffi::OsString, Option<std::ffi::OsString>)>,
+    Option<std::path::PathBuf>,
+) {
+    let std_inner = inner.as_std();
+    let program = std_inner.get_program().to_os_string();
+    let args: Vec<std::ffi::OsString> = std_inner.get_args().map(|a| a.to_os_string()).collect();
+    let envs: Vec<(std::ffi::OsString, Option<std::ffi::OsString>)> = std_inner
+        .get_envs()
+        .map(|(k, v)| (k.to_os_string(), v.map(|val| val.to_os_string())))
+        .collect();
+    let cwd = std_inner.get_current_dir().map(|d| d.to_path_buf());
+    (program, args, envs, cwd)
+}
+
+fn apply_envs(
+    cmd: &mut Command,
+    envs: &[(std::ffi::OsString, Option<std::ffi::OsString>)],
+) {
+    for (k, v) in envs {
+        match v {
+            Some(val) => {
+                cmd.env(k, val);
+            }
+            None => {
+                cmd.env_remove(k);
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Seatbelt runner (macOS)
+// ---------------------------------------------------------------------------
+
+pub struct SeatbeltRunner;
+
+impl SandboxRunner for SeatbeltRunner {
+    fn prepare(
+        &self,
+        mut inner: Command,
+        policy: &SandboxPolicy,
+        workdir: &std::path::Path,
+    ) -> Result<PreparedCommand, SandboxError> {
+        let mechanism = Mechanism::Seatbelt;
+        let profile = build_seatbelt_profile(policy, workdir);
+
+        let (program, args, envs, cwd) = extract_command_parts(&mut inner);
+
+        let mut wrapped = Command::new("/usr/bin/sandbox-exec");
+        wrapped.arg("-p").arg(&profile).arg(&program);
+        wrapped.args(&args);
+        apply_envs(&mut wrapped, &envs);
+        if let Some(dir) = cwd.as_deref() {
+            wrapped.current_dir(dir);
+        }
+
+        let description = format!(
+            "sandbox-exec {} (workdir={})",
+            policy.mode.as_str(),
+            workdir.display()
+        );
+        Ok(PreparedCommand {
+            cmd: wrapped,
+            mechanism: Some(mechanism),
+            description,
+        })
+    }
+}
+
+fn build_seatbelt_profile(policy: &SandboxPolicy, workdir: &std::path::Path) -> String {
+    let mut s = String::from("(version 1)\n(deny default)\n");
+    // Process basics
+    s.push_str("(allow process-exec)\n(allow process-fork)\n");
+    s.push_str("(allow signal (target same-sandbox))\n");
+    // Broad read access
+    s.push_str("(allow file-read*)\n");
+    // Always allow reading workdir
+    s.push_str(&format!(
+        "(allow file-read* (subpath \"{}\"))\n",
+        workdir.display()
+    ));
+    if policy.mode.allows_writes() {
+        // Workspace writes
+        s.push_str(&format!(
+            "(allow file-write* (subpath \"{}\"))\n",
+            workdir.display()
+        ));
+        for extra in policy.paths.extra_workspaces() {
+            s.push_str(&format!(
+                "(allow file-write* (subpath \"{}\"))\n",
+                extra.display()
+            ));
+        }
+        for p in policy.paths.allow_write_paths() {
+            s.push_str(&format!(
+                "(allow file-write* (subpath \"{}\"))\n",
+                p.display()
+            ));
+        }
+        // Temp + devnull are almost always needed for tooling
+        s.push_str("(allow file-write* (subpath \"/tmp\"))\n");
+        s.push_str("(allow file-write* (literal \"/dev/null\"))\n");
+    }
+    // Deny list always takes precedence when explicitly set
+    for p in policy.paths.deny_write_paths() {
+        s.push_str(&format!(
+            "(deny file-write* (subpath \"{}\"))\n",
+            p.display()
+        ));
+    }
+    for p in policy.paths.deny_read_paths() {
+        s.push_str(&format!(
+            "(deny file-read* (subpath \"{}\"))\n",
+            p.display()
+        ));
+    }
+    // Network
+    if policy.network.disabled {
+        s.push_str("(deny network*)\n");
+    } else {
+        s.push_str("(allow network*)\n");
+    }
+    s
+}
+
+// ---------------------------------------------------------------------------
+// Unsupported runner — no OS-level enforcement on this platform.
+// ---------------------------------------------------------------------------
+
+pub struct UnsupportedRunner;
+
+impl SandboxRunner for UnsupportedRunner {
+    fn prepare(
+        &self,
+        inner: Command,
+        policy: &SandboxPolicy,
+        workdir: &std::path::Path,
+    ) -> Result<PreparedCommand, SandboxError> {
+        if policy.fail_if_unavailable {
+            return Err(SandboxError::PrimitiveUnavailable {
+                platform: current_platform(),
+                detail: policy.availability.describe(),
+            });
+        }
+        let _ = workdir;
+        tracing::warn!(
+            platform = current_platform(),
+            "sandbox: OS-level primitive unavailable; falling back to \
+             unsandboxed execution. Rust-level policy checks still apply."
+        );
+        Ok(PreparedCommand {
+            cmd: inner,
+            mechanism: None,
+            description: format!(
+                "unsandboxed (warning: OS primitive unavailable on {})",
+                current_platform()
+            ),
+        })
+    }
+}
+
+fn current_platform() -> &'static str {
+    if cfg!(target_os = "linux") {
+        "linux"
+    } else if cfg!(target_os = "macos") {
+        "macos"
+    } else if cfg!(target_os = "windows") {
+        "windows"
+    } else {
+        "unknown"
+    }
+}
+
+/// Helper: build a [`SandboxPolicy`] from a snapshot of
+/// [`crate::types::app_state::AppState`] plus the session workspace.
+///
+/// Exposed so tools can re-derive the policy per call (permission rules
+/// may change mid-session).
+pub fn policy_from_app_state(
+    app_state: &crate::types::app_state::AppState,
+    workspace: PathBuf,
+    force_no_network: bool,
+) -> SandboxPolicy {
+    use super::policy::SandboxPolicyBuilder;
+
+    // Extract deny rules from the permission system for filesystem merging.
+    let mut deny_reads: Vec<String> = Vec::new();
+    let mut deny_writes: Vec<String> = Vec::new();
+    for deny_rules in app_state.tool_permission_context.always_deny_rules.values() {
+        for rule in deny_rules {
+            if let Some(path) = rule.strip_prefix("Read(").and_then(|s| s.strip_suffix(')')) {
+                deny_reads.push(path.to_string());
+            } else if let Some(path) = rule.strip_prefix("Edit(").and_then(|s| s.strip_suffix(')'))
+            {
+                deny_writes.push(path.to_string());
+            }
+        }
+    }
+
+    // Additional working directories from permissions are extra workspaces.
+    let extra_workspaces: Vec<PathBuf> = app_state
+        .tool_permission_context
+        .additional_working_directories
+        .values()
+        .filter(|dir| !dir.read_only)
+        .map(|dir| PathBuf::from(&dir.path))
+        .collect();
+
+    SandboxPolicyBuilder::new(workspace)
+        .settings(app_state.settings.sandbox.clone())
+        .no_network(force_no_network)
+        .extra_workspaces(extra_workspaces)
+        .permission_deny_reads(deny_reads)
+        .permission_deny_writes(deny_writes)
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inactive_policy_returns_no_runner() {
+        let policy = SandboxPolicy::default();
+        assert!(make_runner(&policy).is_none());
+    }
+
+    #[test]
+    fn unsupported_runner_warns_then_passes_through() {
+        let policy = SandboxPolicy::default();
+        let runner = UnsupportedRunner;
+        let inner = Command::new("echo");
+        let prepared = runner
+            .prepare(inner, &policy, std::path::Path::new("/tmp"))
+            .expect("no fail_if_unavailable → pass-through");
+        assert!(prepared.mechanism.is_none());
+        assert!(prepared.description.contains("unsandboxed"));
+    }
+
+    #[test]
+    fn unsupported_runner_hard_fails_when_configured() {
+        use super::super::policy::SandboxPolicyBuilder;
+        use crate::config::settings::SandboxSettings;
+        let policy = SandboxPolicyBuilder::new(std::path::PathBuf::from("/tmp"))
+            .settings(SandboxSettings {
+                enabled: Some(true),
+                fail_if_unavailable: Some(true),
+                ..Default::default()
+            })
+            .build();
+        let runner = UnsupportedRunner;
+        let inner = Command::new("echo");
+        let err = runner
+            .prepare(inner, &policy, std::path::Path::new("/tmp"))
+            .expect_err("fail_if_unavailable → hard fail");
+        assert!(matches!(err, SandboxError::PrimitiveUnavailable { .. }));
+    }
+
+    #[test]
+    fn seatbelt_profile_includes_workdir() {
+        use super::super::policy::SandboxPolicyBuilder;
+        use crate::config::settings::SandboxSettings;
+        let policy = SandboxPolicyBuilder::new(std::path::PathBuf::from("/proj"))
+            .settings(SandboxSettings {
+                enabled: Some(true),
+                ..Default::default()
+            })
+            .build();
+        let profile = build_seatbelt_profile(&policy, std::path::Path::new("/proj"));
+        assert!(profile.contains("(version 1)"));
+        assert!(profile.contains("/proj"));
+    }
+
+    #[test]
+    fn seatbelt_profile_denies_network_when_disabled() {
+        use super::super::policy::SandboxPolicyBuilder;
+        use crate::config::settings::{SandboxNetworkSettings, SandboxSettings};
+        let policy = SandboxPolicyBuilder::new(std::path::PathBuf::from("/proj"))
+            .settings(SandboxSettings {
+                enabled: Some(true),
+                network: SandboxNetworkSettings {
+                    disabled: Some(true),
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .build();
+        let profile = build_seatbelt_profile(&policy, std::path::Path::new("/proj"));
+        assert!(profile.contains("(deny network*)"));
+    }
+
+    #[test]
+    fn policy_from_app_state_picks_up_deny_rules() {
+        use crate::types::app_state::AppState;
+        use std::collections::HashMap;
+
+        let mut app_state = AppState::default();
+        let mut rules = HashMap::new();
+        rules.insert(
+            "Edit".to_string(),
+            vec!["Edit(/etc/passwd)".to_string(), "Read(~/.ssh)".to_string()],
+        );
+        app_state.tool_permission_context.always_deny_rules = rules;
+
+        let policy = policy_from_app_state(&app_state, std::path::PathBuf::from("/proj"), false);
+        // Deny-write should have /etc/passwd
+        let writes = policy.paths.deny_write_paths();
+        assert!(writes.iter().any(|p| p.ends_with("passwd")));
+    }
+}

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -4,6 +4,7 @@ use serde_json::{json, Value};
 use tokio::process::Command;
 
 use crate::permissions::dangerous::is_dangerous_command;
+use crate::sandbox::{make_runner, policy_from_app_state};
 use crate::types::message::AssistantMessage;
 use crate::types::tool::{
     InterruptBehavior, PermissionResult, Tool, ToolProgress, ToolResult, ToolUseContext,
@@ -211,6 +212,20 @@ impl Tool for BashTool {
             }
         }
 
+        // Sandbox escape-hatch gate: when the caller passed
+        // `dangerouslyDisableSandbox: true` but settings forbid it, deny.
+        let wants_escape = input
+            .get("dangerouslyDisableSandbox")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if wants_escape && !app_state.settings.sandbox.allow_unsandboxed_commands.unwrap_or(true) {
+            return PermissionResult::Deny {
+                message: "sandbox.allowUnsandboxedCommands=false rejects \
+                          dangerouslyDisableSandbox"
+                    .to_string(),
+            };
+        }
+
         PermissionResult::Allow {
             updated_input: input.clone(),
         }
@@ -219,7 +234,7 @@ impl Tool for BashTool {
     async fn call(
         &self,
         input: Value,
-        _ctx: &ToolUseContext,
+        ctx: &ToolUseContext,
         _parent_message: &AssistantMessage,
         _on_progress: Option<Box<dyn Fn(ToolProgress) + Send + Sync>>,
     ) -> Result<ToolResult> {
@@ -259,9 +274,66 @@ impl Tool for BashTool {
             cmd.env(&k, &v);
         }
 
-        // Capture stdout and stderr
-        cmd.stdout(std::process::Stdio::piped());
-        cmd.stderr(std::process::Stdio::piped());
+        // Sandbox integration. Build the effective policy from the current
+        // AppState + cwd and wrap the command when the sandbox is active.
+        // The `dangerouslyDisableSandbox` escape hatch (already gated by
+        // check_permissions) bypasses wrapping but still records a warning.
+        let escape = input
+            .get("dangerouslyDisableSandbox")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let app_state_arc = (ctx.get_app_state)();
+        let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        let policy =
+            policy_from_app_state(&app_state_arc, cwd.clone(), false);
+
+        // Excluded-commands check: if the command matches, short-circuit the
+        // sandbox wrapping (runs in the host) unless unsandboxed is forbidden.
+        let is_excluded = policy.is_excluded_command(&command);
+        if is_excluded && !policy.allow_unsandboxed_commands {
+            return Ok(ToolResult {
+                data: json!({
+                    "error": crate::sandbox::SandboxError::EscapeHatchDisabled {
+                        command: command.clone()
+                    }
+                    .to_string(),
+                    "sandbox_blocked": true,
+                }),
+                new_messages: vec![],
+                ..Default::default()
+            });
+        }
+
+        let mut sandbox_description = String::from("unsandboxed");
+        if !escape && !is_excluded {
+            if let Some(runner) = make_runner(&policy) {
+                match runner.prepare(cmd, &policy, &cwd) {
+                    Ok(prepared) => {
+                        sandbox_description = prepared.description;
+                        cmd = prepared.cmd;
+                        // Piped stdio must be re-applied because the wrapper command
+                        // is freshly constructed.
+                        cmd.stdout(std::process::Stdio::piped());
+                        cmd.stderr(std::process::Stdio::piped());
+                    }
+                    Err(e) => {
+                        return Ok(ToolResult {
+                            data: json!({
+                                "error": e.to_string(),
+                                "sandbox_blocked": true,
+                            }),
+                            new_messages: vec![],
+                            ..Default::default()
+                        });
+                    }
+                }
+            }
+        } else {
+            // Capture stdout and stderr on the unwrapped command.
+            cmd.stdout(std::process::Stdio::piped());
+            cmd.stderr(std::process::Stdio::piped());
+        }
+        tracing::debug!(sandbox = %sandbox_description, "bash tool exec");
 
         let timeout_duration = resolve_timeout(timeout_ms);
 

--- a/src/tools/execution/pipeline.rs
+++ b/src/tools/execution/pipeline.rs
@@ -6,10 +6,28 @@ use std::time::Instant;
 use serde_json::Value;
 use tracing::{debug, warn};
 
-use crate::permissions::decision::{self, PermissionBehavior, PermissionDecision};
+use crate::permissions::decision::{
+    self, HookPermissionDecision, PermissionBehavior, PermissionDecision,
+};
 use crate::tools::hooks::{
     self, HookEventConfig, PermissionOverride, PostToolHookResult, PreToolHookResult,
 };
+
+/// Convert the legacy [`PermissionOverride`] (carried back by
+/// `run_pre_tool_hooks`) into the richer [`HookPermissionDecision`] the
+/// central decision flow expects.
+fn build_hook_decision(
+    o: Option<&PermissionOverride>,
+) -> Option<HookPermissionDecision> {
+    let o = o?;
+    let mut h = HookPermissionDecision::default();
+    h.source = Some("PreToolUse".into());
+    match o {
+        PermissionOverride::Allow => h.allow = true,
+        PermissionOverride::Deny { reason } => h.deny = Some(reason.clone()),
+    }
+    Some(h)
+}
 use crate::types::message::AssistantMessage;
 use crate::types::tool::{Tool, ToolProgress, ToolResult, ToolUseContext, Tools};
 
@@ -140,56 +158,82 @@ pub async fn run_tool_use(
     }
 
     // ── Stage 5: Permission check ───────────────────────────────────
-    // Resolve hook permission override first, then fall back to rule engine
-    if let Some(override_decision) = permission_override {
-        match override_decision {
-            PermissionOverride::Deny { reason } => {
-                return make_error_result(
-                    tool_use_id,
-                    tool_name,
-                    &format!("Permission denied by hook: {}", reason),
-                    started,
-                );
-            }
-            PermissionOverride::Allow => {
-                // Hook explicitly allowed — skip normal permission check
-                debug!(tool = tool_name, "permission allowed by hook override");
-            }
+    // Build a `HookPermissionDecision` from the pre-tool hook output and
+    // route everything (rules + hook + mode) through the central
+    // decision flow so deny / ask still beat hook allow per spec.
+    let hook_decision = build_hook_decision(permission_override.as_ref());
+
+    // The tool may still expose its own per-tool checks (e.g. dangerous
+    // command detection in Bash). Run them first so a deny from the tool
+    // wins over the hook's allow.
+    match tool.check_permissions(&effective_input, ctx).await {
+        crate::types::tool::PermissionResult::Deny { message } => {
+            return make_error_result(
+                tool_use_id,
+                tool_name,
+                &format!("Permission denied: {}", message),
+                started,
+            );
         }
-    } else {
-        // Normal permission check via the rule engine
-        let perm_result = tool.check_permissions(&effective_input, ctx).await;
-        match perm_result {
-            crate::types::tool::PermissionResult::Allow { .. } => {
-                // Allowed
-            }
-            crate::types::tool::PermissionResult::Deny { message } => {
+        crate::types::tool::PermissionResult::Allow { .. }
+        | crate::types::tool::PermissionResult::Ask { .. } => {
+            // Continue to the central flow.
+        }
+    }
+
+    let app_state = (ctx.get_app_state)();
+    let central_decision = decision::has_permissions_to_use_tool_with_hook(
+        tool_name,
+        &effective_input,
+        &app_state.tool_permission_context,
+        hook_decision.as_ref(),
+        None,
+    );
+
+    let effective_input = central_decision
+        .updated_input
+        .clone()
+        .unwrap_or(effective_input);
+
+    match central_decision.behavior {
+        PermissionBehavior::Allow => {
+            debug!(
+                tool = tool_name,
+                reason = ?central_decision.reason,
+                "permission allowed"
+            );
+        }
+        PermissionBehavior::Deny => {
+            return make_error_result(
+                tool_use_id,
+                tool_name,
+                &format!(
+                    "Permission denied: {}",
+                    central_decision
+                        .message
+                        .unwrap_or_else(|| "policy".into())
+                ),
+                started,
+            );
+        }
+        PermissionBehavior::Ask => {
+            let message = central_decision
+                .message
+                .unwrap_or_else(|| format!("Allow tool '{}'?", tool_name));
+            if ctx.options.is_non_interactive_session {
                 return make_error_result(
                     tool_use_id,
                     tool_name,
-                    &format!("Permission denied: {}", message),
+                    &format!("Permission required (non-interactive mode): {}", message),
                     started,
                 );
             }
-            crate::types::tool::PermissionResult::Ask { message } => {
-                // In non-interactive mode, deny with explanation
-                if ctx.options.is_non_interactive_session {
-                    return make_error_result(
-                        tool_use_id,
-                        tool_name,
-                        &format!("Permission required (non-interactive mode): {}", message),
-                        started,
-                    );
-                }
-                // In interactive mode, this would prompt the user.
-                // Phase 1: deny with explanation.
-                return make_error_result(
-                    tool_use_id,
-                    tool_name,
-                    &format!("Permission required: {}", message),
-                    started,
-                );
-            }
+            return make_error_result(
+                tool_use_id,
+                tool_name,
+                &format!("Permission required: {}", message),
+                started,
+            );
         }
     }
 

--- a/src/tools/execution/pipeline.rs
+++ b/src/tools/execution/pipeline.rs
@@ -16,9 +16,7 @@ use crate::tools::hooks::{
 /// Convert the legacy [`PermissionOverride`] (carried back by
 /// `run_pre_tool_hooks`) into the richer [`HookPermissionDecision`] the
 /// central decision flow expects.
-fn build_hook_decision(
-    o: Option<&PermissionOverride>,
-) -> Option<HookPermissionDecision> {
+fn build_hook_decision(o: Option<&PermissionOverride>) -> Option<HookPermissionDecision> {
     let o = o?;
     let mut h = HookPermissionDecision::default();
     h.source = Some("PreToolUse".into());
@@ -164,8 +162,9 @@ pub async fn run_tool_use(
     let hook_decision = build_hook_decision(permission_override.as_ref());
 
     // The tool may still expose its own per-tool checks (e.g. dangerous
-    // command detection in Bash). Run them first so a deny from the tool
-    // wins over the hook's allow.
+    // command detection in Bash). Run them first so tool-local deny/ask
+    // decisions cannot be bypassed by hook overrides, broad allow rules,
+    // or permissive modes.
     match tool.check_permissions(&effective_input, ctx).await {
         crate::types::tool::PermissionResult::Deny { message } => {
             return make_error_result(
@@ -175,8 +174,23 @@ pub async fn run_tool_use(
                 started,
             );
         }
-        crate::types::tool::PermissionResult::Allow { .. }
-        | crate::types::tool::PermissionResult::Ask { .. } => {
+        crate::types::tool::PermissionResult::Ask { message } => {
+            if ctx.options.is_non_interactive_session {
+                return make_error_result(
+                    tool_use_id,
+                    tool_name,
+                    &format!("Permission required (non-interactive mode): {}", message),
+                    started,
+                );
+            }
+            return make_error_result(
+                tool_use_id,
+                tool_name,
+                &format!("Permission required: {}", message),
+                started,
+            );
+        }
+        crate::types::tool::PermissionResult::Allow { .. } => {
             // Continue to the central flow.
         }
     }
@@ -209,9 +223,7 @@ pub async fn run_tool_use(
                 tool_name,
                 &format!(
                     "Permission denied: {}",
-                    central_decision
-                        .message
-                        .unwrap_or_else(|| "policy".into())
+                    central_decision.message.unwrap_or_else(|| "policy".into())
                 ),
                 started,
             );
@@ -372,9 +384,124 @@ pub async fn run_tool_use(
 
 #[cfg(test)]
 mod tests {
-    use super::super::{make_error_result, ToolExecutionResult};
+    use super::super::make_error_result;
     use super::*;
+    use crate::types::app_state::AppState;
+    use crate::types::message::AssistantMessage;
+    use crate::types::tool::{
+        FileStateCache, PermissionMode, PermissionResult, ToolUseOptions, ValidationResult,
+    };
+    use async_trait::async_trait;
+    use serde_json::json;
+    use std::sync::{Arc, RwLock};
     use std::time::Instant;
+    use uuid::Uuid;
+
+    struct AskTool;
+
+    #[async_trait]
+    impl Tool for AskTool {
+        fn name(&self) -> &str {
+            "AskTool"
+        }
+
+        async fn description(&self, _input: &Value) -> String {
+            "Test tool that always requests confirmation.".into()
+        }
+
+        fn input_json_schema(&self) -> Value {
+            json!({
+                "type": "object",
+                "additionalProperties": false
+            })
+        }
+
+        fn is_concurrency_safe(&self, _input: &Value) -> bool {
+            true
+        }
+
+        fn is_read_only(&self, _input: &Value) -> bool {
+            true
+        }
+
+        async fn validate_input(&self, _input: &Value, _ctx: &ToolUseContext) -> ValidationResult {
+            ValidationResult::Ok
+        }
+
+        async fn check_permissions(
+            &self,
+            _input: &Value,
+            _ctx: &ToolUseContext,
+        ) -> PermissionResult {
+            PermissionResult::Ask {
+                message: "tool-local confirmation".into(),
+            }
+        }
+
+        async fn call(
+            &self,
+            _input: Value,
+            _ctx: &ToolUseContext,
+            _parent_message: &AssistantMessage,
+            _on_progress: Option<Box<dyn Fn(ToolProgress) + Send + Sync>>,
+        ) -> anyhow::Result<ToolResult> {
+            Ok(ToolResult {
+                data: Value::String("executed".into()),
+                ..Default::default()
+            })
+        }
+
+        async fn prompt(&self) -> String {
+            "Ask tool prompt".into()
+        }
+    }
+
+    fn make_ctx(state: Arc<RwLock<AppState>>, is_non_interactive_session: bool) -> ToolUseContext {
+        let state_reader = Arc::clone(&state);
+        let state_writer = Arc::clone(&state);
+        let (_tx, rx) = tokio::sync::watch::channel(false);
+
+        ToolUseContext {
+            options: ToolUseOptions {
+                debug: false,
+                main_loop_model: "test-model".to_string(),
+                verbose: false,
+                is_non_interactive_session,
+                custom_system_prompt: None,
+                append_system_prompt: None,
+                max_budget_usd: None,
+            },
+            abort_signal: rx,
+            read_file_state: FileStateCache::default(),
+            get_app_state: Arc::new(move || state_reader.read().unwrap().clone()),
+            set_app_state: Arc::new(move |update| {
+                let current = state_writer.read().unwrap().clone();
+                let next = update(current);
+                *state_writer.write().unwrap() = next;
+            }),
+            messages: vec![],
+            agent_id: None,
+            agent_type: None,
+            query_tracking: None,
+            permission_callback: None,
+            ask_user_callback: None,
+            bg_agent_tx: None,
+        }
+    }
+
+    fn dummy_parent() -> AssistantMessage {
+        AssistantMessage {
+            uuid: Uuid::new_v4(),
+            timestamp: chrono::Utc::now().timestamp_millis(),
+            role: "assistant".to_string(),
+            content: vec![],
+            usage: None,
+            stop_reason: None,
+            is_api_error_message: false,
+            api_error: None,
+            cost_usd: 0.0,
+        }
+    }
 
     /// Verify that `make_error_result` (the shared early-exit helper used by
     /// every pipeline stage) produces a correctly structured error result.
@@ -414,5 +541,32 @@ mod tests {
         // Referencing the async fn without calling it confirms it is in scope.
         // We use size_of_val on a ZST to avoid an invalid cast.
         let _ = std::mem::size_of_val(&run_tool_use);
+    }
+
+    #[tokio::test]
+    async fn tool_local_ask_is_not_bypassed_by_permission_mode() {
+        let mut app_state = AppState::default();
+        app_state.tool_permission_context.mode = PermissionMode::Bypass;
+        let state = Arc::new(RwLock::new(app_state));
+        let ctx = make_ctx(state, false);
+        let tools: Tools = vec![Arc::new(AskTool)];
+
+        let result = run_tool_use(
+            "tool-use-1",
+            "AskTool",
+            json!({}),
+            &tools,
+            &ctx,
+            &dummy_parent(),
+            None,
+            &[],
+        )
+        .await;
+
+        assert!(result.is_error, "tool-local Ask should stop execution");
+        assert_eq!(
+            result.result.data.as_str(),
+            Some("Permission required: tool-local confirmation")
+        );
     }
 }

--- a/src/tools/powershell.rs
+++ b/src/tools/powershell.rs
@@ -8,6 +8,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use serde_json::{json, Value};
 
+use crate::sandbox::{make_runner, policy_from_app_state};
 use crate::types::message::AssistantMessage;
 use crate::types::tool::{
     InterruptBehavior, PermissionResult, Tool, ToolProgress, ToolResult, ToolUseContext,
@@ -116,7 +117,27 @@ impl Tool for PowerShellTool {
         ValidationResult::Ok
     }
 
-    async fn check_permissions(&self, input: &Value, _ctx: &ToolUseContext) -> PermissionResult {
+    async fn check_permissions(&self, input: &Value, ctx: &ToolUseContext) -> PermissionResult {
+        // Sandbox escape-hatch gate: same rule as BashTool.
+        let wants_escape = input
+            .get("dangerouslyDisableSandbox")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if wants_escape {
+            let app_state = (ctx.get_app_state)();
+            if !app_state
+                .settings
+                .sandbox
+                .allow_unsandboxed_commands
+                .unwrap_or(true)
+            {
+                return PermissionResult::Deny {
+                    message: "sandbox.allowUnsandboxedCommands=false rejects \
+                              dangerouslyDisableSandbox"
+                        .to_string(),
+                };
+            }
+        }
         PermissionResult::Allow {
             updated_input: input.clone(),
         }
@@ -125,7 +146,7 @@ impl Tool for PowerShellTool {
     async fn call(
         &self,
         input: Value,
-        _ctx: &ToolUseContext,
+        ctx: &ToolUseContext,
         _parent_message: &AssistantMessage,
         _on_progress: Option<Box<dyn Fn(ToolProgress) + Send + Sync>>,
     ) -> Result<ToolResult> {
@@ -151,8 +172,56 @@ impl Tool for PowerShellTool {
             cmd.env(&k, &v);
         }
 
-        cmd.stdout(std::process::Stdio::piped());
-        cmd.stderr(std::process::Stdio::piped());
+        // Sandbox integration — same flow as BashTool.
+        let escape = input
+            .get("dangerouslyDisableSandbox")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let app_state_arc = (ctx.get_app_state)();
+        let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        let policy = policy_from_app_state(&app_state_arc, cwd.clone(), false);
+        let is_excluded = policy.is_excluded_command(&command);
+        if is_excluded && !policy.allow_unsandboxed_commands {
+            return Ok(ToolResult {
+                data: json!({
+                    "error": crate::sandbox::SandboxError::EscapeHatchDisabled {
+                        command: command.clone()
+                    }
+                    .to_string(),
+                    "sandbox_blocked": true,
+                }),
+                new_messages: vec![],
+                ..Default::default()
+            });
+        }
+
+        if !escape && !is_excluded {
+            if let Some(runner) = make_runner(&policy) {
+                match runner.prepare(cmd, &policy, &cwd) {
+                    Ok(prepared) => {
+                        cmd = prepared.cmd;
+                        cmd.stdout(std::process::Stdio::piped());
+                        cmd.stderr(std::process::Stdio::piped());
+                    }
+                    Err(e) => {
+                        return Ok(ToolResult {
+                            data: json!({
+                                "error": e.to_string(),
+                                "sandbox_blocked": true,
+                            }),
+                            new_messages: vec![],
+                            ..Default::default()
+                        });
+                    }
+                }
+            } else {
+                cmd.stdout(std::process::Stdio::piped());
+                cmd.stderr(std::process::Stdio::piped());
+            }
+        } else {
+            cmd.stdout(std::process::Stdio::piped());
+            cmd.stderr(std::process::Stdio::piped());
+        }
 
         let timeout_duration = resolve_timeout(Some(timeout_ms));
 

--- a/src/tools/web_fetch.rs
+++ b/src/tools/web_fetch.rs
@@ -17,6 +17,7 @@ use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use serde_json::{json, Value};
 
+use crate::sandbox::{policy_from_app_state, NetworkDecision};
 use crate::types::message::AssistantMessage;
 use crate::types::tool::*;
 
@@ -276,7 +277,7 @@ impl Tool for WebFetchTool {
     async fn call(
         &self,
         input: Value,
-        _ctx: &ToolUseContext,
+        ctx: &ToolUseContext,
         _parent: &AssistantMessage,
         _on_progress: Option<Box<dyn Fn(ToolProgress) + Send + Sync>>,
     ) -> Result<ToolResult> {
@@ -284,6 +285,24 @@ impl Tool for WebFetchTool {
         let _prompt = input.get("prompt").and_then(|v| v.as_str()).unwrap_or("");
 
         let url = normalise_url(raw_url)?;
+
+        // Sandbox network policy check (runs before the cache so that a
+        // configuration change is noticed immediately rather than returning
+        // stale-but-allowed content).
+        let app_state = (ctx.get_app_state)();
+        let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        let policy = policy_from_app_state(&app_state, cwd, false);
+        if let NetworkDecision::Denied(err) = policy.network.check_url(&url) {
+            return Ok(ToolResult {
+                data: json!({
+                    "url": url,
+                    "error": err.to_string(),
+                    "sandbox_blocked": true,
+                }),
+                new_messages: vec![],
+                ..Default::default()
+            });
+        }
 
         // Check cache first
         if let Some((cached, status)) = cache_get(&url) {

--- a/src/types/app_state.rs
+++ b/src/types/app_state.rs
@@ -41,14 +41,48 @@ pub struct AppState {
     pub terminal_focus: bool,
 }
 
-/// 设置 JSON (简化版)
+/// 设置 JSON (运行时投影)
+///
+/// 这是 [`crate::config::settings::EffectiveSettings`] 的运行时镜像 ——
+/// 启动路径在 `main.rs` 用合并后的 effective settings 填充本结构,
+/// 命令(如 `/config set`) 写回这里, 序列化时再回到 RawSettings。
 #[derive(Debug, Clone, Default)]
 pub struct SettingsJson {
+    // -- Core identity --------------------------------------------------
     pub model: Option<String>,
     pub backend: Option<String>,
     pub theme: Option<String>,
     pub verbose: Option<bool>,
-    // 后续添加更多设置字段
+
+    // -- Permissions / sandbox -----------------------------------------
+    pub permission_mode: Option<String>,
+    pub permissions: crate::config::settings::PermissionsSettings,
+    pub sandbox: crate::config::settings::SandboxSettings,
+
+    // -- UI / UX --------------------------------------------------------
+    pub status_line: crate::config::settings::StatusLineSettings,
+    pub spinner_tips: crate::config::settings::SpinnerTipsSettings,
+    pub output_style: Option<String>,
+    pub language: Option<String>,
+    pub voice_enabled: Option<bool>,
+    pub editor_mode: Option<String>,
+    pub view_mode: Option<String>,
+    pub terminal_progress_bar_enabled: Option<bool>,
+
+    // -- Models / effort -----------------------------------------------
+    pub available_models: Vec<String>,
+    pub effort_level: Option<String>,
+    pub fast_mode: Option<bool>,
+    pub fast_mode_per_session_opt_in: Option<bool>,
+
+    // -- Modes / integrations ------------------------------------------
+    pub teammate_mode: Option<bool>,
+    pub claude_in_chrome_default_enabled: Option<bool>,
+
+    // -- Per-key source (provenance) -----------------------------------
+    /// 来源映射: key -> 哪个 layer 提供了该值。由启动路径 + `/config set`
+    /// 在写入对应键时一并更新。`/config show` 读取此 map 显示来源信息。
+    pub sources: crate::config::settings::SourceMap,
 }
 
 impl Default for AppState {

--- a/src/types/tool.rs
+++ b/src/types/tool.rs
@@ -85,6 +85,8 @@ pub struct ToolProgress {
 }
 
 /// 权限模式
+///
+/// 对齐 docs/claude-code-configuration/permissions.md 中描述的 6 种模式。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PermissionMode {
     /// 默认/询问模式: 需要用户确认
@@ -95,6 +97,41 @@ pub enum PermissionMode {
     Bypass,
     /// 计划模式: 只读, 不执行写入
     Plan,
+    /// AcceptEdits: 文件编辑工具 (Write/Edit/MultiEdit) 与常用工作区
+    /// 文件系统命令默认允许; 其它工具仍走默认询问流程。
+    AcceptEdits,
+    /// DontAsk: 对所有需要询问的请求静默 deny。常用于 headless / CI
+    /// 场景, 避免阻塞。`deny` 规则仍优先生效。
+    DontAsk,
+}
+
+impl PermissionMode {
+    /// Parse a mode string. Accepts both kebab-case and camelCase tokens
+    /// from the permissions docs as well as the legacy lower-case forms.
+    /// Unknown / empty values fall back to [`PermissionMode::Default`].
+    pub fn parse(value: &str) -> PermissionMode {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "auto" => PermissionMode::Auto,
+            "bypass" | "bypasspermissions" | "bypass-permissions" => PermissionMode::Bypass,
+            "plan" | "readonly" | "read-only" => PermissionMode::Plan,
+            "acceptedits" | "accept-edits" | "accept_edits" => PermissionMode::AcceptEdits,
+            "dontask" | "dont-ask" | "dont_ask" | "no-ask" => PermissionMode::DontAsk,
+            _ => PermissionMode::Default,
+        }
+    }
+
+    /// Stable lower-case identifier (camelCase) used for source-map tagging
+    /// and `/permissions show` output.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PermissionMode::Default => "default",
+            PermissionMode::Auto => "auto",
+            PermissionMode::Bypass => "bypass",
+            PermissionMode::Plan => "plan",
+            PermissionMode::AcceptEdits => "acceptEdits",
+            PermissionMode::DontAsk => "dontAsk",
+        }
+    }
 }
 
 /// 工具权限上下文

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -170,12 +170,7 @@ pub async fn abort_handler(
 /// GET /api/state -- Return current application state (enhanced for Phase 3).
 pub async fn state_handler(State(state): State<WebState>) -> impl IntoResponse {
     let app_state = state.engine.app_state();
-    let permission_mode = match app_state.tool_permission_context.mode {
-        PermissionMode::Default => "default",
-        PermissionMode::Auto => "auto",
-        PermissionMode::Bypass => "bypass",
-        PermissionMode::Plan => "plan",
-    };
+    let permission_mode = app_state.tool_permission_context.mode.as_str();
 
     // Get tool names from engine
     let tool_names: Vec<String> = state.engine.tool_names();

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -2,12 +2,7 @@
 
 use std::sync::atomic::Ordering;
 
-use axum::{
-    extract::State,
-    http::StatusCode,
-    response::IntoResponse,
-    Json,
-};
+use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
@@ -317,9 +312,9 @@ pub async fn command_handler(
     info!(command = %req.command, args = %req.args, "POST /api/command");
 
     let commands = crate::commands::get_all_commands();
-    let cmd = commands.iter().find(|c| {
-        c.name == req.command || c.aliases.contains(&req.command)
-    });
+    let cmd = commands
+        .iter()
+        .find(|c| c.name == req.command || c.aliases.contains(&req.command));
 
     let cmd = match cmd {
         Some(c) => c,
@@ -357,45 +352,36 @@ pub async fn command_handler(
             });
 
             match result {
-                crate::commands::CommandResult::Output(text) => {
-                    Json(CommandResponse {
-                        response_type: "output".into(),
-                        content: text,
-                    })
-                }
-                crate::commands::CommandResult::Clear => {
-                    Json(CommandResponse {
-                        response_type: "clear".into(),
-                        content: "Conversation cleared".into(),
-                    })
-                }
-                crate::commands::CommandResult::Exit(msg) => {
-                    Json(CommandResponse {
-                        response_type: "output".into(),
-                        content: msg,
-                    })
-                }
+                crate::commands::CommandResult::Output(text) => Json(CommandResponse {
+                    response_type: "output".into(),
+                    content: text,
+                }),
+                crate::commands::CommandResult::Clear => Json(CommandResponse {
+                    response_type: "clear".into(),
+                    content: "Conversation cleared".into(),
+                }),
+                crate::commands::CommandResult::Exit(msg) => Json(CommandResponse {
+                    response_type: "output".into(),
+                    content: msg,
+                }),
                 crate::commands::CommandResult::Query(_msgs) => {
                     // TODO: inject messages and start a new SSE stream
                     Json(CommandResponse {
                         response_type: "output".into(),
-                        content: "Command queued (query commands not yet supported in web UI)".into(),
+                        content: "Command queued (query commands not yet supported in web UI)"
+                            .into(),
                     })
                 }
-                crate::commands::CommandResult::None => {
-                    Json(CommandResponse {
-                        response_type: "output".into(),
-                        content: "OK".into(),
-                    })
-                }
+                crate::commands::CommandResult::None => Json(CommandResponse {
+                    response_type: "output".into(),
+                    content: "OK".into(),
+                }),
             }
         }
-        Err(e) => {
-            Json(CommandResponse {
-                response_type: "error".into(),
-                content: format!("Command error: {}", e),
-            })
-        }
+        Err(e) => Json(CommandResponse {
+            response_type: "error".into(),
+            content: format!("Command error: {}", e),
+        }),
     }
 }
 

--- a/src/web/sse.rs
+++ b/src/web/sse.rs
@@ -14,9 +14,8 @@ pub fn sdk_stream_to_sse(
 ) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
     let sse_stream = stream.map(|msg| {
         let event_name = msg.event_name();
-        let data = serde_json::to_string(&msg).unwrap_or_else(|e| {
-            format!(r#"{{"error":"serialization failed: {}"}}"#, e)
-        });
+        let data = serde_json::to_string(&msg)
+            .unwrap_or_else(|e| format!(r#"{{"error":"serialization failed: {}"}}"#, e));
         Ok(Event::default().event(event_name).data(data))
     });
     Sse::new(sse_stream).keep_alive(

--- a/tests/e2e_browser_mcp.rs
+++ b/tests/e2e_browser_mcp.rs
@@ -77,11 +77,7 @@ fn dump_prompt_emits_browser_section_when_server_flagged() {
 
     let mut cmd = cli();
     strip_api_keys(&mut cmd)
-        .args([
-            "--dump-system-prompt",
-            "-C",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["--dump-system-prompt", "-C", dir.path().to_str().unwrap()])
         .env("CC_RUST_HOME", dir.path().to_str().unwrap())
         .assert()
         .success()
@@ -96,11 +92,7 @@ fn dump_prompt_has_no_browser_section_without_flagged_server() {
 
     let mut cmd = cli();
     strip_api_keys(&mut cmd)
-        .args([
-            "--dump-system-prompt",
-            "-C",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["--dump-system-prompt", "-C", dir.path().to_str().unwrap()])
         .env("CC_RUST_HOME", dir.path().to_str().unwrap())
         .assert()
         .success()

--- a/tests/e2e_chrome_mcp_bridge.rs
+++ b/tests/e2e_chrome_mcp_bridge.rs
@@ -57,16 +57,31 @@ fn bridge_initializes_before_native_host_exists() {
         .recv_timeout(Duration::from_secs(5))
         .expect("initialize response timeout")
         .expect("initialize response read failed");
-    assert!(init.contains(r#""jsonrpc":"2.0""#), "unexpected init: {init}");
-    assert!(init.contains(r#""claude-in-chrome""#), "unexpected init: {init}");
+    assert!(
+        init.contains(r#""jsonrpc":"2.0""#),
+        "unexpected init: {init}"
+    );
+    assert!(
+        init.contains(r#""claude-in-chrome""#),
+        "unexpected init: {init}"
+    );
 
-    send_json_line(&mut stdin, r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#);
+    send_json_line(
+        &mut stdin,
+        r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#,
+    );
     let tools = rx
         .recv_timeout(Duration::from_secs(5))
         .expect("tools/list response timeout")
         .expect("tools/list response read failed");
-    assert!(tools.contains(r#""tools""#), "unexpected tools/list: {tools}");
-    assert!(tools.contains(r#""navigate""#), "unexpected tools/list: {tools}");
+    assert!(
+        tools.contains(r#""tools""#),
+        "unexpected tools/list: {tools}"
+    );
+    assert!(
+        tools.contains(r#""navigate""#),
+        "unexpected tools/list: {tools}"
+    );
 
     drop(stdin);
     let exit = child.wait().expect("wait for bridge");

--- a/tests/e2e_chrome_native_host.rs
+++ b/tests/e2e_chrome_native_host.rs
@@ -92,8 +92,14 @@ fn ping_pong_round_trips_over_framed_stdio() {
     let deadline = Instant::now() + Duration::from_secs(5);
     let response = read_frame(&mut stdout, deadline).expect("read pong frame");
     let text = String::from_utf8(response).expect("utf8");
-    assert!(text.contains(r#""type":"pong""#), "unexpected response: {text}");
-    assert!(text.contains(r#""timestamp""#), "pong missing timestamp: {text}");
+    assert!(
+        text.contains(r#""type":"pong""#),
+        "unexpected response: {text}"
+    );
+    assert!(
+        text.contains(r#""timestamp""#),
+        "pong missing timestamp: {text}"
+    );
 
     // Close stdin; native host should exit cleanly.
     drop(stdin);
@@ -152,7 +158,10 @@ fn unknown_type_returns_error_message() {
     let deadline = Instant::now() + Duration::from_secs(5);
     let response = read_frame(&mut stdout, deadline).expect("read error frame");
     let text = String::from_utf8(response).expect("utf8");
-    assert!(text.contains(r#""type":"error""#), "unexpected response: {text}");
+    assert!(
+        text.contains(r#""type":"error""#),
+        "unexpected response: {text}"
+    );
 
     drop(stdin);
     let _ = child.wait();

--- a/tests/e2e_chrome_subsystem.rs
+++ b/tests/e2e_chrome_subsystem.rs
@@ -44,7 +44,12 @@ fn chrome_flag_is_accepted() {
     let dir = tempfile::tempdir().expect("tempdir");
     let mut cmd = cli();
     strip_api_keys(&mut cmd)
-        .args(["--chrome", "--init-only", "-C", dir.path().to_str().unwrap()])
+        .args([
+            "--chrome",
+            "--init-only",
+            "-C",
+            dir.path().to_str().unwrap(),
+        ])
         .env("CC_RUST_HOME", dir.path().to_str().unwrap())
         .assert()
         .success();
@@ -93,11 +98,7 @@ fn chrome_flag_emits_browser_automation_section() {
     let dir = tempfile::tempdir().expect("tempdir");
     let mut cmd = cli();
     strip_api_keys(&mut cmd)
-        .args([
-            "--dump-system-prompt",
-            "-C",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["--dump-system-prompt", "-C", dir.path().to_str().unwrap()])
         .env("CC_RUST_HOME", dir.path().to_str().unwrap())
         .env("CLAUDE_CODE_ENABLE_CFC", "1")
         .assert()
@@ -113,11 +114,7 @@ fn no_env_no_cli_no_browser_section() {
     let dir = tempfile::tempdir().expect("tempdir");
     let mut cmd = cli();
     strip_api_keys(&mut cmd)
-        .args([
-            "--dump-system-prompt",
-            "-C",
-            dir.path().to_str().unwrap(),
-        ])
+        .args(["--dump-system-prompt", "-C", dir.path().to_str().unwrap()])
         .env("CC_RUST_HOME", dir.path().to_str().unwrap())
         .assert()
         .success()

--- a/tests/e2e_permissions.rs
+++ b/tests/e2e_permissions.rs
@@ -1,0 +1,84 @@
+//! E2E tests for the permission system layered settings → context flow.
+//!
+//! The fine-grained matcher / mode / hook tests live inside
+//! `src/permissions/{rules,decision,bash_matcher}.rs`. This file exercises
+//! the cross-cutting behaviour you can only test by running the CLI
+//! binary against a real settings file:
+//!
+//! 1. Permission rules from `~/.cc-rust/settings.json` actually flow into
+//!    the runtime `ToolPermissionContext`.
+//! 2. The schema published in `docs/schemas/settings.schema.json`
+//!    describes the `permissions` object the way the loader expects.
+//!
+//! Run with: `cargo test --test e2e_permissions`
+
+use serde_json::json;
+use serial_test::serial;
+
+#[test]
+#[serial]
+fn permissions_from_user_settings_round_trip() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let user_settings = dir.path().join("settings.json");
+    let body = json!({
+        "permissions": {
+            "defaultMode": "acceptEdits",
+            "allow": ["Read", "Bash(prefix:git)"],
+            "deny": ["Bash(rm)"],
+            "ask": ["Bash(prefix:cargo publish)"],
+            "additionalDirectories": ["/tmp/extra"],
+            "enableBypassMode": false,
+            "enableAutoMode": true
+        }
+    });
+    std::fs::write(&user_settings, serde_json::to_string_pretty(&body).unwrap())
+        .expect("write user settings");
+
+    let project = tempfile::tempdir().expect("project tmpdir");
+
+    let mut cmd = assert_cmd::Command::cargo_bin("claude-code-rs").expect("binary not found");
+    cmd.env("CC_RUST_HOME", dir.path())
+        .env("ANTHROPIC_API_KEY", "")
+        .env("AZURE_API_KEY", "")
+        .env("OPENAI_API_KEY", "")
+        .env_remove("ANTHROPIC_AUTH_TOKEN")
+        .arg("--init-only")
+        .arg("--cwd")
+        .arg(project.path());
+    // We don't have an introspection flag for permission rules at the CLI
+    // level, but `--init-only` builds the `AppState` and exits — if any
+    // settings field name had drifted from the loader we would have
+    // failed to deserialize and the binary would have errored.
+    cmd.assert().success();
+}
+
+#[test]
+#[serial]
+fn schema_describes_permissions_subkeys() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("docs")
+        .join("schemas")
+        .join("settings.schema.json");
+    let txt = std::fs::read_to_string(&path).expect("schema present");
+    let v: serde_json::Value = serde_json::from_str(&txt).expect("schema is JSON");
+    let perms = v
+        .pointer("/properties/permissions/properties")
+        .and_then(|o| o.as_object())
+        .expect("schema has permissions.properties object");
+
+    for k in [
+        "defaultMode",
+        "allow",
+        "ask",
+        "deny",
+        "additionalDirectories",
+        "enableBypassMode",
+        "enableAutoMode",
+    ] {
+        assert!(
+            perms.contains_key(k),
+            "schema/permissions missing field {}",
+            k
+        );
+    }
+}

--- a/tests/e2e_sandbox.rs
+++ b/tests/e2e_sandbox.rs
@@ -1,0 +1,165 @@
+//! E2E tests for the sandbox subsystem (issue #8).
+//!
+//! This is a black-box suite — unit-level behavior (policy assembly, path
+//! matching, network allowlist, mode parsing) is covered by
+//! `#[cfg(test)]` blocks inside `src/sandbox/*.rs`. Here we verify:
+//!
+//! - the committed schema declares every public sandbox setting
+//! - the extended nested schema round-trips through the binary loader
+//! - the CLI `--no-network` flag is accepted without error
+//!
+//! Run with: `cargo test --test e2e_sandbox`
+
+use serde_json::json;
+use serial_test::serial;
+
+#[test]
+#[serial]
+fn schema_file_declares_extended_sandbox_shape() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("docs")
+        .join("schemas")
+        .join("settings.schema.json");
+    let txt = std::fs::read_to_string(&path).expect("schema file exists");
+    let v: serde_json::Value = serde_json::from_str(&txt).expect("valid JSON");
+    let props = v
+        .pointer("/properties/sandbox/properties")
+        .and_then(|p| p.as_object())
+        .expect("sandbox properties exist");
+    for must_have in [
+        "enabled",
+        "mode",
+        "failIfUnavailable",
+        "allowUnsandboxedCommands",
+        "allowManagedReadPathsOnly",
+        "allowManagedDomainsOnly",
+        "excludedCommands",
+        "allowedCommands",
+        "filesystem",
+        "network",
+    ] {
+        assert!(
+            props.contains_key(must_have),
+            "sandbox schema missing key '{}'",
+            must_have
+        );
+    }
+
+    // Check the nested shapes too.
+    let fs_props = v
+        .pointer("/properties/sandbox/properties/filesystem/properties")
+        .and_then(|p| p.as_object())
+        .expect("filesystem properties exist");
+    for must_have in ["allowRead", "denyRead", "allowWrite", "denyWrite"] {
+        assert!(
+            fs_props.contains_key(must_have),
+            "sandbox.filesystem schema missing key '{}'",
+            must_have
+        );
+    }
+
+    let net_props = v
+        .pointer("/properties/sandbox/properties/network/properties")
+        .and_then(|p| p.as_object())
+        .expect("network properties exist");
+    for must_have in ["disabled", "allowedDomains", "httpProxyPort", "socksProxyPort"] {
+        assert!(
+            net_props.contains_key(must_have),
+            "sandbox.network schema missing key '{}'",
+            must_have
+        );
+    }
+}
+
+/// CLI init with a fully-populated sandbox config — makes sure the new
+/// nested `filesystem` / `network` / `failIfUnavailable` / `excludedCommands`
+/// keys all parse without error.
+#[test]
+#[serial]
+fn cli_starts_with_extended_sandbox_settings() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let user_settings = dir.path().join("settings.json");
+    let body = json!({
+        "sandbox": {
+            "enabled": true,
+            "mode": "workspace",
+            "failIfUnavailable": false,
+            "allowUnsandboxedCommands": true,
+            "excludedCommands": ["docker *"],
+            "allowedCommands": ["make test"],
+            "filesystem": {
+                "allowWrite": ["~/.kube"],
+                "denyWrite": ["/etc"],
+                "allowRead": ["."],
+                "denyRead": ["~/.ssh"]
+            },
+            "network": {
+                "disabled": false,
+                "allowedDomains": ["github.com", "*.npmjs.org"]
+            }
+        }
+    });
+    std::fs::write(&user_settings, serde_json::to_string_pretty(&body).unwrap())
+        .expect("write user settings");
+
+    let project = tempfile::tempdir().expect("project tmpdir");
+    let mut cmd = assert_cmd::Command::cargo_bin("claude-code-rs").expect("binary not found");
+    cmd.env("CC_RUST_HOME", dir.path())
+        .env("ANTHROPIC_API_KEY", "")
+        .env("AZURE_API_KEY", "")
+        .env("OPENAI_API_KEY", "")
+        .env_remove("ANTHROPIC_AUTH_TOKEN")
+        .arg("--init-only")
+        .arg("--cwd")
+        .arg(project.path());
+    cmd.assert().success();
+}
+
+/// Smoke-check that the CLI accepts `--no-network` without blowing up
+/// during init-only fast path.
+#[test]
+#[serial]
+fn cli_accepts_no_network_flag() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let project = tempfile::tempdir().expect("project tmpdir");
+    let mut cmd = assert_cmd::Command::cargo_bin("claude-code-rs").expect("binary not found");
+    cmd.env("CC_RUST_HOME", dir.path())
+        .env("ANTHROPIC_API_KEY", "")
+        .env("AZURE_API_KEY", "")
+        .env("OPENAI_API_KEY", "")
+        .env_remove("ANTHROPIC_AUTH_TOKEN")
+        .arg("--init-only")
+        .arg("--no-network")
+        .arg("--cwd")
+        .arg(project.path());
+    cmd.assert().success();
+}
+
+/// Invalid sandbox mode in settings shouldn't break startup — the value
+/// is rejected by the validation pass but init continues.
+#[test]
+#[serial]
+fn cli_rejects_invalid_sandbox_mode_without_crashing() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let user_settings = dir.path().join("settings.json");
+    let body = json!({
+        "sandbox": {
+            "enabled": true,
+            "mode": "paranoid"
+        }
+    });
+    std::fs::write(&user_settings, serde_json::to_string_pretty(&body).unwrap())
+        .expect("write user settings");
+
+    let project = tempfile::tempdir().expect("project tmpdir");
+    let mut cmd = assert_cmd::Command::cargo_bin("claude-code-rs").expect("binary not found");
+    cmd.env("CC_RUST_HOME", dir.path())
+        .env("ANTHROPIC_API_KEY", "")
+        .env("AZURE_API_KEY", "")
+        .env("OPENAI_API_KEY", "")
+        .env_remove("ANTHROPIC_AUTH_TOKEN")
+        .arg("--init-only")
+        .arg("--cwd")
+        .arg(project.path());
+    cmd.assert().success();
+}

--- a/tests/e2e_settings.rs
+++ b/tests/e2e_settings.rs
@@ -92,8 +92,7 @@ fn cli_starts_with_extended_user_settings() {
     // Use a project workspace dir distinct from CC_RUST_HOME.
     let project = tempfile::tempdir().expect("project tmpdir");
 
-    let mut cmd =
-        assert_cmd::Command::cargo_bin("claude-code-rs").expect("binary not found");
+    let mut cmd = assert_cmd::Command::cargo_bin("claude-code-rs").expect("binary not found");
     cmd.env("CC_RUST_HOME", dir.path())
         .env("ANTHROPIC_API_KEY", "")
         .env("AZURE_API_KEY", "")

--- a/tests/e2e_settings.rs
+++ b/tests/e2e_settings.rs
@@ -1,0 +1,109 @@
+//! E2E tests for the layered settings system.
+//!
+//! Exercises [`config::settings`] end-to-end: writing every layer to a
+//! tempdir, loading them, and asserting both the merged effective values
+//! and the per-key source map.
+//!
+//! These tests are intentionally hermetic — they set `CC_RUST_HOME` to a
+//! per-test tempdir so they never touch the user's real settings file.
+//!
+//! Run with: `cargo test --test e2e_settings`
+
+use serde_json::json;
+use serial_test::serial;
+
+// The merge / source-tracking logic lives in `src/config/settings.rs` and
+// is fully covered by its `#[cfg(test)]` block. This integration test
+// adds a black-box check that the committed schema file is parseable and
+// that the CLI binary can boot with the new extended settings shape.
+#[test]
+#[serial]
+fn schema_file_is_valid_json() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("docs")
+        .join("schemas")
+        .join("settings.schema.json");
+    assert!(
+        path.exists(),
+        "expected committed schema at {}",
+        path.display()
+    );
+    let txt = std::fs::read_to_string(&path).expect("read schema");
+    let v: serde_json::Value = serde_json::from_str(&txt).expect("schema is valid JSON");
+    assert_eq!(
+        v.pointer("/$schema")
+            .and_then(|s| s.as_str())
+            .unwrap_or_default(),
+        "https://json-schema.org/draft/2020-12/schema"
+    );
+    let props = v
+        .pointer("/properties")
+        .and_then(|p| p.as_object())
+        .expect("schema has /properties");
+    for must_have in [
+        "permissions",
+        "sandbox",
+        "statusLine",
+        "outputStyle",
+        "spinnerTips",
+        "availableModels",
+        "fastMode",
+        "voiceEnabled",
+        "editorMode",
+        "teammateMode",
+    ] {
+        assert!(
+            props.contains_key(must_have),
+            "committed schema must declare {}",
+            must_have
+        );
+    }
+}
+
+/// Tiny smoke test exercising the layered loader through the CLI binary.
+/// Sets up a CC_RUST_HOME with a user-level settings file containing a
+/// few new fields, then runs `--init-only` and `--dump-system-prompt`
+/// to make sure nothing trips on the new struct shape.
+#[test]
+#[serial]
+fn cli_starts_with_extended_user_settings() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let user_settings = dir.path().join("settings.json");
+    let body = json!({
+        "model": "claude-sonnet-4-20250514",
+        "outputStyle": "concise",
+        "language": "en",
+        "editorMode": "vim",
+        "permissions": {
+            "defaultMode": "ask",
+            "allow": ["Bash"],
+            "deny": ["FileWrite"]
+        },
+        "spinnerTips": {
+            "enabled": true,
+            "intervalMs": 5000,
+            "customTips": ["hi"]
+        },
+        "fastMode": false
+    });
+    std::fs::write(&user_settings, serde_json::to_string_pretty(&body).unwrap())
+        .expect("write user settings");
+
+    // Use a project workspace dir distinct from CC_RUST_HOME.
+    let project = tempfile::tempdir().expect("project tmpdir");
+
+    let mut cmd =
+        assert_cmd::Command::cargo_bin("claude-code-rs").expect("binary not found");
+    cmd.env("CC_RUST_HOME", dir.path())
+        .env("ANTHROPIC_API_KEY", "")
+        .env("AZURE_API_KEY", "")
+        .env("OPENAI_API_KEY", "")
+        .env_remove("ANTHROPIC_AUTH_TOKEN")
+        .arg("--init-only")
+        .arg("--cwd")
+        .arg(project.path());
+
+    let assert = cmd.assert();
+    // Just need a clean exit — the new settings file must parse.
+    assert.success();
+}


### PR DESCRIPTION
Closes #6 and #7.

## Summary

- **Issue #6** — refactors `config::settings` into a 6-layer model (Default/Managed/User/Project/Local/Env/Cli) with per-key source tracking; extends `RawSettings`/`SettingsJson` from 4 fields to 23+ typed fields covering permissions, sandbox, statusLine, spinnerTips, outputStyle, language, voiceEnabled, editorMode, viewMode, terminalProgressBarEnabled, availableModels, effortLevel, fastMode, fastModePerSessionOptIn, teammateMode, claudeInChromeDefaultEnabled.
- **Issue #7** — fixes rule precedence to `deny → ask → allow` per spec; adds `acceptEdits` and `dontAsk` modes; replaces `decision.rs` hook stub with a real `HookPermissionDecision` flow; introduces a Bash matcher with compound-command tokenisation and process-wrapper stripping.

## Issue #6 — Layered configuration

| Acceptance | Where |
|---|---|
| user/project/local + managed predication | `src/config/settings.rs` `SettingsSource` enum |
| Bootstrap uses `EffectiveSettings` | `src/main.rs` `load_effective` |
| `SettingsJson` ≥ 4 fields | `src/types/app_state.rs` (23 typed + sources map) |
| `/config show` effective + sources | `src/commands/config_cmd.rs` |
| Backups on write | `write_settings_file` rotates 5 `.bak` files |
| Schema in repo | `docs/schemas/settings.schema.json` + `schema_file_matches_runtime` drift test |

## Issue #7 — Permission system

| Acceptance | Where |
|---|---|
| Rule precedence deny → ask → allow | `src/permissions/rules.rs:57-89` + `decision.rs:264-318` |
| `acceptEdits` / `dontAsk` modes | `src/types/tool.rs:88-130` (`PermissionMode::parse/as_str`) |
| `decision.rs` no hook stub | `HookPermissionDecision` + `has_permissions_to_use_tool_with_hook` |
| Bash compound + wrapper tests | new `src/permissions/bash_matcher.rs` (11 unit tests) |
| `/permissions` source-aware | `src/commands/permissions_cmd.rs` (deny/ask/allow + session + dirs) |
| Session vs persistent grants | `[transient]` tag + `--session` scope; persistent scopes write to disk with backup |

### Key cross-cutting changes

- **Pipeline through central decision** — `src/tools/execution/pipeline.rs` converts the pre-tool hook output into a `HookPermissionDecision` and lets the central flow apply precedence (deny rule still beats hook allow; ask rule still forces a prompt; hook deny is treated as policy).
- **Settings → rules wired** — `build_tool_permission_context` in `src/main.rs` pulls `permissions.allow/ask/deny/additionalDirectories/enableBypassMode/enableAutoMode` from each settings layer into `ToolPermissionContext`, tagged with the source.
- **Specifiers extended** — `Bash(...)`, `Read(...)`, `WebFetch(...)`, `Agent(...)`, `mcp__*(...)` patterns supported. `Bash(rm)` now catches `git status && rm -rf /tmp/x`; `Bash(prefix:cargo)` matches `sudo cargo build` and `bash -c \"cargo test\"`.

## Test plan

- [x] `cargo test --bin claude-code-rs config::` — 60 passed
- [x] `cargo test --bin claude-code-rs commands::config_cmd:: commands::permissions_cmd::` — 10 passed
- [x] `cargo test --bin claude-code-rs permissions:: tools::hooks::` — 110 passed
- [x] `cargo test --test e2e_settings --test e2e_permissions` — 4 passed
- [x] `cargo check` — 0 new warnings (6 baseline observability/web warnings unchanged)
- [ ] Reviewer: confirm full `cargo test --bin claude-code-rs` (pre-existing flakes due to env contention; all failing tests pass when run individually)

## Reviewer notes

- Backward-compat aliases (`GlobalConfig`, `ProjectConfig`, `MergedConfig`, `load_global_config`, `load_project_config`, `load_and_merge`, `merge_configs`) are preserved as `#[allow(dead_code)]` type aliases / wrappers so external callers keep compiling.
- `docs/STORAGE.md` gains a *Settings layering* section documenting the new layer order and file locations.
- Managed-settings path on Windows is `%ProgramData%\cc-rust\settings.json` (overridable via `CC_RUST_MANAGED_SETTINGS`); on other platforms `/etc/cc-rust/managed-settings.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)