### PR TITLE
Add session sidebar with workspace grouping (issue #1, phase 2/3)

### DIFF
--- a/src/engine/lifecycle/mod.rs
+++ b/src/engine/lifecycle/mod.rs
@@ -287,6 +287,14 @@ impl QueryEngine {
         &self.config.cwd
     }
 
+    /// Get a reference to the engine's immutable configuration.
+    ///
+    /// Used by the web layer to clone the config when rebuilding an engine
+    /// on `/api/sessions/new` or `/api/sessions/:id/resume`.
+    pub fn config_ref(&self) -> &QueryEngineConfig {
+        &self.config
+    }
+
     /// Replace the tool registry.
     #[allow(dead_code)]
     pub fn set_tools(&self, tools: Tools) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -905,10 +905,10 @@ async fn run_full_init(cli: Cli) -> anyhow::Result<ExitCode> {
 
     // B.10: Web UI mode
     if cli.web {
-        let web_state = web::state::WebState {
-            engine: engine.clone(),
-            is_streaming: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-        };
+        let web_state = web::state::WebState::new(
+            engine.clone(),
+            Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        );
         return match web::start_server(web_state, cli.web_port, cli.no_open).await {
             Ok(()) => Ok(ExitCode::SUCCESS),
             Err(e) => {

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -31,6 +31,19 @@ pub struct SessionInfo {
     pub message_count: usize,
     /// Working directory at the time the session was created.
     pub cwd: String,
+    /// Derived title — first user message text, truncated. Empty if not computable.
+    #[serde(default)]
+    pub title: String,
+    /// Stable grouping key for the workspace. Sessions sharing the same git
+    /// common-dir (or canonical path for non-git dirs) get the same key.
+    #[serde(default)]
+    pub workspace_key: String,
+    /// Root directory for the workspace (git root or the session cwd).
+    #[serde(default)]
+    pub workspace_root: String,
+    /// Human-readable workspace label (basename of the root).
+    #[serde(default)]
+    pub workspace_name: String,
 }
 
 /// On-disk representation of a saved session.
@@ -108,7 +121,12 @@ fn git_common_dir(repo: &Repository) -> PathBuf {
     }
 }
 
-fn workspace_key(path: &Path) -> String {
+/// Stable workspace key for grouping sessions that belong to the same repo.
+///
+/// For git repositories (including worktrees) this is the canonical form of
+/// the git common directory, so all worktrees of the same repo share a key.
+/// For non-git directories it's the canonical path (or stable workspace path).
+pub fn workspace_key(path: &Path) -> String {
     if let Ok(repo) = Repository::discover(path) {
         return normalize_match_key(&git_common_dir(&repo));
     }
@@ -116,9 +134,126 @@ fn workspace_key(path: &Path) -> String {
     normalize_match_key(&stable_workspace_path(path))
 }
 
+/// Return the root directory for the workspace (git root when available, else
+/// the path itself). This is a display-friendly absolute path.
+pub fn workspace_root(path: &Path) -> PathBuf {
+    if let Ok(repo) = Repository::discover(path) {
+        let common = git_common_dir(&repo);
+        // `.git` or `worktrees/<name>` live under the root -- strip one level
+        // so the root points at the working directory, not the git metadata.
+        if common.file_name().and_then(|s| s.to_str()) == Some(".git") {
+            if let Some(parent) = common.parent() {
+                return parent.to_path_buf();
+            }
+        }
+        return common;
+    }
+    stable_workspace_path(path)
+}
+
+/// Display name for a workspace — the basename of the workspace root.
+pub fn workspace_name(root: &Path) -> String {
+    root.file_name()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| root.to_string_lossy().to_string())
+}
+
+/// Extract a title from the first non-meta user message in a SessionFile.
+/// Returns an empty string if no suitable message exists.
+fn derive_title(messages: &[SerializableMessage]) -> String {
+    for sm in messages {
+        if sm.msg_type != "user" {
+            continue;
+        }
+        // Skip meta messages (system-injected context).
+        if sm
+            .data
+            .get("is_meta")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+        {
+            continue;
+        }
+
+        let text = extract_user_text(&sm.data);
+        if text.is_empty() {
+            continue;
+        }
+
+        let trimmed = text.trim();
+        // Pick the first non-empty line, then truncate.
+        let first_line = trimmed.lines().find(|l| !l.trim().is_empty()).unwrap_or("");
+        let first_line = first_line.trim();
+        if first_line.is_empty() {
+            continue;
+        }
+
+        const MAX: usize = 80;
+        let out: String = first_line.chars().take(MAX).collect();
+        if first_line.chars().count() > MAX {
+            return format!("{}…", out);
+        }
+        return out;
+    }
+    String::new()
+}
+
+/// Pull plain text from the `content` field of a serialized user message.
+/// Accepts the two historical representations: a bare string or a list of
+/// content blocks with `{type: "text", text: ...}` entries.
+fn extract_user_text(data: &serde_json::Value) -> String {
+    let Some(content) = data.get("content") else {
+        return String::new();
+    };
+
+    match content {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Array(blocks) => blocks
+            .iter()
+            .filter_map(|b| {
+                let ty = b.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                if ty != "text" {
+                    return None;
+                }
+                b.get("text").and_then(|v| v.as_str()).map(|s| s.to_string())
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+        _ => String::new(),
+    }
+}
+
+fn build_session_info(file: SessionFile) -> SessionInfo {
+    let cwd_path = Path::new(&file.cwd);
+    let ws_root = workspace_root(cwd_path);
+    let ws_key = workspace_key(cwd_path);
+    let ws_name = workspace_name(&ws_root);
+    let title = derive_title(&file.messages);
+    SessionInfo {
+        session_id: file.session_id,
+        created_at: file.created_at,
+        last_modified: file.last_modified,
+        message_count: file.messages.len(),
+        cwd: file.cwd,
+        title,
+        workspace_key: ws_key,
+        workspace_root: ws_root.to_string_lossy().to_string(),
+        workspace_name: ws_name,
+    }
+}
+
 fn filter_sessions_for_workspace(mut sessions: Vec<SessionInfo>, cwd: &Path) -> Vec<SessionInfo> {
     let current_workspace = workspace_key(cwd);
-    sessions.retain(|session| workspace_key(Path::new(&session.cwd)) == current_workspace);
+    sessions.retain(|session| {
+        // Use the cached workspace_key when present (new code), fall back to
+        // computing from cwd for sessions written by older builds.
+        if !session.workspace_key.is_empty() {
+            session.workspace_key == current_workspace
+        } else {
+            workspace_key(Path::new(&session.cwd)) == current_workspace
+        }
+    });
     sessions
 }
 
@@ -227,13 +362,7 @@ pub fn list_sessions() -> Result<Vec<SessionInfo>> {
             Err(_) => continue,
         };
 
-        sessions.push(SessionInfo {
-            session_id: file.session_id,
-            created_at: file.created_at,
-            last_modified: file.last_modified,
-            message_count: file.messages.len(),
-            cwd: file.cwd,
-        });
+        sessions.push(build_session_info(file));
     }
 
     // Most recently modified first.
@@ -453,28 +582,24 @@ mod tests {
         std::fs::create_dir_all(&other_dir).unwrap();
         Repository::init(&repo_dir).unwrap();
 
+        fn info(id: &str, cwd: &Path, modified: i64, messages: usize) -> SessionInfo {
+            SessionInfo {
+                session_id: id.into(),
+                created_at: 0,
+                last_modified: modified,
+                message_count: messages,
+                cwd: normalize_display_path(cwd),
+                title: String::new(),
+                workspace_key: workspace_key(cwd),
+                workspace_root: workspace_root(cwd).to_string_lossy().to_string(),
+                workspace_name: workspace_name(&workspace_root(cwd)),
+            }
+        }
+
         let sessions = vec![
-            SessionInfo {
-                session_id: "repo-root".into(),
-                created_at: 0,
-                last_modified: 3,
-                message_count: 10,
-                cwd: normalize_display_path(&repo_dir),
-            },
-            SessionInfo {
-                session_id: "repo-nested".into(),
-                created_at: 0,
-                last_modified: 2,
-                message_count: 8,
-                cwd: normalize_display_path(&nested_dir),
-            },
-            SessionInfo {
-                session_id: "other".into(),
-                created_at: 0,
-                last_modified: 1,
-                message_count: 2,
-                cwd: normalize_display_path(&other_dir),
-            },
+            info("repo-root", &repo_dir, 3, 10),
+            info("repo-nested", &nested_dir, 2, 8),
+            info("other", &other_dir, 1, 2),
         ];
 
         let filtered = filter_sessions_for_workspace(sessions, &nested_dir);

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -1,13 +1,24 @@
 //! Axum route handlers for the web chat API.
 
+use std::path::Path;
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
-use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+use axum::{
+    extract::{Path as AxumPath, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
 use serde::{Deserialize, Serialize};
-use tracing::info;
+use tracing::{info, warn};
 
+use crate::bootstrap::SessionId;
+use crate::engine::lifecycle::QueryEngine;
 use crate::engine::sdk_types::SdkMessage;
-use crate::types::config::QuerySource;
+use crate::session::{resume as session_resume, storage};
+use crate::types::config::{QueryEngineConfig, QuerySource};
+use crate::types::message::{ContentBlock, Message, MessageContent};
 use crate::types::tool::PermissionMode;
 
 use super::sse::sdk_stream_to_sse;
@@ -121,7 +132,7 @@ pub async fn chat_handler(
     state.is_streaming.store(true, Ordering::SeqCst);
 
     // Get the stream from the engine
-    let stream = state.engine.submit_message(&req.message, QuerySource::Sdk);
+    let stream = state.engine().submit_message(&req.message, QuerySource::Sdk);
 
     // Wrap in a stream that clears is_streaming when done
     let is_streaming = state.is_streaming.clone();
@@ -157,21 +168,21 @@ pub async fn abort_handler(
     Json(_req): Json<AbortRequest>,
 ) -> impl IntoResponse {
     info!("POST /api/abort");
-    state.engine.abort();
+    state.engine().abort();
     state.is_streaming.store(false, Ordering::SeqCst);
     StatusCode::OK
 }
 
 /// GET /api/state -- Return current application state (enhanced for Phase 3).
 pub async fn state_handler(State(state): State<WebState>) -> impl IntoResponse {
-    let app_state = state.engine.app_state();
+    let app_state = state.engine().app_state();
     let permission_mode = app_state.tool_permission_context.mode.as_str();
 
     // Get tool names from engine
-    let tool_names: Vec<String> = state.engine.tool_names();
+    let tool_names: Vec<String> = state.engine().tool_names();
 
     // Get usage tracking
-    let usage = state.engine.usage();
+    let usage = state.engine().usage();
 
     // Get command list
     let commands: Vec<CommandInfo> = crate::commands::get_all_commands()
@@ -185,7 +196,7 @@ pub async fn state_handler(State(state): State<WebState>) -> impl IntoResponse {
 
     Json(StateResponse {
         model: app_state.main_loop_model.clone(),
-        session_id: state.engine.session_id.to_string(),
+        session_id: state.engine().session_id.to_string(),
         tools: tool_names,
         permission_mode: permission_mode.to_string(),
         thinking_enabled: app_state.thinking_enabled,
@@ -224,7 +235,7 @@ pub async fn settings_handler(
             }
             // Resolve model aliases
             let resolved = resolve_model_alias(&model);
-            state.engine.update_app_state(|s| {
+            state.engine().update_app_state(|s| {
                 s.main_loop_model = resolved.clone();
                 s.settings.model = Some(resolved.clone());
             });
@@ -244,7 +255,7 @@ pub async fn settings_handler(
                 "plan" => PermissionMode::Plan,
                 _ => PermissionMode::Default,
             };
-            state.engine.update_app_state(|s| {
+            state.engine().update_app_state(|s| {
                 s.tool_permission_context.mode = mode.clone();
             });
             (
@@ -257,7 +268,7 @@ pub async fn settings_handler(
         }
         "set_thinking" => {
             let enabled = req.value.as_bool();
-            state.engine.update_app_state(|s| {
+            state.engine().update_app_state(|s| {
                 s.thinking_enabled = enabled;
             });
             (
@@ -270,7 +281,7 @@ pub async fn settings_handler(
         }
         "set_fast_mode" => {
             let enabled = req.value.as_bool().unwrap_or(false);
-            state.engine.update_app_state(|s| {
+            state.engine().update_app_state(|s| {
                 s.fast_mode = enabled;
             });
             (
@@ -283,7 +294,7 @@ pub async fn settings_handler(
         }
         "set_effort" => {
             let effort = req.value.as_str().map(|s| s.to_string());
-            state.engine.update_app_state(|s| {
+            state.engine().update_app_state(|s| {
                 s.effort_value = effort.clone();
             });
             (
@@ -327,22 +338,22 @@ pub async fn command_handler(
     };
 
     // Build a CommandContext
-    let messages = state.engine.messages();
-    let app_state = state.engine.app_state();
-    let cwd = std::path::PathBuf::from(state.engine.cwd());
+    let messages = state.engine().messages();
+    let app_state = state.engine().app_state();
+    let cwd = std::path::PathBuf::from(state.engine().cwd());
 
     let mut ctx = crate::commands::CommandContext {
         messages,
         cwd,
         app_state: app_state.clone(),
-        session_id: state.engine.session_id.clone(),
+        session_id: state.engine().session_id.clone(),
     };
 
     match cmd.handler.execute(&req.args, &mut ctx).await {
         Ok(result) => {
             // Apply any state mutations from the command
             // Commands mutate ctx.app_state in-place; write it back
-            state.engine.update_app_state(|s| {
+            state.engine().update_app_state(|s| {
                 s.main_loop_model = ctx.app_state.main_loop_model.clone();
                 s.settings = ctx.app_state.settings.clone();
                 s.tool_permission_context = ctx.app_state.tool_permission_context.clone();
@@ -386,8 +397,361 @@ pub async fn command_handler(
 }
 
 // ---------------------------------------------------------------------------
+// Session management endpoints (Phase 2)
+// ---------------------------------------------------------------------------
+
+/// Lightweight description of a workspace used to group sessions.
+#[derive(Serialize)]
+pub struct WorkspaceInfo {
+    pub key: String,
+    pub root: String,
+    pub name: String,
+}
+
+/// Response shape for `GET /api/sessions`.
+#[derive(Serialize)]
+pub struct SessionListResponse {
+    /// Workspace derived from the engine's cwd — the UI uses this to mark
+    /// which group is "current".
+    pub current_workspace: WorkspaceInfo,
+    /// Session id currently loaded in the engine.
+    pub active_session_id: String,
+    /// All known sessions on disk, sorted by last_modified desc.
+    pub sessions: Vec<SessionSummary>,
+}
+
+/// Serializable session summary including derived grouping fields.
+#[derive(Serialize)]
+pub struct SessionSummary {
+    pub session_id: String,
+    pub created_at: i64,
+    pub last_modified: i64,
+    pub message_count: usize,
+    pub cwd: String,
+    pub title: String,
+    pub workspace_key: String,
+    pub workspace_root: String,
+    pub workspace_name: String,
+}
+
+impl From<storage::SessionInfo> for SessionSummary {
+    fn from(s: storage::SessionInfo) -> Self {
+        Self {
+            session_id: s.session_id,
+            created_at: s.created_at,
+            last_modified: s.last_modified,
+            message_count: s.message_count,
+            cwd: s.cwd,
+            title: s.title,
+            workspace_key: s.workspace_key,
+            workspace_root: s.workspace_root,
+            workspace_name: s.workspace_name,
+        }
+    }
+}
+
+/// Simplified message shape used by session detail / resume responses.
+#[derive(Serialize)]
+pub struct StoredMessage {
+    pub uuid: String,
+    pub timestamp: i64,
+    pub role: String,
+    /// Plain-text view of the message (concatenation of text blocks for
+    /// assistant, or the raw text for a user message).
+    pub content: String,
+    /// Structured blocks (text / tool_use / tool_result / thinking / image)
+    /// when available — matches the shape the frontend already renders for
+    /// live messages.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_blocks: Option<Vec<ContentBlock>>,
+}
+
+#[derive(Serialize)]
+pub struct SessionDetailResponse {
+    pub session_id: String,
+    pub created_at: i64,
+    pub last_modified: i64,
+    pub cwd: String,
+    pub title: String,
+    pub workspace_name: String,
+    pub messages: Vec<StoredMessage>,
+}
+
+#[derive(Serialize)]
+pub struct NewSessionResponse {
+    pub session_id: String,
+}
+
+/// GET /api/sessions -- List all sessions with workspace grouping metadata.
+pub async fn sessions_list_handler(State(state): State<WebState>) -> impl IntoResponse {
+    let engine = state.engine();
+    let cwd_str = engine.cwd().to_string();
+    let cwd_path = Path::new(&cwd_str);
+
+    let ws_key = storage::workspace_key(cwd_path);
+    let ws_root = storage::workspace_root(cwd_path);
+    let ws_name = storage::workspace_name(&ws_root);
+
+    let sessions = match storage::list_sessions() {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(error = %e, "failed to list sessions");
+            Vec::new()
+        }
+    };
+
+    let summaries: Vec<SessionSummary> = sessions.into_iter().map(SessionSummary::from).collect();
+
+    Json(SessionListResponse {
+        current_workspace: WorkspaceInfo {
+            key: ws_key,
+            root: ws_root.to_string_lossy().to_string(),
+            name: ws_name,
+        },
+        active_session_id: engine.session_id.to_string(),
+        sessions: summaries,
+    })
+}
+
+/// GET /api/sessions/:id -- Load a session's message history for preview.
+pub async fn session_detail_handler(
+    AxumPath(id): AxumPath<String>,
+    State(_state): State<WebState>,
+) -> impl IntoResponse {
+    info!(session_id = %id, "GET /api/sessions/:id");
+
+    let messages = match session_resume::resume_session(&id) {
+        Ok(m) => m,
+        Err(e) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(ApiError {
+                    error: format!("Session not found: {}", e),
+                    code: "session_not_found".into(),
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    // Look up disk metadata for title / cwd / timestamps.
+    let info = storage::list_sessions()
+        .ok()
+        .and_then(|list| list.into_iter().find(|s| s.session_id == id));
+
+    let (title, cwd, created_at, last_modified, workspace_name) = match info {
+        Some(i) => (
+            i.title,
+            i.cwd,
+            i.created_at,
+            i.last_modified,
+            i.workspace_name,
+        ),
+        None => (String::new(), String::new(), 0, 0, String::new()),
+    };
+
+    let rendered: Vec<StoredMessage> = messages.iter().map(stored_message_from).collect();
+
+    Json(SessionDetailResponse {
+        session_id: id,
+        created_at,
+        last_modified,
+        cwd,
+        title,
+        workspace_name,
+        messages: rendered,
+    })
+    .into_response()
+}
+
+/// POST /api/sessions/new -- Start a fresh session in the current workspace.
+///
+/// The existing engine is detached (its history is preserved on disk by the
+/// auto-save path) and a new engine is constructed in its place with an empty
+/// message history and a new session id.
+pub async fn session_new_handler(State(state): State<WebState>) -> impl IntoResponse {
+    if state.is_streaming.load(Ordering::SeqCst) {
+        return (
+            StatusCode::CONFLICT,
+            Json(ApiError {
+                error: "A query is in progress — abort it before starting a new session".into(),
+                code: "engine_busy".into(),
+            }),
+        )
+            .into_response();
+    }
+
+    let engine = rebuild_engine(&state, None);
+    let new_id = engine.session_id.to_string();
+    state.replace_engine(engine);
+
+    info!(session_id = %new_id, "POST /api/sessions/new");
+    Json(NewSessionResponse {
+        session_id: new_id,
+    })
+    .into_response()
+}
+
+/// POST /api/sessions/:id/resume -- Load an existing session into the engine.
+pub async fn session_resume_handler(
+    AxumPath(id): AxumPath<String>,
+    State(state): State<WebState>,
+) -> impl IntoResponse {
+    if state.is_streaming.load(Ordering::SeqCst) {
+        return (
+            StatusCode::CONFLICT,
+            Json(ApiError {
+                error: "A query is in progress — abort it before switching sessions".into(),
+                code: "engine_busy".into(),
+            }),
+        )
+            .into_response();
+    }
+
+    info!(session_id = %id, "POST /api/sessions/:id/resume");
+
+    let messages = match session_resume::resume_session(&id) {
+        Ok(m) => m,
+        Err(e) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(ApiError {
+                    error: format!("Session not found: {}", e),
+                    code: "session_not_found".into(),
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    let engine = rebuild_engine_with_session_id(&state, Some(messages.clone()), Some(&id));
+    state.replace_engine(engine);
+
+    let rendered: Vec<StoredMessage> = messages.iter().map(stored_message_from).collect();
+
+    let info = storage::list_sessions()
+        .ok()
+        .and_then(|list| list.into_iter().find(|s| s.session_id == id));
+
+    let (title, cwd, created_at, last_modified, workspace_name) = match info {
+        Some(i) => (
+            i.title,
+            i.cwd,
+            i.created_at,
+            i.last_modified,
+            i.workspace_name,
+        ),
+        None => (String::new(), String::new(), 0, 0, String::new()),
+    };
+
+    Json(SessionDetailResponse {
+        session_id: id,
+        created_at,
+        last_modified,
+        cwd,
+        title,
+        workspace_name,
+        messages: rendered,
+    })
+    .into_response()
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Build a fresh engine that inherits the current engine's config, with an
+/// optional seed message list. The new engine gets a freshly minted session id.
+fn rebuild_engine(state: &WebState, seed: Option<Vec<Message>>) -> Arc<QueryEngine> {
+    rebuild_engine_with_session_id(state, seed, None)
+}
+
+/// Rebuild with a caller-provided session id (used by resume so the engine's
+/// auto-save keeps writing back to the resumed session file).
+fn rebuild_engine_with_session_id(
+    state: &WebState,
+    seed: Option<Vec<Message>>,
+    session_id: Option<&str>,
+) -> Arc<QueryEngine> {
+    let current = state.engine();
+    let mut cfg: QueryEngineConfig = current.config_ref().clone();
+    cfg.initial_messages = seed;
+
+    let mut engine = QueryEngine::new(cfg);
+    if let Some(id) = session_id {
+        engine.session_id = SessionId::from_string(id);
+    }
+    Arc::new(engine)
+}
+
+/// Convert an internal `Message` into the lightweight wire form used by the
+/// session detail / resume responses.
+fn stored_message_from(msg: &Message) -> StoredMessage {
+    match msg {
+        Message::User(u) => {
+            let (text, blocks) = match &u.content {
+                MessageContent::Text(t) => (t.clone(), None),
+                MessageContent::Blocks(bs) => {
+                    let text = bs
+                        .iter()
+                        .filter_map(|b| match b {
+                            ContentBlock::Text { text } => Some(text.as_str()),
+                            _ => None,
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    (text, Some(bs.clone()))
+                }
+            };
+            StoredMessage {
+                uuid: u.uuid.to_string(),
+                timestamp: u.timestamp,
+                role: "user".into(),
+                content: text,
+                content_blocks: blocks,
+            }
+        }
+        Message::Assistant(a) => {
+            let text = a
+                .content
+                .iter()
+                .filter_map(|b| match b {
+                    ContentBlock::Text { text } => Some(text.as_str()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join("");
+            StoredMessage {
+                uuid: a.uuid.to_string(),
+                timestamp: a.timestamp,
+                role: "assistant".into(),
+                content: text,
+                content_blocks: Some(a.content.clone()),
+            }
+        }
+        Message::System(s) => StoredMessage {
+            uuid: s.uuid.to_string(),
+            timestamp: s.timestamp,
+            role: "system".into(),
+            content: s.content.clone(),
+            content_blocks: None,
+        },
+        Message::Progress(p) => StoredMessage {
+            uuid: p.uuid.to_string(),
+            timestamp: p.timestamp,
+            role: "progress".into(),
+            content: String::new(),
+            content_blocks: None,
+        },
+        Message::Attachment(a) => StoredMessage {
+            uuid: a.uuid.to_string(),
+            timestamp: a.timestamp,
+            role: "attachment".into(),
+            content: String::new(),
+            content_blocks: None,
+        },
+    }
+}
 
 /// Resolve common model aliases to full model names.
 fn resolve_model_alias(name: &str) -> String {

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -27,6 +27,14 @@ pub fn build_router(state: WebState) -> Router {
         // Phase 3: Settings and command endpoints
         .route("/api/settings", post(handlers::settings_handler))
         .route("/api/command", post(handlers::command_handler))
+        // Phase 2 of the web UI overhaul: session management
+        .route("/api/sessions", get(handlers::sessions_list_handler))
+        .route("/api/sessions/new", post(handlers::session_new_handler))
+        .route("/api/sessions/{id}", get(handlers::session_detail_handler))
+        .route(
+            "/api/sessions/{id}/resume",
+            post(handlers::session_resume_handler),
+        )
         // Static files (SPA)
         .fallback(static_files::static_handler)
         // Middleware

--- a/src/web/state.rs
+++ b/src/web/state.rs
@@ -3,13 +3,41 @@
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
+use parking_lot::RwLock;
+
 use crate::engine::lifecycle::QueryEngine;
 
 /// Shared state passed to all Axum handlers via State extractor.
+///
+/// The engine is held behind an `RwLock<Arc<QueryEngine>>` so the web layer
+/// can swap it out when the user creates a new session or resumes an older
+/// one. Individual handlers snapshot the engine via [`WebState::engine`] and
+/// operate on that `Arc` for the duration of the request, so a mid-flight
+/// swap cannot disturb an in-progress stream.
 #[derive(Clone)]
 pub struct WebState {
-    /// Reference to the query engine.
-    pub engine: Arc<QueryEngine>,
+    /// Current engine, swappable between turns.
+    pub engine_slot: Arc<RwLock<Arc<QueryEngine>>>,
     /// Flag: is a query currently in progress?
     pub is_streaming: Arc<AtomicBool>,
+}
+
+impl WebState {
+    /// Build a new `WebState` from an initial engine.
+    pub fn new(engine: Arc<QueryEngine>, is_streaming: Arc<AtomicBool>) -> Self {
+        Self {
+            engine_slot: Arc::new(RwLock::new(engine)),
+            is_streaming,
+        }
+    }
+
+    /// Snapshot the current engine.
+    pub fn engine(&self) -> Arc<QueryEngine> {
+        self.engine_slot.read().clone()
+    }
+
+    /// Replace the current engine (used by new/resume session flows).
+    pub fn replace_engine(&self, engine: Arc<QueryEngine>) {
+        *self.engine_slot.write() = engine;
+    }
 }

--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -1,16 +1,27 @@
 import { useEffect, useState, useCallback } from 'react'
 import { ChatPanel } from '@/components/chat/ChatPanel'
 import { Sidebar } from '@/components/sidebar/Sidebar'
+import { SessionSidebar } from '@/components/sessions/SessionSidebar'
 import { DebugPanel } from '@/components/debug/DebugPanel'
 import { useChatStore } from '@/lib/store'
-import { fetchAppState, checkConnection } from '@/lib/api'
-import { Cpu, Shield, Bug, Settings, PanelRightOpen, Wifi, WifiOff } from 'lucide-react'
+import { fetchAppState, checkConnection, fetchSessions } from '@/lib/api'
+import {
+  Bug,
+  Cpu,
+  MessageSquare,
+  PanelRightOpen,
+  Settings,
+  Shield,
+  WifiOff,
+} from 'lucide-react'
 
 export default function App() {
   const appState = useChatStore((s) => s.appState)
   const debugPanelOpen = useChatStore((s) => s.debugPanelOpen)
   const toggleDebug = useChatStore((s) => s.toggleDebugPanel)
+  const setSessions = useChatStore((s) => s.setSessions)
   const [sidebarOpen, setSidebarOpen] = useState(false)
+  const [sessionsOpen, setSessionsOpen] = useState(true)
   const [connected, setConnected] = useState(true)
 
   // Fetch app state on mount + periodic health check
@@ -21,6 +32,18 @@ export default function App() {
         setConnected(true)
       })
       .catch(() => setConnected(false))
+
+    // Prime the session sidebar with an initial list so the user can see
+    // their history immediately without clicking refresh.
+    fetchSessions()
+      .then((res) =>
+        setSessions({
+          sessions: res.sessions,
+          currentWorkspace: res.current_workspace,
+          activeSessionId: res.active_session_id,
+        }),
+      )
+      .catch(() => { /* sidebar shows its own empty state on failure */ })
 
     // Health check every 30s
     const interval = setInterval(async () => {
@@ -35,7 +58,7 @@ export default function App() {
       }
     }, 30000)
     return () => clearInterval(interval)
-  }, [])
+  }, [setSessions])
 
   // Ctrl+Shift+D keyboard shortcut for debug panel
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
@@ -52,10 +75,25 @@ export default function App() {
 
   return (
     <div className="flex h-screen w-screen overflow-hidden">
+      {/* Left: session sidebar */}
+      <SessionSidebar
+        open={sessionsOpen}
+        onClose={() => setSessionsOpen(false)}
+      />
+
       {/* Main area */}
       <main className="flex flex-1 flex-col overflow-hidden min-w-0">
         {/* Header bar */}
         <header className="flex h-12 items-center border-b border-border px-3 sm:px-4 gap-2 sm:gap-3 shrink-0">
+          <button
+            onClick={() => setSessionsOpen((v) => !v)}
+            className={`rounded p-1 transition-colors ${
+              sessionsOpen ? 'bg-primary/20 text-primary' : 'text-muted-foreground hover:text-foreground'
+            }`}
+            title={sessionsOpen ? 'Hide sessions' : 'Show sessions'}
+          >
+            <MessageSquare className="h-4 w-4" />
+          </button>
           <h1 className="text-sm font-semibold text-foreground shrink-0">cc-rust</h1>
           <span className="text-xs text-muted-foreground hidden sm:inline">Web UI</span>
 

--- a/web-ui/src/components/sessions/SessionSidebar.tsx
+++ b/web-ui/src/components/sessions/SessionSidebar.tsx
@@ -1,0 +1,343 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useChatStore } from '@/lib/store'
+import {
+  createNewSession,
+  fetchAppState,
+  fetchSessions,
+  resumeSession,
+} from '@/lib/api'
+import type { SessionSummary } from '@/lib/types'
+import {
+  ChevronDown,
+  ChevronRight,
+  FolderOpen,
+  MessageSquare,
+  Plus,
+  RefreshCcw,
+  Sparkles,
+  X,
+} from 'lucide-react'
+
+interface SessionSidebarProps {
+  open: boolean
+  onClose: () => void
+}
+
+interface WorkspaceGroup {
+  key: string
+  name: string
+  root: string
+  sessions: SessionSummary[]
+  isCurrent: boolean
+}
+
+/**
+ * Left-hand session navigator — lists all sessions grouped by workspace,
+ * with quick entries for starting a new session and for the Playground
+ * (a labeled throwaway session). Current-workspace sessions float to the
+ * top so they're reachable without scanning.
+ */
+export function SessionSidebar({ open, onClose }: SessionSidebarProps) {
+  const sessions = useChatStore((s) => s.sessions)
+  const currentWorkspace = useChatStore((s) => s.currentWorkspace)
+  const activeSessionId = useChatStore((s) => s.activeSessionId)
+  const loading = useChatStore((s) => s.sessionsLoading)
+  const setSessions = useChatStore((s) => s.setSessions)
+  const setLoading = useChatStore((s) => s.setSessionsLoading)
+  const loadSessionMessages = useChatStore((s) => s.loadSessionMessages)
+  const setActiveSessionId = useChatStore((s) => s.setActiveSessionId)
+  const clearMessages = useChatStore((s) => s.clearMessages)
+
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
+  const [error, setError] = useState<string | null>(null)
+  const [pending, setPending] = useState(false)
+
+  async function refresh() {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetchSessions()
+      setSessions({
+        sessions: res.sessions,
+        currentWorkspace: res.current_workspace,
+        activeSessionId: res.active_session_id,
+      })
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // Initial load when the sidebar first opens.
+  useEffect(() => {
+    if (open && sessions.length === 0 && !loading) {
+      void refresh()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open])
+
+  async function handleNewSession(playground: boolean) {
+    if (pending) return
+    setPending(true)
+    setError(null)
+    try {
+      const { session_id } = await createNewSession()
+      clearMessages()
+      setActiveSessionId(session_id)
+      // Refresh app state (session_id on the backend changed).
+      try {
+        const state = await fetchAppState()
+        useChatStore.getState().setAppState(state)
+      } catch { /* ignore — state will re-fetch on next heartbeat */ }
+      // Refresh session list in the background.
+      void refresh()
+      if (playground) {
+        // Playground starts with a hint so the user can see what the
+        // session is for. Kept as a system message so it doesn't get
+        // sent to the model until the user types their first real prompt.
+        useChatStore.getState().addAssistantMessage({
+          id: crypto.randomUUID(),
+          role: 'system',
+          content:
+            'Playground session — experiment freely. Everything here is saved like any other session.',
+          timestamp: Date.now(),
+        })
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setPending(false)
+    }
+  }
+
+  async function handleSwitchSession(id: string) {
+    if (pending || id === activeSessionId) return
+    setPending(true)
+    setError(null)
+    try {
+      const detail = await resumeSession(id)
+      loadSessionMessages(detail.messages)
+      setActiveSessionId(detail.session_id)
+      try {
+        const state = await fetchAppState()
+        useChatStore.getState().setAppState(state)
+      } catch { /* ignore */ }
+      void refresh()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setPending(false)
+    }
+  }
+
+  const groups = useMemo<WorkspaceGroup[]>(() => {
+    const byKey = new Map<string, WorkspaceGroup>()
+    for (const s of sessions) {
+      const key = s.workspace_key || s.cwd
+      let g = byKey.get(key)
+      if (!g) {
+        g = {
+          key,
+          name: s.workspace_name || s.cwd || 'unknown',
+          root: s.workspace_root || s.cwd || '',
+          sessions: [],
+          isCurrent: currentWorkspace ? currentWorkspace.key === key : false,
+        }
+        byKey.set(key, g)
+      }
+      g.sessions.push(s)
+    }
+
+    // If we have a current_workspace but no sessions in it yet, still show it.
+    if (currentWorkspace && !byKey.has(currentWorkspace.key)) {
+      byKey.set(currentWorkspace.key, {
+        key: currentWorkspace.key,
+        name: currentWorkspace.name,
+        root: currentWorkspace.root,
+        sessions: [],
+        isCurrent: true,
+      })
+    }
+
+    // Current workspace first, then alphabetical.
+    return Array.from(byKey.values()).sort((a, b) => {
+      if (a.isCurrent && !b.isCurrent) return -1
+      if (b.isCurrent && !a.isCurrent) return 1
+      return a.name.localeCompare(b.name)
+    })
+  }, [sessions, currentWorkspace])
+
+  if (!open) return null
+
+  return (
+    <aside className="w-72 border-r border-border flex flex-col overflow-hidden bg-background shrink-0">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-border px-3 py-3">
+        <div className="flex items-center gap-2">
+          <MessageSquare className="h-4 w-4 text-muted-foreground" />
+          <span className="text-sm font-medium">Sessions</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => void refresh()}
+            disabled={loading || pending}
+            className="rounded p-1 hover:bg-muted transition-colors disabled:opacity-40"
+            title="Refresh sessions"
+          >
+            <RefreshCcw className={`h-3.5 w-3.5 text-muted-foreground ${loading ? 'animate-spin' : ''}`} />
+          </button>
+          <button
+            onClick={onClose}
+            className="rounded p-1 hover:bg-muted transition-colors"
+            title="Close sessions"
+          >
+            <X className="h-4 w-4 text-muted-foreground" />
+          </button>
+        </div>
+      </div>
+
+      {/* Quick actions */}
+      <div className="border-b border-border p-2 space-y-1">
+        <button
+          onClick={() => void handleNewSession(false)}
+          disabled={pending}
+          className="w-full flex items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-muted disabled:opacity-50 transition-colors"
+        >
+          <Plus className="h-3.5 w-3.5 text-primary" />
+          <span>New Session</span>
+        </button>
+        <button
+          onClick={() => void handleNewSession(true)}
+          disabled={pending}
+          className="w-full flex items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-muted disabled:opacity-50 transition-colors"
+          title="Start a labeled playground session for quick experiments"
+        >
+          <Sparkles className="h-3.5 w-3.5 text-amber-400" />
+          <span>Playground</span>
+        </button>
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div className="border-b border-border px-3 py-2 text-[11px] text-red-400 bg-red-500/5">
+          {error}
+        </div>
+      )}
+
+      {/* Session groups */}
+      <div className="flex-1 overflow-y-auto">
+        {loading && sessions.length === 0 ? (
+          <div className="text-xs text-muted-foreground italic text-center py-8 px-3">
+            Loading sessions…
+          </div>
+        ) : groups.length === 0 ? (
+          <div className="text-xs text-muted-foreground italic text-center py-8 px-3">
+            No sessions yet. Send a message to start one.
+          </div>
+        ) : (
+          groups.map((g) => {
+            const isCollapsed = collapsed[g.key] ?? !g.isCurrent
+            return (
+              <div key={g.key} className="border-b border-border/60 last:border-b-0">
+                <button
+                  onClick={() =>
+                    setCollapsed((prev) => ({ ...prev, [g.key]: !isCollapsed }))
+                  }
+                  className="w-full flex items-center gap-1.5 px-3 py-2 text-left hover:bg-muted transition-colors"
+                  title={g.root}
+                >
+                  {isCollapsed ? (
+                    <ChevronRight className="h-3 w-3 text-muted-foreground shrink-0" />
+                  ) : (
+                    <ChevronDown className="h-3 w-3 text-muted-foreground shrink-0" />
+                  )}
+                  <FolderOpen className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                  <span className="text-xs font-medium truncate flex-1">
+                    {g.name}
+                  </span>
+                  {g.isCurrent && (
+                    <span className="text-[10px] px-1 py-0.5 rounded bg-primary/20 text-primary shrink-0">
+                      current
+                    </span>
+                  )}
+                  <span className="text-[10px] text-muted-foreground shrink-0">
+                    {g.sessions.length}
+                  </span>
+                </button>
+
+                {!isCollapsed && (
+                  <ul className="pb-1">
+                    {g.sessions.map((s) => (
+                      <SessionItem
+                        key={s.session_id}
+                        session={s}
+                        active={s.session_id === activeSessionId}
+                        disabled={pending}
+                        onClick={() => void handleSwitchSession(s.session_id)}
+                      />
+                    ))}
+                    {g.sessions.length === 0 && (
+                      <li className="text-[11px] text-muted-foreground italic px-9 py-1">
+                        no saved sessions
+                      </li>
+                    )}
+                  </ul>
+                )}
+              </div>
+            )
+          })
+        )}
+      </div>
+    </aside>
+  )
+}
+
+// ---------------------------------------------------------------------------
+
+interface SessionItemProps {
+  session: SessionSummary
+  active: boolean
+  disabled: boolean
+  onClick: () => void
+}
+
+function SessionItem({ session, active, disabled, onClick }: SessionItemProps) {
+  const label = session.title?.trim() || '(empty session)'
+  const ts = formatTimestamp(session.last_modified)
+
+  return (
+    <li>
+      <button
+        onClick={onClick}
+        disabled={disabled}
+        className={`w-full text-left px-3 py-1.5 pl-9 pr-3 hover:bg-muted transition-colors disabled:opacity-60 ${
+          active ? 'bg-primary/10 border-l-2 border-primary' : ''
+        }`}
+        title={`${session.session_id}\n${session.cwd}`}
+      >
+        <div className="text-xs text-foreground truncate">{label}</div>
+        <div className="text-[10px] text-muted-foreground flex items-center gap-2">
+          <span>{ts}</span>
+          <span>·</span>
+          <span>{session.message_count} msgs</span>
+        </div>
+      </button>
+    </li>
+  )
+}
+
+function formatTimestamp(unixSeconds: number): string {
+  if (!unixSeconds) return 'unknown'
+  const d = new Date(unixSeconds * 1000)
+  const now = new Date()
+  const sameDay =
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate()
+
+  if (sameDay) {
+    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  }
+  return d.toLocaleDateString([], { month: 'short', day: 'numeric' })
+}

--- a/web-ui/src/lib/api.ts
+++ b/web-ui/src/lib/api.ts
@@ -1,5 +1,10 @@
 import { useChatStore } from './store'
-import type { AppState, StreamingBlock } from './types'
+import type {
+  AppState,
+  SessionDetail,
+  SessionListResponse,
+  StreamingBlock,
+} from './types'
 
 const API_BASE = ''  // same origin in dev (Vite proxy) and prod (embedded)
 
@@ -334,6 +339,50 @@ export async function updateSetting(action: string, value: unknown): Promise<Set
 interface CommandResponse {
   type: 'output' | 'clear' | 'error'
   content: string
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2: Session navigation APIs
+// ---------------------------------------------------------------------------
+
+/** List all sessions + the current workspace descriptor. */
+export async function fetchSessions(): Promise<SessionListResponse> {
+  const res = await fetch(`${API_BASE}/api/sessions`)
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  return res.json()
+}
+
+/** Create a fresh session. Returns the new session_id. */
+export async function createNewSession(): Promise<{ session_id: string }> {
+  const res = await fetch(`${API_BASE}/api/sessions/new`, { method: 'POST' })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: res.statusText }))
+    throw new Error(err.error || `HTTP ${res.status}`)
+  }
+  return res.json()
+}
+
+/** Load a session's messages without switching the engine. */
+export async function fetchSessionDetail(id: string): Promise<SessionDetail> {
+  const res = await fetch(`${API_BASE}/api/sessions/${encodeURIComponent(id)}`)
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: res.statusText }))
+    throw new Error(err.error || `HTTP ${res.status}`)
+  }
+  return res.json()
+}
+
+/** Switch the engine to a previously saved session. */
+export async function resumeSession(id: string): Promise<SessionDetail> {
+  const res = await fetch(
+    `${API_BASE}/api/sessions/${encodeURIComponent(id)}/resume`,
+    { method: 'POST' },
+  )
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: res.statusText }))
+    throw new Error(err.error || `HTTP ${res.status}`)
+  }
+  return res.json()
 }
 
 /**

--- a/web-ui/src/lib/store.ts
+++ b/web-ui/src/lib/store.ts
@@ -1,5 +1,14 @@
 import { create } from 'zustand'
-import type { ChatMessage, AppState, ContentBlock, ResultEvent, StreamingBlock } from './types'
+import type {
+  AppState,
+  ChatMessage,
+  ContentBlock,
+  ResultEvent,
+  SessionSummary,
+  StoredMessage,
+  StreamingBlock,
+  WorkspaceInfo,
+} from './types'
 
 interface ChatStore {
   // Messages
@@ -12,6 +21,12 @@ interface ChatStore {
 
   // App state
   appState: AppState | null
+
+  // Session navigation (Phase 2)
+  sessions: SessionSummary[]
+  currentWorkspace: WorkspaceInfo | null
+  activeSessionId: string | null
+  sessionsLoading: boolean
 
   // Debug
   rawEvents: Array<{ timestamp: number; event: string; data: string }>
@@ -50,6 +65,16 @@ interface ChatStore {
   appendToolInputDelta: (index: number, jsonChunk: string) => void
   finishStreamingBlock: (index: number) => void
   clearStreamingBlocks: () => void
+
+  // Phase 2: session navigation
+  setSessions: (info: {
+    sessions: SessionSummary[]
+    currentWorkspace: WorkspaceInfo
+    activeSessionId: string
+  }) => void
+  setSessionsLoading: (loading: boolean) => void
+  setActiveSessionId: (id: string) => void
+  loadSessionMessages: (messages: StoredMessage[]) => void
 }
 
 export const useChatStore = create<ChatStore>((set, get) => ({
@@ -62,6 +87,11 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   debugPanelOpen: false,
   debugTab: 'events' as const,
   lastResult: null,
+
+  sessions: [],
+  currentWorkspace: null,
+  activeSessionId: null,
+  sessionsLoading: false,
 
   addUserMessage: (content: string) => {
     const msg: ChatMessage = {
@@ -241,5 +271,64 @@ export const useChatStore = create<ChatStore>((set, get) => ({
 
   clearStreamingBlocks: () => {
     set({ streamingBlocks: [] })
+  },
+
+  // Phase 2: session navigation
+  setSessions: ({ sessions, currentWorkspace, activeSessionId }) => {
+    set({ sessions, currentWorkspace, activeSessionId })
+  },
+
+  setSessionsLoading: (loading: boolean) => {
+    set({ sessionsLoading: loading })
+  },
+
+  setActiveSessionId: (id: string) => {
+    set({ activeSessionId: id })
+  },
+
+  loadSessionMessages: (messages: StoredMessage[]) => {
+    // Convert StoredMessage[] -> ChatMessage[] the components already render.
+    // user: plain text preferred over blocks so the regular UserMessage view
+    //   renders as if the message were just typed.
+    // assistant: preserve content_blocks so tool cards light up.
+    // system: surface as system messages.
+    // progress/attachment: dropped — they were intermediate transport and
+    //   aren't needed to reconstruct a readable view.
+    const chat: ChatMessage[] = []
+    for (const m of messages) {
+      if (m.role === 'progress' || m.role === 'attachment') continue
+      if (m.role === 'user') {
+        chat.push({
+          id: m.uuid,
+          role: 'user',
+          content: m.content,
+          timestamp: m.timestamp * 1000,
+          contentBlocks: m.content_blocks,
+        })
+      } else if (m.role === 'assistant') {
+        chat.push({
+          id: m.uuid,
+          role: 'assistant',
+          content: m.content,
+          timestamp: m.timestamp * 1000,
+          contentBlocks: m.content_blocks,
+          toolCalls: (m.content_blocks || []).filter((b) => b.type === 'tool_use'),
+        })
+      } else {
+        chat.push({
+          id: m.uuid,
+          role: 'system',
+          content: m.content,
+          timestamp: m.timestamp * 1000,
+        })
+      }
+    }
+    set({
+      messages: chat,
+      streamingContent: '',
+      streamingBlocks: [],
+      isStreaming: false,
+      lastResult: null,
+    })
   },
 }))

--- a/web-ui/src/lib/types.ts
+++ b/web-ui/src/lib/types.ts
@@ -194,3 +194,54 @@ export interface CommandInfo {
   aliases: string[]
   description: string
 }
+
+// ---------------------------------------------------------------------------
+// Session navigation (Phase 2 of the web UI overhaul)
+// ---------------------------------------------------------------------------
+
+/** Workspace descriptor — the grouping key used on the session sidebar. */
+export interface WorkspaceInfo {
+  key: string
+  root: string
+  name: string
+}
+
+/** Summary row returned by GET /api/sessions. */
+export interface SessionSummary {
+  session_id: string
+  created_at: number
+  last_modified: number
+  message_count: number
+  cwd: string
+  title: string
+  workspace_key: string
+  workspace_root: string
+  workspace_name: string
+}
+
+/** GET /api/sessions response shape. */
+export interface SessionListResponse {
+  current_workspace: WorkspaceInfo
+  active_session_id: string
+  sessions: SessionSummary[]
+}
+
+/** One message from a loaded session. Mirrors the Rust `StoredMessage`. */
+export interface StoredMessage {
+  uuid: string
+  timestamp: number
+  role: 'user' | 'assistant' | 'system' | 'progress' | 'attachment'
+  content: string
+  content_blocks?: ContentBlock[]
+}
+
+/** Full session payload returned by GET /api/sessions/:id and resume. */
+export interface SessionDetail {
+  session_id: string
+  created_at: number
+  last_modified: number
+  cwd: string
+  title: string
+  workspace_name: string
+  messages: StoredMessage[]
+}


### PR DESCRIPTION
## Summary

Delivers phases 2 and 3 of the web UI overhaul from issue #1: session
navigation on the left, workspace-grouped history, and click-to-switch.
Phase 1 (runtime storage paths) landed earlier; phases 4 (composer
upgrades) and 5 (rich markdown / mermaid) are reserved for follow-up PRs.

## What changed

**Backend**
- `SessionInfo` now carries derived fields used for the sidebar:
  `title` (first non-meta user message, truncated to ~80 chars),
  `workspace_key`, `workspace_root`, `workspace_name`. All computed at
  list time in \`list_sessions\` via a new \`build_session_info\` helper
  (\`workspace_key\` is also pub so handlers can compute the current
  workspace for grouping).
- \`WebState\` wraps the engine in \`Arc<RwLock<Arc<QueryEngine>>>\` so
  new / resume can swap engines between turns. Handlers snapshot via
  \`state.engine()\` for the duration of a request, so an in-flight
  stream is never disturbed by a swap. \`QueryEngine\` gains
  \`config_ref()\` so the web layer can clone the config when rebuilding.
- New endpoints registered on \`/api\`:
  - \`GET /api/sessions\` — list + current-workspace descriptor + active id
  - \`GET /api/sessions/{id}\` — preview messages
  - \`POST /api/sessions/new\` — rebuild engine with a fresh session id
  - \`POST /api/sessions/{id}/resume\` — rebuild engine with loaded messages,
    reusing the persisted session id so auto-save stays coherent

**Frontend (web-ui)**
- New \`SessionSidebar\` (\`components/sessions/SessionSidebar.tsx\`):
  workspace-grouped list, current workspace floats to top with a
  \"current\" badge, collapsible groups, \`+ New Session\` and
  \`Playground\` quick actions, refresh + close controls, inline error
  banner, timestamp formatting (time today vs. localized date).
- Store wiring: \`sessions\`, \`currentWorkspace\`, \`activeSessionId\`,
  \`sessionsLoading\`, plus \`setSessions\`, \`setActiveSessionId\`, and
  \`loadSessionMessages\` (converts \`StoredMessage[]\` → \`ChatMessage[]\`,
  preserving \`content_blocks\` so tool cards still render on resumed
  sessions, dropping transport-only roles).
- API client: \`fetchSessions\`, \`fetchSessionDetail\`, \`createNewSession\`,
  \`resumeSession\`.
- Layout: left \`SessionSidebar\` (default open), middle \`ChatPanel\`,
  right settings \`Sidebar\` (unchanged), header gets a toggle button.

## Why

Per issue #1 the left side of the Web UI was a settings drawer only —
no way to start a new session, switch to an old one, or see what else
was on disk. Workspace grouping is needed because \`~/.cc-rust/sessions\`
collects sessions from every repo / worktree on the machine; without
grouping, the list is unreadable.

## Test plan

- [x] \`cargo build --release\` clean (only pre-existing warnings)
- [x] \`cargo test --release --bin claude-code-rs -- session::storage\` — 5/5 pass
- [x] \`tsc --noEmit\` + \`vite build\` clean on web-ui
- [x] E2E in browser (release binary on :3001):
  - 60 historical sessions list under the \"rust (current)\" group with
    derived titles (\"Say hello in 3 languages\", \"say hi\", …)
  - Click a session → chat pane loads stored messages, sidebar marks it active
  - \`Playground\` → messages clear + system hint; active id rotates
  - No console errors across switches

## Reviewer notes

- The \"Playground\" entry is intentionally the same backend call as
  \`+ New Session\` for MVP — it just injects a system hint so the user
  knows what the session is for. A richer distinction (ephemeral mode,
  tagged kind) is deferred to a later PR.
- Rebuilding the engine on new/resume drops the audit sink that
  \`main.rs\` wires up once at startup. For web mode this is acceptable
  (audit is opt-in and the initial session keeps its sink); re-init
  would be the follow-up if we want audit trails across session swaps.
- Axum route syntax uses the 0.7+ \`{id}\` form; the initial pass used
  \`:id\` and panicked at startup, which was caught by
  \`preview_start\` and fixed before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)