### PR TITLE
Implement AWS Bedrock and GCP Vertex as Claude cloud providers (issue #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,22 @@ single data root — `$CC_RUST_HOME` if set, otherwise `~/.cc-rust/`. See
 1) 在 rust/src/api/ 下实现对新服务提供商的封装，遵循现有 Client 设计模式。
 2) 集成到 config 中的 provider 切换逻辑，确保在运行时可选切换。
 
+已内置的第三方云 Claude 接入（AWS Bedrock / GCP Vertex AI）使用方法及已知限制，参见
+[`docs/cloud-providers.md`](docs/cloud-providers.md)。启用示例：
+
+```bash
+# AWS Bedrock
+export CLAUDE_CODE_USE_BEDROCK=1
+export AWS_REGION=us-east-1
+export AWS_BEARER_TOKEN_BEDROCK=...   # or AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY
+
+# GCP Vertex AI
+export CLAUDE_CODE_USE_VERTEX=1
+export ANTHROPIC_VERTEX_PROJECT_ID=my-project
+export CLOUD_ML_REGION=us-east5
+gcloud auth application-default login
+```
+
 测试策略
 - 单元测试：为核心组件（QueryEngine、Tool、Skill、Permissions 等）编写单元测试。
 - 集成测试：通过模拟前端输入，验证整个对话流的正确性与边界条件。

--- a/docs/cloud-providers.md
+++ b/docs/cloud-providers.md
@@ -1,0 +1,152 @@
+# Cloud Claude Providers — AWS Bedrock / GCP Vertex AI
+
+Bedrock and Vertex are **alternative transports for the same Claude
+conversation loop**, not separate product modes. They replace the default
+first-party `api.anthropic.com` endpoint with AWS- or GCP-managed endpoints
+that serve the same Claude models.
+
+## Provider selection
+
+Set one of the following environment variables to activate a third-party
+provider. It takes priority over `ANTHROPIC_API_KEY` and any other provider
+detection:
+
+| Variable                    | Effect                                    |
+|-----------------------------|-------------------------------------------|
+| `CLAUDE_CODE_USE_BEDROCK=1` | Route all Claude calls via AWS Bedrock   |
+| `CLAUDE_CODE_USE_VERTEX=1`  | Route all Claude calls via GCP Vertex AI |
+
+Truthy values: `1`, `true`, `yes`, `on` (case-insensitive). Matches the
+`isEnvTruthy` behavior in `claude-code-bun`.
+
+## AWS Bedrock
+
+### Setup
+
+1. `export CLAUDE_CODE_USE_BEDROCK=1`
+2. Set the region (defaults to `us-east-1`):
+   ```bash
+   export AWS_REGION=us-west-2
+   # or AWS_DEFAULT_REGION=us-west-2
+   ```
+3. Choose an authentication mode:
+
+   **Bedrock API key (recommended for simplicity)**:
+   ```bash
+   export AWS_BEARER_TOKEN_BEDROCK=<bedrock-api-key>
+   ```
+
+   **Standard AWS credentials (SigV4)**:
+   ```bash
+   export AWS_ACCESS_KEY_ID=...
+   export AWS_SECRET_ACCESS_KEY=...
+   export AWS_SESSION_TOKEN=...   # optional, for STS / assume-role
+   ```
+
+### Optional overrides
+
+| Variable                       | Default                                                    | Purpose                           |
+|--------------------------------|------------------------------------------------------------|-----------------------------------|
+| `ANTHROPIC_BEDROCK_BASE_URL`   | `https://bedrock-runtime.{region}.amazonaws.com`          | Override endpoint (proxy / mocks) |
+| `ANTHROPIC_MODEL`              | `claude-sonnet-4-5-20250929`                              | Initial default model             |
+
+### Model mapping
+
+cc-rust uses first-party model IDs internally and auto-translates to Bedrock
+IDs on the wire. You can also pass Bedrock IDs directly.
+
+| cc-rust input                   | Bedrock wire ID                                    |
+|---------------------------------|----------------------------------------------------|
+| `claude-sonnet-4-5-20250929`    | `us.anthropic.claude-sonnet-4-5-20250929-v1:0`    |
+| `claude-haiku-4-5-20251001`     | `us.anthropic.claude-haiku-4-5-20251001-v1:0`     |
+| `claude-opus-4-5-20251101`      | `us.anthropic.claude-opus-4-5-20251101-v1:0`      |
+| `claude-3-7-sonnet-20250219`    | `us.anthropic.claude-3-7-sonnet-20250219-v1:0`    |
+| `anthropic.claude-…-v2:0`       | *(passthrough)*                                    |
+| `eu.anthropic.claude-…-v1:0`    | *(passthrough)*                                    |
+| `arn:aws:bedrock:…`             | *(passthrough)* — supply your own inference profile ARN |
+
+See `src/api/model_mapping.rs` for the full list.
+
+## GCP Vertex AI
+
+### Setup
+
+1. `export CLAUDE_CODE_USE_VERTEX=1`
+2. Set the project ID (first non-empty wins):
+   ```bash
+   export ANTHROPIC_VERTEX_PROJECT_ID=my-project
+   # or GOOGLE_CLOUD_PROJECT, or GCLOUD_PROJECT
+   ```
+3. Set the region (defaults to `us-east5`):
+   ```bash
+   export CLOUD_ML_REGION=europe-west4
+   ```
+4. Provide an access token:
+
+   **Option A — gcloud CLI (recommended)**:
+   ```bash
+   gcloud auth application-default login
+   # cc-rust will invoke `gcloud auth application-default print-access-token`
+   # automatically as a fallback.
+   ```
+
+   **Option B — pre-obtained token**:
+   ```bash
+   export CLAUDE_CODE_VERTEX_ACCESS_TOKEN=$(gcloud auth application-default print-access-token)
+   # or GOOGLE_OAUTH_ACCESS_TOKEN=...
+   ```
+
+### Model mapping
+
+| cc-rust input                   | Vertex wire ID                |
+|---------------------------------|-------------------------------|
+| `claude-sonnet-4-5-20250929`    | `claude-sonnet-4-5@20250929`  |
+| `claude-haiku-4-5-20251001`     | `claude-haiku-4-5@20251001`   |
+| `claude-opus-4-5-20251101`      | `claude-opus-4-5@20251101`    |
+| `claude-opus-4-6`               | `claude-opus-4-6`             |
+| `claude-…@YYYYMMDD`             | *(passthrough)*               |
+
+## Known limits (MVP)
+
+Phase 1 ships basic Claude conversation support. The following are intentionally
+out of scope and tracked for Phase 2:
+
+- **Bedrock streaming transport** — MVP calls the non-streaming `/invoke`
+  endpoint and synthesizes `StreamEvent`s from the single JSON response. True
+  server-side streaming via `invoke-with-response-stream` (AWS EventStream
+  binary format) is not yet implemented. User-visible behavior is identical:
+  the existing stream accumulator / UI sees a valid event sequence.
+- **Bedrock inference profile ARN discovery** — you can pass ARNs directly,
+  but there is no automatic profile listing (`bedrock:ListInferenceProfiles`).
+- **Bedrock CountTokens parity** — token counting uses the shared estimator,
+  not Bedrock's dedicated endpoint.
+- **Vertex per-model region override** — `CLOUD_ML_REGION` is the sole
+  region source; there is no per-model override yet.
+- **Vertex service-account JSON → JWT → token exchange** — not implemented
+  in-process. Users with service accounts should exchange to an access token
+  externally (e.g. via `gcloud auth activate-service-account`).
+- **First-party-only features** (voice, bridge, some analytics) continue to
+  operate as if first-party; feature gating per-provider is also Phase 2.
+
+## Quick verification
+
+Once configured, running the CLI should produce a normal Claude session:
+
+```bash
+# Bedrock
+CLAUDE_CODE_USE_BEDROCK=1 AWS_BEARER_TOKEN_BEDROCK=... AWS_REGION=us-east-1 \
+  cargo run -- "say hi"
+
+# Vertex
+CLAUDE_CODE_USE_VERTEX=1 ANTHROPIC_VERTEX_PROJECT_ID=my-proj \
+  CLOUD_ML_REGION=us-east5 \
+  cargo run -- "say hi"
+```
+
+## Source files
+
+- `src/api/client/mod.rs` — `ApiProvider::{Bedrock, Vertex}` variants and `from_{bedrock,vertex}_env()`
+- `src/api/bedrock.rs` — Bedrock request flow + synthesized streaming
+- `src/api/vertex.rs` — Vertex request flow (real SSE streaming)
+- `src/api/sigv4.rs` — Minimal AWS SigV4 signer (sha2 + hmac, no SDK dep)
+- `src/api/model_mapping.rs` — First-party ↔ provider model ID translation

--- a/src/api/bedrock.rs
+++ b/src/api/bedrock.rs
@@ -1,0 +1,496 @@
+//! AWS Bedrock provider — routes Claude requests to AWS-managed Claude endpoints.
+//!
+//! Bedrock is one of several "third-party cloud" providers for Claude; this
+//! module is a thin adaptation layer that reuses the existing streaming
+//! architecture. It is NOT a separate product — it's an alternative transport
+//! for the same Claude conversation loop.
+//!
+//! # Endpoint
+//!
+//! `POST https://bedrock-runtime.{region}.amazonaws.com/model/{model_id}/invoke`
+//!
+//! With `ANTHROPIC_BEDROCK_BASE_URL` set, the base is overridden (useful for
+//! proxies / mock servers).
+//!
+//! # Authentication (MVP)
+//!
+//! Two modes supported:
+//! - `AWS_BEARER_TOKEN_BEDROCK` (Bedrock API key) → `Authorization: Bearer ...`
+//! - `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` (+ optional `AWS_SESSION_TOKEN`)
+//!   → SigV4 request signing
+//!
+//! # Request body
+//!
+//! Bedrock expects the Anthropic Messages body with two differences:
+//! - The `model` field is removed (model is in the URL).
+//! - `anthropic_version: "bedrock-2023-05-31"` is required.
+//! - `stream` is removed (endpoint suffix determines streaming).
+//!
+//! # Streaming (MVP note)
+//!
+//! MVP uses Bedrock's non-streaming `/invoke` endpoint and synthesizes a
+//! stream of `StreamEvent`s from the single JSON response. True server-side
+//! streaming via `invoke-with-response-stream` (AWS EventStream binary format)
+//! is a Phase-2 enhancement. This satisfies the MVP goal of "basic Claude
+//! conversation works" with the existing accumulator/stream pipeline
+//! unchanged.
+
+use std::pin::Pin;
+
+use anyhow::{bail, Context, Result};
+use futures::Stream;
+use serde_json::{json, Value};
+
+use crate::api::client::MessagesRequest;
+use crate::api::model_mapping::to_bedrock_model_id;
+use crate::api::sigv4::{self, AwsCredentials, SignRequest};
+use crate::types::message::{ContentBlock, MessageDelta, StreamEvent, Usage};
+
+pub const BEDROCK_ANTHROPIC_VERSION: &str = "bedrock-2023-05-31";
+
+/// How the caller authenticates to Bedrock.
+#[derive(Debug, Clone)]
+pub enum BedrockAuth {
+    /// Pre-issued Bedrock API key (`AWS_BEARER_TOKEN_BEDROCK`).
+    BearerToken(String),
+    /// Standard AWS credentials that will be used to SigV4-sign each request.
+    AwsCredentials(AwsCredentials),
+}
+
+impl BedrockAuth {
+    /// Resolve auth from the environment.
+    ///
+    /// Priority:
+    /// 1. `AWS_BEARER_TOKEN_BEDROCK` (simpler; matches claude-code-bun).
+    /// 2. `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` (SigV4).
+    pub fn from_env() -> Option<Self> {
+        if let Ok(tok) = std::env::var("AWS_BEARER_TOKEN_BEDROCK") {
+            if !tok.is_empty() {
+                return Some(Self::BearerToken(tok));
+            }
+        }
+        AwsCredentials::from_env().map(Self::AwsCredentials)
+    }
+}
+
+/// Resolve the AWS region for Bedrock.
+///
+/// Matches claude-code-bun: `AWS_REGION` → `AWS_DEFAULT_REGION`
+/// → default `us-east-1`.
+pub fn resolve_region() -> String {
+    std::env::var("AWS_REGION")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .or_else(|| {
+            std::env::var("AWS_DEFAULT_REGION")
+                .ok()
+                .filter(|v| !v.is_empty())
+        })
+        .unwrap_or_else(|| "us-east-1".to_string())
+}
+
+/// Build the Bedrock invoke URL for a given model ID.
+pub fn build_invoke_url(region: &str, model_id: &str, base_url_override: Option<&str>) -> String {
+    let model_id_encoded = urlencoding::encode(model_id);
+    if let Some(base) = base_url_override {
+        let base = base.trim_end_matches('/');
+        return format!("{}/model/{}/invoke", base, model_id_encoded);
+    }
+    format!(
+        "https://bedrock-runtime.{}.amazonaws.com/model/{}/invoke",
+        region, model_id_encoded
+    )
+}
+
+/// Convert a `MessagesRequest` into the Bedrock-specific JSON body.
+fn to_bedrock_body(request: &MessagesRequest) -> Result<Vec<u8>> {
+    let mut body = json!({
+        "anthropic_version": BEDROCK_ANTHROPIC_VERSION,
+        "max_tokens": request.max_tokens,
+        "messages": request.messages.clone(),
+    });
+    if let Some(system) = &request.system {
+        body["system"] = Value::Array(system.clone());
+    }
+    if let Some(tools) = &request.tools {
+        body["tools"] = Value::Array(tools.clone());
+    }
+    if let Some(thinking) = &request.thinking {
+        body["thinking"] = thinking.clone();
+    }
+    if let Some(tool_choice) = &request.tool_choice {
+        body["tool_choice"] = tool_choice.clone();
+    }
+    serde_json::to_vec(&body).context("failed to serialize Bedrock request body")
+}
+
+/// Parsed `/invoke` response used to synthesize stream events.
+struct InvokeResponse {
+    content: Vec<ContentBlock>,
+    stop_reason: Option<String>,
+    usage: Usage,
+}
+
+fn parse_invoke_response(json_str: &str) -> Result<InvokeResponse> {
+    let v: Value =
+        serde_json::from_str(json_str).context("failed to parse Bedrock JSON response")?;
+
+    let stop_reason = v
+        .get("stop_reason")
+        .and_then(|s| s.as_str())
+        .map(|s| s.to_string());
+
+    let content: Vec<ContentBlock> = v
+        .get("content")
+        .and_then(|c| c.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|block| serde_json::from_value(block.clone()).ok())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let usage: Usage = v
+        .get("usage")
+        .and_then(|u| serde_json::from_value(u.clone()).ok())
+        .unwrap_or_default();
+
+    Ok(InvokeResponse {
+        content,
+        stop_reason,
+        usage,
+    })
+}
+
+/// Turn a single invoke response into the equivalent sequence of
+/// `StreamEvent`s, so downstream consumers see Bedrock as a streaming
+/// provider even though MVP uses the non-streaming `/invoke` endpoint.
+fn synthesize_stream_events(resp: InvokeResponse) -> Vec<StreamEvent> {
+    let mut events = Vec::new();
+
+    // Input tokens go on MessageStart; output tokens on MessageDelta.
+    let mut start_usage = resp.usage.clone();
+    start_usage.output_tokens = 0;
+    events.push(StreamEvent::MessageStart { usage: start_usage });
+
+    for (idx, block) in resp.content.iter().enumerate() {
+        match block {
+            ContentBlock::Text { text } => {
+                events.push(StreamEvent::ContentBlockStart {
+                    index: idx,
+                    content_block: ContentBlock::Text {
+                        text: String::new(),
+                    },
+                });
+                if !text.is_empty() {
+                    events.push(StreamEvent::ContentBlockDelta {
+                        index: idx,
+                        delta: json!({"type": "text_delta", "text": text}),
+                    });
+                }
+                events.push(StreamEvent::ContentBlockStop { index: idx });
+            }
+            ContentBlock::Thinking { thinking, signature } => {
+                events.push(StreamEvent::ContentBlockStart {
+                    index: idx,
+                    content_block: ContentBlock::Thinking {
+                        thinking: String::new(),
+                        signature: signature.clone(),
+                    },
+                });
+                if !thinking.is_empty() {
+                    events.push(StreamEvent::ContentBlockDelta {
+                        index: idx,
+                        delta: json!({"type": "thinking_delta", "thinking": thinking}),
+                    });
+                }
+                events.push(StreamEvent::ContentBlockStop { index: idx });
+            }
+            ContentBlock::ToolUse { id, name, input } => {
+                events.push(StreamEvent::ContentBlockStart {
+                    index: idx,
+                    content_block: ContentBlock::ToolUse {
+                        id: id.clone(),
+                        name: name.clone(),
+                        input: json!({}),
+                    },
+                });
+                events.push(StreamEvent::ContentBlockDelta {
+                    index: idx,
+                    delta: json!({
+                        "type": "input_json_delta",
+                        "partial_json": serde_json::to_string(input).unwrap_or_default(),
+                    }),
+                });
+                events.push(StreamEvent::ContentBlockStop { index: idx });
+            }
+            other => {
+                events.push(StreamEvent::ContentBlockStart {
+                    index: idx,
+                    content_block: other.clone(),
+                });
+                events.push(StreamEvent::ContentBlockStop { index: idx });
+            }
+        }
+    }
+
+    let mut end_usage = Usage::default();
+    end_usage.output_tokens = resp.usage.output_tokens;
+    end_usage.cache_creation_input_tokens = resp.usage.cache_creation_input_tokens;
+    end_usage.cache_read_input_tokens = resp.usage.cache_read_input_tokens;
+    events.push(StreamEvent::MessageDelta {
+        delta: MessageDelta {
+            stop_reason: resp.stop_reason,
+        },
+        usage: Some(end_usage),
+    });
+    events.push(StreamEvent::MessageStop);
+
+    events
+}
+
+/// Bedrock stream provider (implements `StreamProvider`).
+pub struct BedrockStreamProvider {
+    pub region: String,
+    pub auth: BedrockAuth,
+    pub base_url_override: Option<String>,
+}
+
+#[async_trait::async_trait]
+impl crate::api::stream_provider::StreamProvider for BedrockStreamProvider {
+    async fn stream(
+        &self,
+        http: &reqwest::Client,
+        request: &MessagesRequest,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamEvent>> + Send>>> {
+        let bedrock_model = to_bedrock_model_id(&request.model);
+        let url = build_invoke_url(&self.region, &bedrock_model, self.base_url_override.as_deref());
+        let body = to_bedrock_body(request)?;
+
+        let mut builder = http
+            .post(&url)
+            .header("content-type", "application/json")
+            .header("accept", "application/json")
+            .body(body.clone());
+
+        match &self.auth {
+            BedrockAuth::BearerToken(tok) => {
+                builder = builder.header("authorization", format!("Bearer {}", tok));
+            }
+            BedrockAuth::AwsCredentials(creds) => {
+                let parsed = url::Url::parse(&url).context("invalid Bedrock URL")?;
+                let host = parsed.host_str().context("Bedrock URL missing host")?;
+                let path = parsed.path().to_string();
+                let (amz_date, date_stamp) = sigv4::current_timestamps();
+                let signed = sigv4::sign(
+                    &SignRequest {
+                        method: "POST",
+                        host,
+                        path: &path,
+                        region: &self.region,
+                        service: "bedrock",
+                        body: &body,
+                        content_type: "application/json",
+                        amz_date,
+                        date_stamp,
+                    },
+                    creds,
+                )?;
+                builder = builder
+                    .header("authorization", signed.authorization)
+                    .header("x-amz-date", signed.x_amz_date)
+                    .header("x-amz-content-sha256", signed.x_amz_content_sha256);
+                if let Some(tok) = signed.x_amz_security_token {
+                    builder = builder.header("x-amz-security-token", tok);
+                }
+            }
+        }
+
+        let response = builder
+            .send()
+            .await
+            .context("failed to send Bedrock invoke request")?;
+        let status = response.status();
+        let body_text = response
+            .text()
+            .await
+            .unwrap_or_else(|_| String::from("(failed to read Bedrock response body)"));
+
+        if !status.is_success() {
+            bail!(
+                "Bedrock invoke error (HTTP {}): {}",
+                status.as_u16(),
+                body_text
+            );
+        }
+
+        let parsed = parse_invoke_response(&body_text)?;
+        let events = synthesize_stream_events(parsed);
+
+        let stream = futures::stream::iter(events.into_iter().map(Ok));
+        Ok(Box::pin(stream))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn region_defaults_to_us_east_1() {
+        let saved_r = std::env::var("AWS_REGION").ok();
+        let saved_dr = std::env::var("AWS_DEFAULT_REGION").ok();
+        std::env::remove_var("AWS_REGION");
+        std::env::remove_var("AWS_DEFAULT_REGION");
+
+        assert_eq!(resolve_region(), "us-east-1");
+
+        if let Some(v) = saved_r {
+            std::env::set_var("AWS_REGION", v);
+        }
+        if let Some(v) = saved_dr {
+            std::env::set_var("AWS_DEFAULT_REGION", v);
+        }
+    }
+
+    #[test]
+    fn url_uses_region_and_model() {
+        let url = build_invoke_url(
+            "eu-west-1",
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            None,
+        );
+        assert_eq!(
+            url,
+            "https://bedrock-runtime.eu-west-1.amazonaws.com/model/us.anthropic.claude-sonnet-4-5-20250929-v1%3A0/invoke"
+        );
+    }
+
+    #[test]
+    fn url_override_from_base_url() {
+        let url = build_invoke_url("us-east-1", "foo", Some("https://proxy.example.com"));
+        assert_eq!(url, "https://proxy.example.com/model/foo/invoke");
+    }
+
+    #[test]
+    fn body_strips_stream_and_model_adds_anthropic_version() {
+        let req = MessagesRequest {
+            model: "claude-sonnet-4-5-20250929".to_string(),
+            messages: vec![json!({"role":"user","content":"hi"})],
+            system: None,
+            max_tokens: 128,
+            tools: None,
+            stream: true,
+            thinking: None,
+            tool_choice: None,
+        };
+        let raw = to_bedrock_body(&req).unwrap();
+        let v: Value = serde_json::from_slice(&raw).unwrap();
+        assert_eq!(v["anthropic_version"], BEDROCK_ANTHROPIC_VERSION);
+        assert_eq!(v["max_tokens"], 128);
+        assert!(v.get("model").is_none(), "model must not be in body");
+        assert!(v.get("stream").is_none(), "stream must not be in body");
+    }
+
+    #[test]
+    fn parse_invoke_response_extracts_content() {
+        let json = r#"{
+            "id":"msg_123",
+            "role":"assistant",
+            "model":"claude-sonnet-4-5",
+            "content":[{"type":"text","text":"Hello!"}],
+            "stop_reason":"end_turn",
+            "usage":{"input_tokens":10,"output_tokens":3}
+        }"#;
+        let resp = parse_invoke_response(json).unwrap();
+        assert_eq!(resp.content.len(), 1);
+        assert_eq!(resp.stop_reason.as_deref(), Some("end_turn"));
+        assert_eq!(resp.usage.input_tokens, 10);
+        assert_eq!(resp.usage.output_tokens, 3);
+    }
+
+    #[test]
+    fn synthesize_events_yields_complete_stream() {
+        let resp = InvokeResponse {
+            content: vec![ContentBlock::Text {
+                text: "Hello".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Usage {
+                input_tokens: 10,
+                output_tokens: 1,
+                cache_read_input_tokens: 0,
+                cache_creation_input_tokens: 0,
+            },
+        };
+        let events = synthesize_stream_events(resp);
+        assert!(matches!(
+            events.first(),
+            Some(StreamEvent::MessageStart { .. })
+        ));
+        assert!(matches!(events.last(), Some(StreamEvent::MessageStop)));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, StreamEvent::ContentBlockDelta { .. })));
+    }
+
+    #[test]
+    fn synthesized_stream_accumulates_to_text() {
+        let resp = InvokeResponse {
+            content: vec![ContentBlock::Text {
+                text: "Hello, world!".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Usage {
+                input_tokens: 5,
+                output_tokens: 3,
+                cache_read_input_tokens: 0,
+                cache_creation_input_tokens: 0,
+            },
+        };
+        let events = synthesize_stream_events(resp);
+
+        let mut acc = crate::api::streaming::StreamAccumulator::new();
+        for ev in &events {
+            acc.process_event(ev);
+        }
+        let msg = acc.build("claude-sonnet-4-5-20250929");
+        assert_eq!(msg.content.len(), 1);
+        if let ContentBlock::Text { text } = &msg.content[0] {
+            assert_eq!(text, "Hello, world!");
+        } else {
+            panic!("expected Text block");
+        }
+        assert_eq!(msg.stop_reason.as_deref(), Some("end_turn"));
+        assert_eq!(msg.usage.as_ref().unwrap().input_tokens, 5);
+        assert_eq!(msg.usage.as_ref().unwrap().output_tokens, 3);
+    }
+
+    #[test]
+    fn auth_from_env_prefers_bearer_token() {
+        let saved_bearer = std::env::var("AWS_BEARER_TOKEN_BEDROCK").ok();
+        let saved_ak = std::env::var("AWS_ACCESS_KEY_ID").ok();
+        let saved_sk = std::env::var("AWS_SECRET_ACCESS_KEY").ok();
+        std::env::set_var("AWS_BEARER_TOKEN_BEDROCK", "bedrock-key-123");
+        std::env::set_var("AWS_ACCESS_KEY_ID", "AKIA");
+        std::env::set_var("AWS_SECRET_ACCESS_KEY", "secret");
+
+        match BedrockAuth::from_env() {
+            Some(BedrockAuth::BearerToken(t)) => assert_eq!(t, "bedrock-key-123"),
+            other => panic!("expected BearerToken, got {:?}", other),
+        }
+
+        std::env::remove_var("AWS_BEARER_TOKEN_BEDROCK");
+        std::env::remove_var("AWS_ACCESS_KEY_ID");
+        std::env::remove_var("AWS_SECRET_ACCESS_KEY");
+        if let Some(v) = saved_bearer {
+            std::env::set_var("AWS_BEARER_TOKEN_BEDROCK", v);
+        }
+        if let Some(v) = saved_ak {
+            std::env::set_var("AWS_ACCESS_KEY_ID", v);
+        }
+        if let Some(v) = saved_sk {
+            std::env::set_var("AWS_SECRET_ACCESS_KEY", v);
+        }
+    }
+}

--- a/src/api/client/mod.rs
+++ b/src/api/client/mod.rs
@@ -55,12 +55,20 @@ pub enum ApiProvider {
     },
     /// Google Gemini (streamGenerateContent API)
     Google { api_key: String, base_url: String },
-    /// AWS Bedrock (interface only — not implemented)
-    #[allow(dead_code)]
-    Bedrock { region: String, model_id: String },
-    /// GCP Vertex AI (interface only — not implemented)
-    #[allow(dead_code)]
-    Vertex { project_id: String, region: String },
+    /// AWS Bedrock — Claude via AWS-managed endpoints.
+    ///
+    /// `base_url_override` is read from `ANTHROPIC_BEDROCK_BASE_URL` when set.
+    Bedrock {
+        region: String,
+        auth: crate::api::bedrock::BedrockAuth,
+        base_url_override: Option<String>,
+    },
+    /// GCP Vertex AI — Claude via Google-managed endpoints.
+    Vertex {
+        project_id: String,
+        region: String,
+        access_token: crate::api::vertex::VertexAccessToken,
+    },
 }
 
 /// Request body for the Messages API
@@ -125,13 +133,24 @@ fn make_stream_provider(
             api_key: api_key.clone(),
             base_url: endpoint.clone(),
         }),
-        ApiProvider::Bedrock { .. } | ApiProvider::Vertex { .. } => {
-            // These are stubs — create an Anthropic provider that will fail on use
-            Box::new(AnthropicStreamProvider {
-                api_key: String::new(),
-                base_url: String::new(),
-            })
-        }
+        ApiProvider::Bedrock {
+            region,
+            auth,
+            base_url_override,
+        } => Box::new(crate::api::bedrock::BedrockStreamProvider {
+            region: region.clone(),
+            auth: auth.clone(),
+            base_url_override: base_url_override.clone(),
+        }),
+        ApiProvider::Vertex {
+            project_id,
+            region,
+            access_token,
+        } => Box::new(crate::api::vertex::VertexStreamProvider {
+            region: region.clone(),
+            project_id: project_id.clone(),
+            access_token: access_token.clone(),
+        }),
     }
 }
 
@@ -186,12 +205,22 @@ impl ApiClient {
                 build_openai_compat_url(base_url, name)
             }
             ApiProvider::Google { base_url, .. } => base_url.clone(),
-            ApiProvider::Bedrock { .. } => {
-                unimplemented!("AWS Bedrock provider is not implemented")
-            }
-            ApiProvider::Vertex { .. } => {
-                unimplemented!("GCP Vertex AI provider is not implemented")
-            }
+            ApiProvider::Bedrock {
+                region,
+                base_url_override,
+                ..
+            } => crate::api::bedrock::build_invoke_url(
+                region,
+                &crate::api::model_mapping::to_bedrock_model_id(&self.config.default_model),
+                base_url_override.as_deref(),
+            ),
+            ApiProvider::Vertex {
+                project_id, region, ..
+            } => crate::api::vertex::build_stream_url(
+                region,
+                project_id,
+                &crate::api::model_mapping::to_vertex_model_id(&self.config.default_model),
+            ),
         }
     }
 
@@ -223,14 +252,26 @@ impl ApiClient {
 
     /// Auto-detect provider from environment variables and construct an `ApiClient`.
     ///
-    /// Checks all registered providers (Anthropic, Azure, OpenAI, Google, DeepSeek, etc.)
-    /// and returns the first one that has an API key set in the environment.
+    /// Priority:
+    /// 1. `CLAUDE_CODE_USE_BEDROCK=1` → AWS Bedrock (Claude)
+    /// 2. `CLAUDE_CODE_USE_VERTEX=1`  → GCP Vertex AI (Claude)
+    /// 3. First of the registered API-key providers (Anthropic, Azure, OpenAI, …)
+    ///    that has its env var set.
     ///
     /// For Azure OpenAI, the base URL is read from `AZURE_BASE_URL` since it is
     /// deployment-specific (e.g. `https://<resource>.openai.azure.com/openai/v1/`).
     ///
-    /// Returns `None` if no provider has an API key set.
+    /// Returns `None` if no provider is configured.
     pub fn from_env() -> Option<Self> {
+        // 1. CLAUDE_CODE_USE_BEDROCK / _VERTEX — third-party cloud providers
+        //    checked BEFORE API-key providers, matching claude-code-bun.
+        if is_env_truthy("CLAUDE_CODE_USE_BEDROCK") {
+            return Self::from_bedrock_env();
+        }
+        if is_env_truthy("CLAUDE_CODE_USE_VERTEX") {
+            return Self::from_vertex_env();
+        }
+
         let info = crate::api::providers::detect_provider()?;
         let api_key = std::env::var(info.env_key).ok()?;
 
@@ -284,6 +325,66 @@ impl ApiClient {
         }
 
         Some(Self::from_provider_info(info, &api_key))
+    }
+
+    /// Construct an `ApiClient` for AWS Bedrock using environment variables.
+    ///
+    /// Honors (matching claude-code-bun):
+    /// - `AWS_REGION` / `AWS_DEFAULT_REGION` — region selection
+    /// - `AWS_BEARER_TOKEN_BEDROCK` — preferred auth (Bedrock API key)
+    /// - `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` — SigV4
+    /// - `ANTHROPIC_BEDROCK_BASE_URL` — override the default endpoint
+    ///
+    /// Returns `None` if neither auth mode is available.
+    pub fn from_bedrock_env() -> Option<Self> {
+        let auth = crate::api::bedrock::BedrockAuth::from_env()?;
+        let region = crate::api::bedrock::resolve_region();
+        let base_url_override = std::env::var("ANTHROPIC_BEDROCK_BASE_URL")
+            .ok()
+            .filter(|v| !v.is_empty());
+        let default_model = std::env::var("ANTHROPIC_MODEL")
+            .ok()
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| "claude-sonnet-4-5-20250929".to_string());
+        Some(Self::new(ApiClientConfig {
+            provider: ApiProvider::Bedrock {
+                region,
+                auth,
+                base_url_override,
+            },
+            default_model,
+            max_retries: 3,
+            timeout_secs: 120,
+        }))
+    }
+
+    /// Construct an `ApiClient` for GCP Vertex AI using environment variables.
+    ///
+    /// Honors:
+    /// - `CLOUD_ML_REGION` — region (default: `us-east5`)
+    /// - `ANTHROPIC_VERTEX_PROJECT_ID` / `GOOGLE_CLOUD_PROJECT` / `GCLOUD_PROJECT` — project ID
+    /// - `CLAUDE_CODE_VERTEX_ACCESS_TOKEN` / `GOOGLE_OAUTH_ACCESS_TOKEN` — access token
+    ///   (falls back to `gcloud auth application-default print-access-token` subprocess)
+    ///
+    /// Returns `None` if project ID or access token can't be resolved.
+    pub fn from_vertex_env() -> Option<Self> {
+        let project_id = crate::api::vertex::resolve_project_id()?;
+        let region = crate::api::vertex::resolve_region();
+        let access_token = crate::api::vertex::VertexAccessToken::from_env_or_gcloud()?;
+        let default_model = std::env::var("ANTHROPIC_MODEL")
+            .ok()
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| "claude-sonnet-4-5-20250929".to_string());
+        Some(Self::new(ApiClientConfig {
+            provider: ApiProvider::Vertex {
+                project_id,
+                region,
+                access_token,
+            },
+            default_model,
+            max_retries: 3,
+            timeout_secs: 120,
+        }))
     }
 
     /// Construct an `ApiClient` for the OpenAI Codex provider.
@@ -473,5 +574,17 @@ impl ApiClient {
     /// Get a reference to the config.
     pub fn config(&self) -> &ApiClientConfig {
         &self.config
+    }
+}
+
+/// Return true if env var `name` is set to a truthy value (`1`, `true`, `yes`,
+/// `on`). Matches claude-code-bun's `isEnvTruthy` semantics.
+pub(crate) fn is_env_truthy(name: &str) -> bool {
+    match std::env::var(name) {
+        Ok(v) => matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        ),
+        Err(_) => false,
     }
 }

--- a/src/api/client/tests.rs
+++ b/src/api/client/tests.rs
@@ -61,35 +61,69 @@ fn test_build_url_anthropic_trailing_slash() {
 }
 
 #[test]
-#[should_panic(expected = "AWS Bedrock provider is not implemented")]
-fn test_build_url_bedrock_not_implemented() {
+fn test_build_url_bedrock_returns_aws_endpoint() {
     let config = ApiClientConfig {
         provider: ApiProvider::Bedrock {
             region: "us-east-1".to_string(),
-            model_id: "anthropic.claude-sonnet-4-20250514-v1:0".to_string(),
+            auth: crate::api::bedrock::BedrockAuth::BearerToken("dummy".to_string()),
+            base_url_override: None,
         },
-        default_model: "claude-sonnet-4-20250514".to_string(),
+        default_model: "claude-sonnet-4-5-20250929".to_string(),
         max_retries: 3,
         timeout_secs: 60,
     };
     let client = ApiClient::new(config);
-    let _ = client.build_url(); // should panic
+    let url = client.build_url();
+    assert!(
+        url.starts_with("https://bedrock-runtime.us-east-1.amazonaws.com/model/"),
+        "unexpected URL: {url}"
+    );
+    assert!(url.ends_with("/invoke"), "unexpected URL: {url}");
+    // Default model gets translated to its Bedrock ID.
+    assert!(
+        url.contains("us.anthropic.claude-sonnet-4-5-20250929-v1"),
+        "URL missing translated Bedrock model: {url}"
+    );
 }
 
 #[test]
-#[should_panic(expected = "GCP Vertex AI provider is not implemented")]
-fn test_build_url_vertex_not_implemented() {
+fn test_build_url_bedrock_with_override() {
     let config = ApiClientConfig {
-        provider: ApiProvider::Vertex {
-            project_id: "my-project".to_string(),
-            region: "us-central1".to_string(),
+        provider: ApiProvider::Bedrock {
+            region: "us-east-1".to_string(),
+            auth: crate::api::bedrock::BedrockAuth::BearerToken("dummy".to_string()),
+            base_url_override: Some("https://proxy.example.com".to_string()),
         },
-        default_model: "claude-sonnet-4-20250514".to_string(),
+        default_model: "claude-sonnet-4-5-20250929".to_string(),
         max_retries: 3,
         timeout_secs: 60,
     };
     let client = ApiClient::new(config);
-    let _ = client.build_url(); // should panic
+    let url = client.build_url();
+    assert!(
+        url.starts_with("https://proxy.example.com/model/"),
+        "override should be used, got: {url}"
+    );
+}
+
+#[test]
+fn test_build_url_vertex_returns_streamrawpredict() {
+    let config = ApiClientConfig {
+        provider: ApiProvider::Vertex {
+            project_id: "my-project".to_string(),
+            region: "us-east5".to_string(),
+            access_token: crate::api::vertex::VertexAccessToken("dummy".to_string()),
+        },
+        default_model: "claude-sonnet-4-5-20250929".to_string(),
+        max_retries: 3,
+        timeout_secs: 60,
+    };
+    let client = ApiClient::new(config);
+    let url = client.build_url();
+    assert_eq!(
+        url,
+        "https://us-east5-aiplatform.googleapis.com/v1/projects/my-project/locations/us-east5/publishers/anthropic/models/claude-sonnet-4-5@20250929:streamRawPredict"
+    );
 }
 
 #[test]
@@ -243,7 +277,8 @@ fn test_build_headers_bedrock_no_api_key() {
     let config = ApiClientConfig {
         provider: ApiProvider::Bedrock {
             region: "us-east-1".to_string(),
-            model_id: "model-id".to_string(),
+            auth: crate::api::bedrock::BedrockAuth::BearerToken("dummy".to_string()),
+            base_url_override: None,
         },
         default_model: "model".to_string(),
         max_retries: 1,
@@ -251,7 +286,11 @@ fn test_build_headers_bedrock_no_api_key() {
     };
     let client = ApiClient::new(config);
     let headers = client.build_headers_map();
+    // Generic header map deliberately does not include Bedrock auth — the
+    // Bedrock provider sets Bearer/SigV4 headers per-request in its stream
+    // implementation.
     assert!(headers.get("x-api-key").is_none());
+    assert!(headers.get("authorization").is_none());
     assert_eq!(headers.get("content-type").unwrap(), "application/json");
 }
 
@@ -390,6 +429,111 @@ fn test_from_codex_auth_with_env() {
     std::env::remove_var(OPENAI_CODEX_TOKEN_ENV);
     std::env::remove_var(OPENAI_CODEX_BASE_URL_ENV);
     std::env::remove_var(OPENAI_CODEX_MODEL_ENV);
+}
+
+#[test]
+fn test_from_env_prefers_bedrock_when_flag_set() {
+    let _env_lock = ENV_LOCK.lock().expect("env lock poisoned");
+    // Save + clear all provider keys so Anthropic-API-key detection doesn't shadow.
+    let saved_keys: Vec<_> = crate::api::providers::PROVIDERS
+        .iter()
+        .filter_map(|p| std::env::var(p.env_key).ok().map(|v| (p.env_key, v)))
+        .collect();
+    for p in crate::api::providers::PROVIDERS {
+        std::env::remove_var(p.env_key);
+    }
+
+    std::env::set_var("CLAUDE_CODE_USE_BEDROCK", "1");
+    std::env::set_var("AWS_BEARER_TOKEN_BEDROCK", "bedrock-123");
+    std::env::set_var("AWS_REGION", "us-west-2");
+
+    let client = ApiClient::from_env().expect("Bedrock flag should produce a client");
+    match &client.config().provider {
+        ApiProvider::Bedrock { region, .. } => assert_eq!(region, "us-west-2"),
+        other => panic!("expected Bedrock provider, got {:?}", other),
+    }
+
+    std::env::remove_var("CLAUDE_CODE_USE_BEDROCK");
+    std::env::remove_var("AWS_BEARER_TOKEN_BEDROCK");
+    std::env::remove_var("AWS_REGION");
+    for (k, v) in saved_keys {
+        std::env::set_var(k, v);
+    }
+}
+
+#[test]
+fn test_from_env_prefers_vertex_when_flag_set() {
+    let _env_lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let saved_keys: Vec<_> = crate::api::providers::PROVIDERS
+        .iter()
+        .filter_map(|p| std::env::var(p.env_key).ok().map(|v| (p.env_key, v)))
+        .collect();
+    for p in crate::api::providers::PROVIDERS {
+        std::env::remove_var(p.env_key);
+    }
+    let saved_p_id = std::env::var("ANTHROPIC_VERTEX_PROJECT_ID").ok();
+    let saved_token = std::env::var("CLAUDE_CODE_VERTEX_ACCESS_TOKEN").ok();
+    let saved_region = std::env::var("CLOUD_ML_REGION").ok();
+
+    std::env::set_var("CLAUDE_CODE_USE_VERTEX", "true");
+    std::env::set_var("ANTHROPIC_VERTEX_PROJECT_ID", "proj-42");
+    std::env::set_var("CLAUDE_CODE_VERTEX_ACCESS_TOKEN", "ya29.test");
+    std::env::set_var("CLOUD_ML_REGION", "europe-west4");
+
+    let client = ApiClient::from_env().expect("Vertex flag should produce a client");
+    match &client.config().provider {
+        ApiProvider::Vertex {
+            project_id, region, ..
+        } => {
+            assert_eq!(project_id, "proj-42");
+            assert_eq!(region, "europe-west4");
+        }
+        other => panic!("expected Vertex provider, got {:?}", other),
+    }
+
+    std::env::remove_var("CLAUDE_CODE_USE_VERTEX");
+    std::env::remove_var("ANTHROPIC_VERTEX_PROJECT_ID");
+    std::env::remove_var("CLAUDE_CODE_VERTEX_ACCESS_TOKEN");
+    std::env::remove_var("CLOUD_ML_REGION");
+    if let Some(v) = saved_p_id {
+        std::env::set_var("ANTHROPIC_VERTEX_PROJECT_ID", v);
+    }
+    if let Some(v) = saved_token {
+        std::env::set_var("CLAUDE_CODE_VERTEX_ACCESS_TOKEN", v);
+    }
+    if let Some(v) = saved_region {
+        std::env::set_var("CLOUD_ML_REGION", v);
+    }
+    for (k, v) in saved_keys {
+        std::env::set_var(k, v);
+    }
+}
+
+#[test]
+fn test_from_bedrock_env_returns_none_without_auth() {
+    let _env_lock = ENV_LOCK.lock().expect("env lock poisoned");
+    // Ensure neither auth method is available.
+    let saved_bearer = std::env::var("AWS_BEARER_TOKEN_BEDROCK").ok();
+    let saved_ak = std::env::var("AWS_ACCESS_KEY_ID").ok();
+    let saved_sk = std::env::var("AWS_SECRET_ACCESS_KEY").ok();
+    std::env::remove_var("AWS_BEARER_TOKEN_BEDROCK");
+    std::env::remove_var("AWS_ACCESS_KEY_ID");
+    std::env::remove_var("AWS_SECRET_ACCESS_KEY");
+
+    assert!(
+        ApiClient::from_bedrock_env().is_none(),
+        "from_bedrock_env should yield None without AWS creds"
+    );
+
+    if let Some(v) = saved_bearer {
+        std::env::set_var("AWS_BEARER_TOKEN_BEDROCK", v);
+    }
+    if let Some(v) = saved_ak {
+        std::env::set_var("AWS_ACCESS_KEY_ID", v);
+    }
+    if let Some(v) = saved_sk {
+        std::env::set_var("AWS_SECRET_ACCESS_KEY", v);
+    }
 }
 
 #[test]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,12 +1,17 @@
 //! API Client — multi-provider LLM integration.
 //!
-//! Supports: Anthropic (native), OpenAI-compatible (15+ providers), Google Gemini.
+//! Supports: Anthropic (native), OpenAI-compatible (15+ providers),
+//! Google Gemini, AWS Bedrock (Claude), GCP Vertex AI (Claude).
 
+pub mod bedrock;
 pub mod client;
 pub mod google_provider;
+pub mod model_mapping;
 pub mod openai_compat;
 pub mod pricing;
 pub mod providers;
 pub mod retry;
+pub mod sigv4;
 pub mod stream_provider;
 pub mod streaming;
+pub mod vertex;

--- a/src/api/model_mapping.rs
+++ b/src/api/model_mapping.rs
@@ -1,0 +1,200 @@
+//! Claude model ID mapping across providers (first-party, Bedrock, Vertex).
+//!
+//! cc-rust uses first-party Claude model IDs (e.g. `claude-sonnet-4-5-20250929`)
+//! internally. When talking to AWS Bedrock or GCP Vertex AI, these IDs need to
+//! be translated to provider-specific strings:
+//!
+//! - Bedrock: `us.anthropic.claude-sonnet-4-5-20250929-v1:0`
+//! - Vertex:  `claude-sonnet-4-5@20250929`
+//!
+//! Reference: claude-code-bun `src/utils/model/configs.ts`.
+
+/// A single Claude model's IDs across providers.
+#[derive(Debug, Clone, Copy)]
+pub struct ModelConfig {
+    pub first_party: &'static str,
+    pub bedrock: &'static str,
+    pub vertex: &'static str,
+}
+
+/// All known Claude model configs.
+///
+/// Order matters: mapping lookups use the first match for substring matching
+/// when the input is already in a provider-specific format.
+pub const CLAUDE_MODELS: &[ModelConfig] = &[
+    ModelConfig {
+        first_party: "claude-opus-4-6",
+        bedrock: "us.anthropic.claude-opus-4-6-v1",
+        vertex: "claude-opus-4-6",
+    },
+    ModelConfig {
+        first_party: "claude-sonnet-4-6",
+        bedrock: "us.anthropic.claude-sonnet-4-6",
+        vertex: "claude-sonnet-4-6",
+    },
+    ModelConfig {
+        first_party: "claude-opus-4-5-20251101",
+        bedrock: "us.anthropic.claude-opus-4-5-20251101-v1:0",
+        vertex: "claude-opus-4-5@20251101",
+    },
+    ModelConfig {
+        first_party: "claude-opus-4-1-20250805",
+        bedrock: "us.anthropic.claude-opus-4-1-20250805-v1:0",
+        vertex: "claude-opus-4-1@20250805",
+    },
+    ModelConfig {
+        first_party: "claude-opus-4-20250514",
+        bedrock: "us.anthropic.claude-opus-4-20250514-v1:0",
+        vertex: "claude-opus-4@20250514",
+    },
+    ModelConfig {
+        first_party: "claude-sonnet-4-5-20250929",
+        bedrock: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        vertex: "claude-sonnet-4-5@20250929",
+    },
+    ModelConfig {
+        first_party: "claude-sonnet-4-20250514",
+        bedrock: "us.anthropic.claude-sonnet-4-20250514-v1:0",
+        vertex: "claude-sonnet-4@20250514",
+    },
+    ModelConfig {
+        first_party: "claude-haiku-4-5-20251001",
+        bedrock: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        vertex: "claude-haiku-4-5@20251001",
+    },
+    ModelConfig {
+        first_party: "claude-3-7-sonnet-20250219",
+        bedrock: "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+        vertex: "claude-3-7-sonnet@20250219",
+    },
+    ModelConfig {
+        first_party: "claude-3-5-sonnet-20241022",
+        bedrock: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        vertex: "claude-3-5-sonnet-v2@20241022",
+    },
+    ModelConfig {
+        first_party: "claude-3-5-haiku-20241022",
+        bedrock: "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+        vertex: "claude-3-5-haiku@20241022",
+    },
+];
+
+/// Translate a first-party Claude model ID to its Bedrock equivalent.
+///
+/// If the input is already in Bedrock format (contains `anthropic.` or a known
+/// region prefix), it is returned unchanged. Unknown models are returned as-is
+/// so users can pass custom inference profile ARNs or IDs.
+pub fn to_bedrock_model_id(model: &str) -> String {
+    if looks_like_bedrock_id(model) {
+        return model.to_string();
+    }
+    for cfg in CLAUDE_MODELS {
+        if cfg.first_party == model {
+            return cfg.bedrock.to_string();
+        }
+    }
+    model.to_string()
+}
+
+/// Translate a first-party Claude model ID to its Vertex equivalent.
+///
+/// If the input already contains `@` (Vertex version separator), it is returned
+/// unchanged. Unknown models are returned as-is.
+pub fn to_vertex_model_id(model: &str) -> String {
+    if model.contains('@') || model.starts_with("projects/") {
+        return model.to_string();
+    }
+    for cfg in CLAUDE_MODELS {
+        if cfg.first_party == model {
+            return cfg.vertex.to_string();
+        }
+    }
+    model.to_string()
+}
+
+/// Return true if `model` looks like it's already in Bedrock format.
+fn looks_like_bedrock_id(model: &str) -> bool {
+    if model.starts_with("arn:") {
+        return true;
+    }
+    if model.starts_with("anthropic.") {
+        return true;
+    }
+    // Region-prefixed cross-region inference profiles (us/eu/apac/global).
+    for prefix in ["us.", "eu.", "apac.", "global."] {
+        if model.starts_with(prefix) && model[prefix.len()..].starts_with("anthropic.") {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_party_to_bedrock_sonnet45() {
+        assert_eq!(
+            to_bedrock_model_id("claude-sonnet-4-5-20250929"),
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        );
+    }
+
+    #[test]
+    fn first_party_to_bedrock_haiku45() {
+        assert_eq!(
+            to_bedrock_model_id("claude-haiku-4-5-20251001"),
+            "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+        );
+    }
+
+    #[test]
+    fn bedrock_passthrough_region_prefix() {
+        assert_eq!(
+            to_bedrock_model_id("eu.anthropic.claude-sonnet-4-5-20250929-v1:0"),
+            "eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        );
+    }
+
+    #[test]
+    fn bedrock_passthrough_foundation_model() {
+        assert_eq!(
+            to_bedrock_model_id("anthropic.claude-3-5-sonnet-20241022-v2:0"),
+            "anthropic.claude-3-5-sonnet-20241022-v2:0"
+        );
+    }
+
+    #[test]
+    fn bedrock_passthrough_arn() {
+        let arn = "arn:aws:bedrock:us-east-1:123:inference-profile/claude-opus-4";
+        assert_eq!(to_bedrock_model_id(arn), arn);
+    }
+
+    #[test]
+    fn first_party_to_vertex_sonnet45() {
+        assert_eq!(
+            to_vertex_model_id("claude-sonnet-4-5-20250929"),
+            "claude-sonnet-4-5@20250929"
+        );
+    }
+
+    #[test]
+    fn first_party_to_vertex_opus46() {
+        assert_eq!(to_vertex_model_id("claude-opus-4-6"), "claude-opus-4-6");
+    }
+
+    #[test]
+    fn vertex_passthrough_at_separator() {
+        assert_eq!(
+            to_vertex_model_id("claude-sonnet-4-5@20250929"),
+            "claude-sonnet-4-5@20250929"
+        );
+    }
+
+    #[test]
+    fn unknown_model_passthrough() {
+        assert_eq!(to_bedrock_model_id("custom-model-id"), "custom-model-id");
+        assert_eq!(to_vertex_model_id("custom-model-id"), "custom-model-id");
+    }
+}

--- a/src/api/sigv4.rs
+++ b/src/api/sigv4.rs
@@ -1,0 +1,268 @@
+//! AWS Signature Version 4 (SigV4) request signing — minimal implementation
+//! for Bedrock `/invoke` requests.
+//!
+//! Only implements what's needed to sign a single POST request with a JSON
+//! body. Does not cover query strings, multi-part, chunked streaming, or
+//! presigned URLs.
+//!
+//! Reference: https://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html
+
+use anyhow::{Context, Result};
+use hmac::{Hmac, Mac};
+use sha2::{Digest, Sha256};
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// AWS credentials used for SigV4 signing.
+#[derive(Debug, Clone)]
+pub struct AwsCredentials {
+    pub access_key_id: String,
+    pub secret_access_key: String,
+    pub session_token: Option<String>,
+}
+
+impl AwsCredentials {
+    /// Build credentials from standard environment variables:
+    /// `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN`.
+    pub fn from_env() -> Option<Self> {
+        let access_key_id = std::env::var("AWS_ACCESS_KEY_ID").ok()?;
+        let secret_access_key = std::env::var("AWS_SECRET_ACCESS_KEY").ok()?;
+        if access_key_id.is_empty() || secret_access_key.is_empty() {
+            return None;
+        }
+        let session_token = std::env::var("AWS_SESSION_TOKEN")
+            .ok()
+            .filter(|v| !v.is_empty());
+        Some(Self {
+            access_key_id,
+            secret_access_key,
+            session_token,
+        })
+    }
+}
+
+/// Inputs to a SigV4 POST request signature.
+pub struct SignRequest<'a> {
+    pub method: &'a str,
+    pub host: &'a str,
+    pub path: &'a str,
+    pub region: &'a str,
+    pub service: &'a str,
+    pub body: &'a [u8],
+    pub content_type: &'a str,
+    /// `YYYYMMDD'T'HHMMSS'Z'` timestamp, e.g. `20240115T143000Z`.
+    pub amz_date: String,
+    /// `YYYYMMDD`, e.g. `20240115`.
+    pub date_stamp: String,
+}
+
+/// Headers computed by `sign()` that the caller must set on the outgoing request.
+#[derive(Debug, Clone)]
+pub struct SignedHeaders {
+    pub authorization: String,
+    pub x_amz_date: String,
+    pub x_amz_content_sha256: String,
+    pub x_amz_security_token: Option<String>,
+}
+
+/// Compute SigV4 signature for a POST JSON request.
+pub fn sign(req: &SignRequest, creds: &AwsCredentials) -> Result<SignedHeaders> {
+    let payload_hash = hex::encode(Sha256::digest(req.body));
+
+    // Canonical headers — must be sorted by lowercased name.
+    // We include: content-type, host, x-amz-content-sha256, x-amz-date,
+    // and optionally x-amz-security-token.
+    let mut canonical_headers = format!(
+        "content-type:{}\nhost:{}\nx-amz-content-sha256:{}\nx-amz-date:{}\n",
+        req.content_type, req.host, payload_hash, req.amz_date,
+    );
+    let mut signed_header_names = String::from("content-type;host;x-amz-content-sha256;x-amz-date");
+    if let Some(tok) = &creds.session_token {
+        canonical_headers.push_str(&format!("x-amz-security-token:{}\n", tok));
+        signed_header_names.push_str(";x-amz-security-token");
+    }
+
+    let canonical_request = format!(
+        "{method}\n{path}\n{query}\n{headers}\n{signed}\n{payload}",
+        method = req.method,
+        path = req.path,
+        query = "", // no query string
+        headers = canonical_headers,
+        signed = signed_header_names,
+        payload = payload_hash,
+    );
+
+    let canonical_request_hash = hex::encode(Sha256::digest(canonical_request.as_bytes()));
+
+    let credential_scope = format!(
+        "{date}/{region}/{service}/aws4_request",
+        date = req.date_stamp,
+        region = req.region,
+        service = req.service,
+    );
+
+    let string_to_sign = format!(
+        "AWS4-HMAC-SHA256\n{date}\n{scope}\n{hash}",
+        date = req.amz_date,
+        scope = credential_scope,
+        hash = canonical_request_hash,
+    );
+
+    let signing_key = derive_signing_key(
+        &creds.secret_access_key,
+        &req.date_stamp,
+        req.region,
+        req.service,
+    )
+    .context("failed to derive SigV4 signing key")?;
+
+    let signature = hex::encode(hmac_sha256(&signing_key, string_to_sign.as_bytes())?);
+
+    let authorization = format!(
+        "AWS4-HMAC-SHA256 Credential={ak}/{scope}, SignedHeaders={signed}, Signature={sig}",
+        ak = creds.access_key_id,
+        scope = credential_scope,
+        signed = signed_header_names,
+        sig = signature,
+    );
+
+    Ok(SignedHeaders {
+        authorization,
+        x_amz_date: req.amz_date.clone(),
+        x_amz_content_sha256: payload_hash,
+        x_amz_security_token: creds.session_token.clone(),
+    })
+}
+
+fn hmac_sha256(key: &[u8], data: &[u8]) -> Result<Vec<u8>> {
+    let mut mac =
+        HmacSha256::new_from_slice(key).context("invalid HMAC-SHA256 key (wrong length)")?;
+    mac.update(data);
+    Ok(mac.finalize().into_bytes().to_vec())
+}
+
+fn derive_signing_key(
+    secret: &str,
+    date_stamp: &str,
+    region: &str,
+    service: &str,
+) -> Result<Vec<u8>> {
+    let k_date = hmac_sha256(format!("AWS4{}", secret).as_bytes(), date_stamp.as_bytes())?;
+    let k_region = hmac_sha256(&k_date, region.as_bytes())?;
+    let k_service = hmac_sha256(&k_region, service.as_bytes())?;
+    hmac_sha256(&k_service, b"aws4_request")
+}
+
+/// Format the current UTC time as SigV4 `amz_date` (`YYYYMMDD'T'HHMMSS'Z'`)
+/// and `date_stamp` (`YYYYMMDD`).
+pub fn current_timestamps() -> (String, String) {
+    let now = chrono::Utc::now();
+    (
+        now.format("%Y%m%dT%H%M%SZ").to_string(),
+        now.format("%Y%m%d").to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Reference: AWS SigV4 test suite "get-vanilla"
+    // Simplified here — we only validate our implementation is consistent.
+    #[test]
+    fn signing_key_derivation_is_stable() {
+        let k1 = derive_signing_key(
+            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+            "20150830",
+            "us-east-1",
+            "iam",
+        )
+        .unwrap();
+        let k2 = derive_signing_key(
+            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+            "20150830",
+            "us-east-1",
+            "iam",
+        )
+        .unwrap();
+        assert_eq!(k1, k2, "signing key derivation must be deterministic");
+        // Match AWS docs expected value for these inputs.
+        assert_eq!(
+            hex::encode(&k1),
+            "c4afb1cc5771d871763a393e44b703571b55cc28424d1a5e86da6ed3c154a4b9"
+        );
+    }
+
+    #[test]
+    fn sign_produces_deterministic_authorization() {
+        let creds = AwsCredentials {
+            access_key_id: "AKIAIOSFODNN7EXAMPLE".to_string(),
+            secret_access_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".to_string(),
+            session_token: None,
+        };
+        let req = SignRequest {
+            method: "POST",
+            host: "bedrock-runtime.us-east-1.amazonaws.com",
+            path: "/model/foo/invoke",
+            region: "us-east-1",
+            service: "bedrock",
+            body: b"{}",
+            content_type: "application/json",
+            amz_date: "20240115T143000Z".to_string(),
+            date_stamp: "20240115".to_string(),
+        };
+        let signed1 = sign(&req, &creds).unwrap();
+        let signed2 = sign(&req, &creds).unwrap();
+        assert_eq!(signed1.authorization, signed2.authorization);
+        assert!(signed1
+            .authorization
+            .starts_with("AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/"));
+        assert!(signed1
+            .authorization
+            .contains("SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date"));
+    }
+
+    #[test]
+    fn sign_with_session_token_adds_security_token() {
+        let creds = AwsCredentials {
+            access_key_id: "AKIA".to_string(),
+            secret_access_key: "secret".to_string(),
+            session_token: Some("tok".to_string()),
+        };
+        let req = SignRequest {
+            method: "POST",
+            host: "h",
+            path: "/p",
+            region: "r",
+            service: "s",
+            body: b"",
+            content_type: "application/json",
+            amz_date: "20240115T000000Z".to_string(),
+            date_stamp: "20240115".to_string(),
+        };
+        let signed = sign(&req, &creds).unwrap();
+        assert!(signed
+            .authorization
+            .contains("SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token"));
+        assert_eq!(signed.x_amz_security_token.as_deref(), Some("tok"));
+    }
+
+    #[test]
+    fn credentials_from_env_missing_returns_none() {
+        // Make sure helper returns None when no creds set.
+        // Save and clear relevant env vars for this test.
+        let saved_ak = std::env::var("AWS_ACCESS_KEY_ID").ok();
+        let saved_sk = std::env::var("AWS_SECRET_ACCESS_KEY").ok();
+        std::env::remove_var("AWS_ACCESS_KEY_ID");
+        std::env::remove_var("AWS_SECRET_ACCESS_KEY");
+
+        assert!(AwsCredentials::from_env().is_none());
+
+        if let Some(v) = saved_ak {
+            std::env::set_var("AWS_ACCESS_KEY_ID", v);
+        }
+        if let Some(v) = saved_sk {
+            std::env::set_var("AWS_SECRET_ACCESS_KEY", v);
+        }
+    }
+}

--- a/src/api/vertex.rs
+++ b/src/api/vertex.rs
@@ -1,0 +1,320 @@
+//! GCP Vertex AI provider — routes Claude requests to Google-managed Claude
+//! endpoints.
+//!
+//! Like Bedrock, this is an adaptation layer, not a separate product. Vertex
+//! natively streams SSE in the same format as the Anthropic API, so this
+//! module can reuse the existing SSE parser directly.
+//!
+//! # Endpoint
+//!
+//! `POST https://{region}-aiplatform.googleapis.com/v1/projects/{project}
+//!   /locations/{region}/publishers/anthropic/models/{model}:streamRawPredict`
+//!
+//! # Authentication (MVP)
+//!
+//! Access token resolved from first of:
+//! 1. `CLAUDE_CODE_VERTEX_ACCESS_TOKEN` (explicit override, highest priority)
+//! 2. `GOOGLE_OAUTH_ACCESS_TOKEN`
+//! 3. `gcloud auth application-default print-access-token` subprocess
+//!
+//! Service-account JSON → JWT → token exchange is out of scope for MVP because
+//! it requires an RSA signing crate. Users who rely on service accounts should
+//! run `gcloud auth activate-service-account <sa>` first and this module will
+//! pick up the resulting ADC token.
+//!
+//! # Project / region resolution
+//!
+//! Project ID (first non-empty wins):
+//! - `ANTHROPIC_VERTEX_PROJECT_ID`
+//! - `GOOGLE_CLOUD_PROJECT`
+//! - `GCLOUD_PROJECT`
+//!
+//! Region (first non-empty wins):
+//! - `CLOUD_ML_REGION`
+//! - default `us-east5`
+
+use std::pin::Pin;
+
+use anyhow::{bail, Context, Result};
+use futures::Stream;
+use serde_json::{json, Value};
+
+use crate::api::client::{parse_sse_byte_stream, MessagesRequest};
+use crate::api::model_mapping::to_vertex_model_id;
+use crate::api::retry::categorize_api_error;
+use crate::types::message::StreamEvent;
+
+pub const VERTEX_ANTHROPIC_VERSION: &str = "vertex-2023-10-16";
+pub const DEFAULT_VERTEX_REGION: &str = "us-east5";
+
+/// Pre-obtained OAuth access token used for Vertex calls.
+#[derive(Debug, Clone)]
+pub struct VertexAccessToken(pub String);
+
+impl VertexAccessToken {
+    /// Resolve an access token from the environment or `gcloud` CLI.
+    ///
+    /// Returns `None` if no source succeeds.
+    pub fn from_env_or_gcloud() -> Option<Self> {
+        if let Ok(t) = std::env::var("CLAUDE_CODE_VERTEX_ACCESS_TOKEN") {
+            if !t.is_empty() {
+                return Some(Self(t));
+            }
+        }
+        if let Ok(t) = std::env::var("GOOGLE_OAUTH_ACCESS_TOKEN") {
+            if !t.is_empty() {
+                return Some(Self(t));
+            }
+        }
+        fetch_gcloud_token().map(Self)
+    }
+}
+
+/// Invoke `gcloud auth application-default print-access-token` to obtain an
+/// access token via Application Default Credentials.
+fn fetch_gcloud_token() -> Option<String> {
+    let output = std::process::Command::new("gcloud")
+        .args([
+            "auth",
+            "application-default",
+            "print-access-token",
+            "--quiet",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if token.is_empty() {
+        None
+    } else {
+        Some(token)
+    }
+}
+
+/// Resolve the project ID from environment.
+pub fn resolve_project_id() -> Option<String> {
+    for var in [
+        "ANTHROPIC_VERTEX_PROJECT_ID",
+        "GOOGLE_CLOUD_PROJECT",
+        "GCLOUD_PROJECT",
+    ] {
+        if let Ok(v) = std::env::var(var) {
+            if !v.is_empty() {
+                return Some(v);
+            }
+        }
+    }
+    None
+}
+
+/// Resolve the region from environment, defaulting to `us-east5`.
+pub fn resolve_region() -> String {
+    std::env::var("CLOUD_ML_REGION")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| DEFAULT_VERTEX_REGION.to_string())
+}
+
+/// Build the Vertex `:streamRawPredict` URL for a given model.
+pub fn build_stream_url(region: &str, project_id: &str, model_id: &str) -> String {
+    format!(
+        "https://{region}-aiplatform.googleapis.com/v1/projects/{project}/locations/{region}/publishers/anthropic/models/{model}:streamRawPredict",
+        region = region,
+        project = project_id,
+        model = model_id,
+    )
+}
+
+/// Convert a `MessagesRequest` into the Vertex-specific JSON body.
+///
+/// Same as Bedrock: strip `model` and `stream`; add `anthropic_version`.
+fn to_vertex_body(request: &MessagesRequest) -> Result<Vec<u8>> {
+    let mut body = json!({
+        "anthropic_version": VERTEX_ANTHROPIC_VERSION,
+        "max_tokens": request.max_tokens,
+        "messages": request.messages.clone(),
+    });
+    if let Some(system) = &request.system {
+        body["system"] = Value::Array(system.clone());
+    }
+    if let Some(tools) = &request.tools {
+        body["tools"] = Value::Array(tools.clone());
+    }
+    if let Some(thinking) = &request.thinking {
+        body["thinking"] = thinking.clone();
+    }
+    if let Some(tool_choice) = &request.tool_choice {
+        body["tool_choice"] = tool_choice.clone();
+    }
+    serde_json::to_vec(&body).context("failed to serialize Vertex request body")
+}
+
+/// Vertex stream provider (implements `StreamProvider`).
+pub struct VertexStreamProvider {
+    pub region: String,
+    pub project_id: String,
+    pub access_token: VertexAccessToken,
+}
+
+#[async_trait::async_trait]
+impl crate::api::stream_provider::StreamProvider for VertexStreamProvider {
+    async fn stream(
+        &self,
+        http: &reqwest::Client,
+        request: &MessagesRequest,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamEvent>> + Send>>> {
+        let vertex_model = to_vertex_model_id(&request.model);
+        let url = build_stream_url(&self.region, &self.project_id, &vertex_model);
+        let body = to_vertex_body(request)?;
+
+        let response = http
+            .post(&url)
+            .header("content-type", "application/json")
+            .header("authorization", format!("Bearer {}", self.access_token.0))
+            .body(body)
+            .send()
+            .await
+            .context("failed to send Vertex streamRawPredict request")?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| String::from("(failed to read error body)"));
+            let category = categorize_api_error(status.as_u16(), &error_body);
+            bail!(
+                "Vertex AI error (HTTP {}): {:?} — {}",
+                status.as_u16(),
+                category,
+                error_body
+            );
+        }
+
+        let byte_stream = response.bytes_stream();
+        let sse_stream = parse_sse_byte_stream(byte_stream);
+        Ok(Box::pin(sse_stream))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn region_defaults_to_us_east5() {
+        let saved = std::env::var("CLOUD_ML_REGION").ok();
+        std::env::remove_var("CLOUD_ML_REGION");
+
+        assert_eq!(resolve_region(), "us-east5");
+
+        if let Some(v) = saved {
+            std::env::set_var("CLOUD_ML_REGION", v);
+        }
+    }
+
+    #[test]
+    fn region_uses_cloud_ml_region() {
+        let saved = std::env::var("CLOUD_ML_REGION").ok();
+        std::env::set_var("CLOUD_ML_REGION", "europe-west4");
+
+        assert_eq!(resolve_region(), "europe-west4");
+
+        match saved {
+            Some(v) => std::env::set_var("CLOUD_ML_REGION", v),
+            None => std::env::remove_var("CLOUD_ML_REGION"),
+        }
+    }
+
+    #[test]
+    fn url_construction() {
+        let url = build_stream_url("us-east5", "my-proj", "claude-sonnet-4-5@20250929");
+        assert_eq!(
+            url,
+            "https://us-east5-aiplatform.googleapis.com/v1/projects/my-proj/locations/us-east5/publishers/anthropic/models/claude-sonnet-4-5@20250929:streamRawPredict"
+        );
+    }
+
+    #[test]
+    fn project_id_priority() {
+        let saved_an = std::env::var("ANTHROPIC_VERTEX_PROJECT_ID").ok();
+        let saved_gc = std::env::var("GOOGLE_CLOUD_PROJECT").ok();
+        let saved_gcl = std::env::var("GCLOUD_PROJECT").ok();
+        std::env::remove_var("ANTHROPIC_VERTEX_PROJECT_ID");
+        std::env::remove_var("GOOGLE_CLOUD_PROJECT");
+        std::env::remove_var("GCLOUD_PROJECT");
+
+        // None set → None
+        assert_eq!(resolve_project_id(), None);
+
+        // Only fallback set
+        std::env::set_var("GCLOUD_PROJECT", "gcloud-proj");
+        assert_eq!(resolve_project_id(), Some("gcloud-proj".to_string()));
+
+        // Higher precedence wins
+        std::env::set_var("GOOGLE_CLOUD_PROJECT", "gcp-proj");
+        assert_eq!(resolve_project_id(), Some("gcp-proj".to_string()));
+
+        std::env::set_var("ANTHROPIC_VERTEX_PROJECT_ID", "ant-proj");
+        assert_eq!(resolve_project_id(), Some("ant-proj".to_string()));
+
+        // restore
+        std::env::remove_var("ANTHROPIC_VERTEX_PROJECT_ID");
+        std::env::remove_var("GOOGLE_CLOUD_PROJECT");
+        std::env::remove_var("GCLOUD_PROJECT");
+        if let Some(v) = saved_an {
+            std::env::set_var("ANTHROPIC_VERTEX_PROJECT_ID", v);
+        }
+        if let Some(v) = saved_gc {
+            std::env::set_var("GOOGLE_CLOUD_PROJECT", v);
+        }
+        if let Some(v) = saved_gcl {
+            std::env::set_var("GCLOUD_PROJECT", v);
+        }
+    }
+
+    #[test]
+    fn body_strips_stream_and_model_adds_anthropic_version() {
+        let req = MessagesRequest {
+            model: "claude-sonnet-4-5-20250929".to_string(),
+            messages: vec![json!({"role":"user","content":"hi"})],
+            system: None,
+            max_tokens: 256,
+            tools: None,
+            stream: true,
+            thinking: None,
+            tool_choice: None,
+        };
+        let raw = to_vertex_body(&req).unwrap();
+        let v: Value = serde_json::from_slice(&raw).unwrap();
+        assert_eq!(v["anthropic_version"], VERTEX_ANTHROPIC_VERSION);
+        assert_eq!(v["max_tokens"], 256);
+        assert!(v.get("model").is_none());
+        assert!(v.get("stream").is_none());
+    }
+
+    #[test]
+    fn access_token_env_var_priority() {
+        let saved_cc = std::env::var("CLAUDE_CODE_VERTEX_ACCESS_TOKEN").ok();
+        let saved_go = std::env::var("GOOGLE_OAUTH_ACCESS_TOKEN").ok();
+        std::env::set_var("CLAUDE_CODE_VERTEX_ACCESS_TOKEN", "cc-token");
+        std::env::set_var("GOOGLE_OAUTH_ACCESS_TOKEN", "go-token");
+
+        let t = VertexAccessToken::from_env_or_gcloud().unwrap();
+        assert_eq!(t.0, "cc-token");
+
+        std::env::remove_var("CLAUDE_CODE_VERTEX_ACCESS_TOKEN");
+        let t = VertexAccessToken::from_env_or_gcloud().unwrap();
+        assert_eq!(t.0, "go-token");
+
+        std::env::remove_var("GOOGLE_OAUTH_ACCESS_TOKEN");
+        if let Some(v) = saved_cc {
+            std::env::set_var("CLAUDE_CODE_VERTEX_ACCESS_TOKEN", v);
+        }
+        if let Some(v) = saved_go {
+            std::env::set_var("GOOGLE_OAUTH_ACCESS_TOKEN", v);
+        }
+    }
+}


### PR DESCRIPTION
Closes #20.

## Summary

- Replace panic-based `ApiProvider::Bedrock` / `Vertex` stubs with real provider implementations that reuse the existing `StreamProvider` / `StreamAccumulator` pipeline — no parallel code path.
- Activation matches claude-code-bun: `CLAUDE_CODE_USE_BEDROCK=1` / `CLAUDE_CODE_USE_VERTEX=1` are checked in `ApiClient::from_env()` **before** API-key providers, so enabling the flag takes priority over `ANTHROPIC_API_KEY`.
- First-party ↔ provider model-ID translation so users can pass standard Claude model names (`claude-sonnet-4-5-20250929`) and the right Bedrock / Vertex ID goes out on the wire.

## What changed

**New modules**
- `src/api/bedrock.rs` — Bedrock provider. MVP calls `/invoke` (non-streaming) and synthesizes a full `StreamEvent` sequence so the accumulator / UI sees real streaming semantics. Auth: `AWS_BEARER_TOKEN_BEDROCK` (preferred) or SigV4 with `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN`. Honors `AWS_REGION` / `AWS_DEFAULT_REGION` and `ANTHROPIC_BEDROCK_BASE_URL`.
- `src/api/vertex.rs` — Vertex provider using `:streamRawPredict` (real SSE — same format as the Anthropic direct API). Project from `ANTHROPIC_VERTEX_PROJECT_ID` / `GOOGLE_CLOUD_PROJECT` / `GCLOUD_PROJECT`; region from `CLOUD_ML_REGION` (default `us-east5`); token from `CLAUDE_CODE_VERTEX_ACCESS_TOKEN` / `GOOGLE_OAUTH_ACCESS_TOKEN` / `gcloud auth application-default print-access-token` fallback.
- `src/api/sigv4.rs` — minimal hand-rolled SigV4 signer using only existing `sha2` + `hmac` deps (no AWS SDK). Deterministic signature verified against AWS reference signing-key vectors.
- `src/api/model_mapping.rs` — first-party ↔ Bedrock / Vertex ID translator with passthrough for ARNs, region-prefixed profiles, and already-translated IDs.

**Wiring (`src/api/client/mod.rs`)**
- `ApiProvider::Bedrock` / `::Vertex` variants now carry real auth data.
- `make_stream_provider()` dispatches to the new providers.
- Added `from_bedrock_env()` / `from_vertex_env()` entry points.
- `build_url()` returns real endpoints for both.
- Removed both `unimplemented!()` panics.

**Tests**
- Rewrote the two `#[should_panic]` tests to assert real URL / behavior.
- Added 20+ new tests: model mapping, SigV4 determinism + session-token path, Bedrock body shape + stream synthesis + accumulator round-trip, Vertex URL construction + env priority + project-id priority, `from_env` flag routing, `from_bedrock_env` returning `None` without auth.
- All 94 API tests pass (`cargo test --bin claude-code-rs api:: -- --test-threads=1`).

**Docs**
- New `docs/cloud-providers.md` — env-var reference, setup quickstart, model-mapping table, and Phase-2 scope.
- `README.md` — short pointer to the new doc with copy-paste setup snippets.

## Why

cc-rust previously shipped only the enum shell for Bedrock / Vertex; both paths hit `unimplemented!()` at runtime and tests pinned that panic. The CLI couldn't be used with AWS- or GCP-hosted Claude despite the existing streaming architecture being provider-agnostic. This wires those providers in as transport adapters — they reuse `MessagesRequest`, `StreamProvider`, `StreamAccumulator`, and the rest of the query loop unchanged.

## MVP scope and known limits

Phase 1 ships basic conversation. Explicitly out of scope (documented in `docs/cloud-providers.md`):
- Bedrock `invoke-with-response-stream` (AWS EventStream binary format). MVP synthesizes stream events from `/invoke` — user-visible behavior is identical, accumulator sees a valid event sequence.
- Bedrock inference-profile discovery (`ListInferenceProfiles`). Users can still pass ARNs directly.
- Bedrock `CountTokens` parity.
- Vertex per-model region override.
- Vertex service-account JSON → JWT → token exchange in-process (needs an RSA signing crate). Users with SA JSON should run `gcloud auth activate-service-account` first; the `gcloud` fallback picks up the ADC token.
- Per-provider gating of first-party-only features (voice / bridge / some analytics).

## Test plan
- [x] `cargo build` — no new warnings.
- [x] `cargo test --bin claude-code-rs api:: -- --test-threads=1` — 94 pass, 0 fail.
- [x] `cargo test --bin claude-code-rs` full suite — the only 3 failures (`commands::config_cmd::tests::test_config_set_model_in_memory`, `commands::model_add::tests::test_model_add_unknown_model_no_price_errors`, `observability::sink::tests::off_mode_skips_redaction`) reproduce on the pre-change branch (verified via `git stash`) and are unrelated to this PR.
- [ ] Manual smoke: `CLAUDE_CODE_USE_BEDROCK=1` with valid AWS creds + `say hi` — requires live credentials, not run here.
- [ ] Manual smoke: `CLAUDE_CODE_USE_VERTEX=1` with valid GCP creds + `say hi` — requires live credentials, not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)