### PR TITLE
refactor: split main.rs, appReducer, InputPrompt god files (issue #22)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,140 @@
+//! CLI argument definitions (Phase A).
+//!
+//! Extracted from `main.rs` so the entry point is a thin orchestrator:
+//! `Cli::parse()` owns argument shape, everything else owns behaviour.
+
+use clap::Parser;
+
+/// Claude Code CLI - Rust implementation
+#[derive(Parser, Debug)]
+#[command(
+    name = "claude",
+    version,
+    about = "Claude Code CLI",
+    disable_version_flag = true
+)]
+pub struct Cli {
+    /// Print the version and exit (fast path)
+    #[arg(short = 'V', long)]
+    pub version: bool,
+
+    /// Print mode: output model response and exit (non-interactive)
+    #[arg(short = 'p', long = "print")]
+    pub print: bool,
+
+    /// Resume the most recent session
+    #[arg(long)]
+    pub resume: bool,
+
+    /// Continue a specific session by ID
+    #[arg(long = "continue")]
+    pub continue_session: Option<String>,
+
+    /// Maximum number of turns for agentic loops
+    #[arg(long)]
+    pub max_turns: Option<usize>,
+
+    /// Working directory override
+    #[arg(short = 'C', long = "cwd")]
+    pub cwd: Option<String>,
+
+    /// Model override
+    #[arg(short = 'm', long)]
+    pub model: Option<String>,
+
+    /// Custom system prompt (replaces default)
+    #[arg(long = "system-prompt")]
+    pub system_prompt: Option<String>,
+
+    /// Append to the system prompt
+    #[arg(long = "append-system-prompt")]
+    pub append_system_prompt: Option<String>,
+
+    /// Permission mode: default, auto, bypass
+    #[arg(long = "permission-mode")]
+    pub permission_mode: Option<String>,
+
+    /// Verbose output
+    #[arg(short, long)]
+    pub verbose: bool,
+
+    /// Maximum budget in USD
+    #[arg(long = "max-budget")]
+    pub max_budget: Option<f64>,
+
+    /// Output format (text, json, stream-json)
+    #[arg(long = "output-format")]
+    pub output_format: Option<String>,
+
+    /// Dump system prompt and exit (fast path, internal)
+    #[arg(long = "dump-system-prompt", hide = true)]
+    pub dump_system_prompt: bool,
+
+    /// Init only: initialize and exit (fast path)
+    #[arg(long = "init-only", hide = true)]
+    pub init_only: bool,
+
+    /// Headless mode: run without TUI, communicate via JSON on stdin/stdout
+    #[arg(long, hide = true)]
+    pub headless: bool,
+
+    /// Run as a background daemon with HTTP server (KAIROS mode).
+    #[arg(long, hide = true)]
+    pub daemon: bool,
+
+    /// Daemon HTTP port (default: 19836).
+    #[arg(long, default_value = "19836")]
+    pub port: u16,
+
+    /// Enable native Computer Use tools (screenshot, click, type, key, scroll).
+    /// Registers built-in desktop control tools without needing an external MCP server.
+    #[arg(long = "computer-use")]
+    pub computer_use: bool,
+
+    /// Enable the first-party Chrome integration ("Claude in Chrome"). Scans
+    /// for the Anthropic Chrome extension and installs the native messaging
+    /// host manifest. Overrides the `CLAUDE_CODE_ENABLE_CFC` env var and the
+    /// saved `claudeInChromeDefaultEnabled` config.
+    #[arg(long = "chrome", conflicts_with = "no_chrome")]
+    pub chrome: bool,
+
+    /// Explicitly disable the first-party Chrome integration for this session.
+    /// Overrides env and saved config.
+    #[arg(long = "no-chrome")]
+    pub no_chrome: bool,
+
+    /// INTERNAL: run as a Chrome native-messaging host. Launched by Chrome
+    /// via the manifest installed by the Chrome subsystem setup (see
+    /// `src/browser/setup.rs`). Reads 4-byte-framed JSON from stdin, opens
+    /// a local socket, bridges the two. Not intended for manual invocation.
+    #[arg(long = "chrome-native-host", hide = true)]
+    pub chrome_native_host: bool,
+
+    /// INTERNAL: run as the Claude-in-Chrome stdio MCP bridge. Spawned as a
+    /// subprocess of the cc-rust MCP manager when --chrome is active.
+    /// Connects to the native-host socket and exposes the first-party
+    /// browser tool surface via MCP.
+    #[arg(long = "claude-in-chrome-mcp", hide = true)]
+    pub claude_in_chrome_mcp: bool,
+
+    /// Disable all network access for the current session. Forwarded to
+    /// [`crate::sandbox::SandboxPolicy`] so shell subprocesses and WebFetch
+    /// are both blocked.
+    #[arg(long = "no-network")]
+    pub no_network: bool,
+
+    /// Launch web UI mode (HTTP server with chat interface).
+    #[arg(long)]
+    pub web: bool,
+
+    /// Port for the web UI server (default: 3001).
+    #[arg(long = "web-port", default_value_t = 3001)]
+    pub web_port: u16,
+
+    /// Do not auto-open browser when starting web UI.
+    #[arg(long = "no-open")]
+    pub no_open: bool,
+
+    /// Inline prompt (positional argument or via stdin in print mode)
+    pub prompt: Vec<String>,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,20 @@
 // Phase A: CLI arg parsing -> fast path detection -> immediate exit
 // Phase B: Full initialization -> settings, permissions, tools, AppState -> REPL
 // Phase I: Shutdown and cleanup (graceful_shutdown)
+//
+// Most of the heavy lifting lives in:
+//   - `cli`           — argument shape (`Cli` struct + clap derives)
+//   - `startup`       — logging, fast paths, runtime config helpers, print/json modes
+// Keep main.rs focused on orchestration: fast-path routing, Phase B
+// sequencing, and handing control off to the selected mode (daemon / web /
+// headless / TUI / print / json).
 // ============================================================================
 
 // Process-wide bootstrap singleton layer (import DAG leaf node)
 mod bootstrap;
 
 // Core modules
+mod cli;
 mod commands;
 mod computer_use;
 mod config;
@@ -21,6 +29,7 @@ mod permissions;
 mod query;
 mod sandbox;
 mod session;
+mod startup;
 mod tools;
 mod types;
 mod ui;
@@ -71,7 +80,6 @@ mod ipc;
 mod daemon;
 mod dashboard;
 
-use std::collections::HashMap;
 use std::process::ExitCode;
 use std::sync::Arc;
 
@@ -79,200 +87,23 @@ use anyhow::Context;
 use clap::Parser;
 use tracing::{debug, error, info, warn};
 
+use crate::cli::Cli;
 use crate::config::settings;
 use crate::engine::lifecycle::QueryEngine;
+use crate::startup::runtime_config::{
+    build_tool_permission_context, chrome_cli_override, resolve_cwd, resolve_permission_mode,
+};
 use crate::tools::registry;
 use crate::types::app_state::{AppState, SettingsJson};
-use crate::types::config::{QueryEngineConfig, QuerySource};
-use crate::types::tool::{PermissionMode, ToolPermissionContext};
+use crate::types::config::QueryEngineConfig;
 use crate::ui::tui;
-
-// ---------------------------------------------------------------------------
-// CLI argument definitions (Phase A)
-// ---------------------------------------------------------------------------
-
-/// Claude Code CLI - Rust implementation
-#[derive(Parser, Debug)]
-#[command(
-    name = "claude",
-    version,
-    about = "Claude Code CLI",
-    disable_version_flag = true
-)]
-struct Cli {
-    /// Print the version and exit (fast path)
-    #[arg(short = 'V', long)]
-    version: bool,
-
-    /// Print mode: output model response and exit (non-interactive)
-    #[arg(short = 'p', long = "print")]
-    print: bool,
-
-    /// Resume the most recent session
-    #[arg(long)]
-    resume: bool,
-
-    /// Continue a specific session by ID
-    #[arg(long = "continue")]
-    continue_session: Option<String>,
-
-    /// Maximum number of turns for agentic loops
-    #[arg(long)]
-    max_turns: Option<usize>,
-
-    /// Working directory override
-    #[arg(short = 'C', long = "cwd")]
-    cwd: Option<String>,
-
-    /// Model override
-    #[arg(short = 'm', long)]
-    model: Option<String>,
-
-    /// Custom system prompt (replaces default)
-    #[arg(long = "system-prompt")]
-    system_prompt: Option<String>,
-
-    /// Append to the system prompt
-    #[arg(long = "append-system-prompt")]
-    append_system_prompt: Option<String>,
-
-    /// Permission mode: default, auto, bypass
-    #[arg(long = "permission-mode")]
-    permission_mode: Option<String>,
-
-    /// Verbose output
-    #[arg(short, long)]
-    verbose: bool,
-
-    /// Maximum budget in USD
-    #[arg(long = "max-budget")]
-    max_budget: Option<f64>,
-
-    /// Output format (text, json, stream-json)
-    #[arg(long = "output-format")]
-    output_format: Option<String>,
-
-    /// Dump system prompt and exit (fast path, internal)
-    #[arg(long = "dump-system-prompt", hide = true)]
-    dump_system_prompt: bool,
-
-    /// Init only: initialize and exit (fast path)
-    #[arg(long = "init-only", hide = true)]
-    init_only: bool,
-
-    /// Headless mode: run without TUI, communicate via JSON on stdin/stdout
-    #[arg(long, hide = true)]
-    headless: bool,
-
-    /// Run as a background daemon with HTTP server (KAIROS mode).
-    #[arg(long, hide = true)]
-    daemon: bool,
-
-    /// Daemon HTTP port (default: 19836).
-    #[arg(long, default_value = "19836")]
-    port: u16,
-
-    /// Enable native Computer Use tools (screenshot, click, type, key, scroll).
-    /// Registers built-in desktop control tools without needing an external MCP server.
-    #[arg(long = "computer-use")]
-    computer_use: bool,
-
-    /// Enable the first-party Chrome integration ("Claude in Chrome"). Scans
-    /// for the Anthropic Chrome extension and installs the native messaging
-    /// host manifest. Overrides the `CLAUDE_CODE_ENABLE_CFC` env var and the
-    /// saved `claudeInChromeDefaultEnabled` config.
-    #[arg(long = "chrome", conflicts_with = "no_chrome")]
-    chrome: bool,
-
-    /// Explicitly disable the first-party Chrome integration for this session.
-    /// Overrides env and saved config.
-    #[arg(long = "no-chrome")]
-    no_chrome: bool,
-
-    /// INTERNAL: run as a Chrome native-messaging host. Launched by Chrome
-    /// via the manifest installed by the Chrome subsystem setup (see
-    /// `src/browser/setup.rs`). Reads 4-byte-framed JSON from stdin, opens
-    /// a local socket, bridges the two. Not intended for manual invocation.
-    #[arg(long = "chrome-native-host", hide = true)]
-    chrome_native_host: bool,
-
-    /// INTERNAL: run as the Claude-in-Chrome stdio MCP bridge. Spawned as a
-    /// subprocess of the cc-rust MCP manager when --chrome is active.
-    /// Connects to the native-host socket and exposes the first-party
-    /// browser tool surface via MCP.
-    #[arg(long = "claude-in-chrome-mcp", hide = true)]
-    claude_in_chrome_mcp: bool,
-
-    /// Disable all network access for the current session. Forwarded to
-    /// [`crate::sandbox::SandboxPolicy`] so shell subprocesses and WebFetch
-    /// are both blocked.
-    #[arg(long = "no-network")]
-    no_network: bool,
-
-    /// Launch web UI mode (HTTP server with chat interface).
-    #[arg(long)]
-    web: bool,
-
-    /// Port for the web UI server (default: 3001).
-    #[arg(long = "web-port", default_value_t = 3001)]
-    web_port: u16,
-
-    /// Do not auto-open browser when starting web UI.
-    #[arg(long = "no-open")]
-    no_open: bool,
-
-    /// Inline prompt (positional argument or via stdin in print mode)
-    prompt: Vec<String>,
-}
-
-// ---------------------------------------------------------------------------
-// Log housekeeping
-// ---------------------------------------------------------------------------
-
-/// Delete log files older than `retention_days` in the given directory.
-/// Only removes files matching the `cc-rust.log.YYYY-MM-DD` pattern.
-fn cleanup_old_logs(log_dir: &std::path::Path, retention_days: u64) {
-    let cutoff =
-        std::time::SystemTime::now() - std::time::Duration::from_secs(retention_days * 86400);
-    let entries = match std::fs::read_dir(log_dir) {
-        Ok(e) => e,
-        Err(_) => return,
-    };
-    for entry in entries.flatten() {
-        let name = entry.file_name();
-        let name = name.to_string_lossy();
-        if !name.starts_with("cc-rust.log.") {
-            continue;
-        }
-        if let Ok(meta) = entry.metadata() {
-            let modified = meta.modified().unwrap_or(std::time::SystemTime::now());
-            if modified < cutoff {
-                let _ = std::fs::remove_file(entry.path());
-            }
-        }
-    }
-}
 
 // ---------------------------------------------------------------------------
 // Main entry point
 // ---------------------------------------------------------------------------
 
 fn main() -> ExitCode {
-    // Load .env in priority order (later loads do NOT override earlier ones):
-    //   1. ~/.cc-rust/.env        (global user config)
-    //   2. <exe-dir>/.env         (portable, next to the binary)
-    //   3. <cwd>/.env             (project-local)
-    if let Ok(global_dir) = settings::global_claude_dir() {
-        let global_env = global_dir.join(".env");
-        let _ = dotenvy::from_path(&global_env);
-    }
-    if let Ok(exe_path) = std::env::current_exe() {
-        if let Some(exe_dir) = exe_path.parent() {
-            let exe_env = exe_dir.join(".env");
-            let _ = dotenvy::from_path(&exe_env);
-        }
-    }
-    let _ = dotenvy::dotenv();
+    startup::load_env_files();
 
     // Phase A: parse args first so fast paths can exit immediately
     let cli = Cli::parse();
@@ -290,134 +121,24 @@ fn main() -> ExitCode {
     // REPL, no HTTP server. Just bridge Chrome <-> local socket and exit
     // when Chrome closes stdin.
     if cli.chrome_native_host {
-        let rt = tokio::runtime::Runtime::new().expect("create tokio runtime");
-        return rt.block_on(async {
-            match crate::browser::native_host::run().await {
-                Ok(()) => ExitCode::SUCCESS,
-                Err(e) => {
-                    eprintln!("chrome-native-host error: {e:#}");
-                    ExitCode::FAILURE
-                }
-            }
-        });
+        return startup::fast_paths::run_chrome_native_host();
     }
 
     // Fast path: --claude-in-chrome-mcp
     // Spawned as a stdio MCP subprocess by the cc-rust MCP manager when
     // --chrome is active. Bridges MCP <-> native-host socket.
     if cli.claude_in_chrome_mcp {
-        let rt = tokio::runtime::Runtime::new().expect("create tokio runtime");
-        return rt.block_on(async {
-            match crate::browser::mcp_bridge::run().await {
-                Ok(()) => ExitCode::SUCCESS,
-                Err(e) => {
-                    eprintln!("claude-in-chrome-mcp error: {e:#}");
-                    ExitCode::FAILURE
-                }
-            }
-        });
+        return startup::fast_paths::run_claude_in_chrome_mcp();
     }
 
-    // Initialize tracing (log level based on --verbose)
-    // Two layers: stderr (warn default) + file (~/.cc-rust/logs/, always debug).
-    let log_level = if cli.verbose { "debug" } else { "warn" };
-    let stderr_filter = tracing_subscriber::EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(log_level));
-
-    let log_dir = crate::config::paths::logs_dir();
-    if let Err(e) = std::fs::create_dir_all(&log_dir) {
-        eprintln!(
-            "warning: failed to create log directory {}: {}. File logging disabled.",
-            log_dir.display(),
-            e
-        );
-    }
-    cleanup_old_logs(&log_dir, 7);
-    let file_appender = tracing_appender::rolling::daily(&log_dir, "cc-rust.log");
-    let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
-
-    use tracing_subscriber::layer::SubscriberExt;
-    use tracing_subscriber::util::SubscriberInitExt;
-    use tracing_subscriber::Layer;
-
-    tracing_subscriber::registry()
-        // stderr layer -> respects --verbose / RUST_LOG
-        .with(
-            tracing_subscriber::fmt::layer()
-                .with_target(false)
-                .with_filter(stderr_filter),
-        )
-        // file layer -> always debug, with timestamps + target + line numbers
-        .with(
-            tracing_subscriber::fmt::layer()
-                .with_writer(non_blocking)
-                .with_ansi(false)
-                .with_target(true)
-                .with_line_number(true)
-                .with_filter(tracing_subscriber::EnvFilter::new(
-                    "debug,reqwest=warn,hyper_util=warn,hyper=warn,h2=warn,rustls=warn,ignore=warn,globset=warn",
-                )),
-        )
-        .init();
+    // Initialize tracing (stderr + file). Guard must outlive the process.
+    let _tracing_guard = startup::logging::init_tracing(cli.verbose);
 
     info!("claude-code-rs v{}", env!("CARGO_PKG_VERSION"));
 
     // Fast path: --dump-system-prompt
     if cli.dump_system_prompt {
-        plugins::init_plugins();
-        let tools = registry::get_all_tools();
-        let provider_default =
-            crate::api::client::ApiClient::from_env().map(|c| c.config().default_model.clone());
-        let model_owned = cli
-            .model
-            .clone()
-            .or(provider_default)
-            .unwrap_or_else(|| "claude-sonnet-4-20250514".to_string());
-        let model = model_owned.as_str();
-        let cwd = resolve_cwd(&cli);
-
-        // Populate the browser MCP server registry from config alone (no live
-        // connection). Config-flagged servers (`"browserMcp": true`) are
-        // authoritative; the heuristic half would need connected tools and
-        // isn't exercised here; use `--init-only` for that path.
-        let cwd_path = std::path::Path::new(&cwd);
-        let server_configs =
-            crate::mcp::discovery::discover_mcp_servers(cwd_path).unwrap_or_default();
-        let mut browser_servers =
-            crate::browser::detection::detect_browser_servers(&server_configs, &tools);
-        // Mirror the full-init path: when Chrome subsystem is requested via
-        // CLI / env, pre-register the first-party server name so the
-        // `# Browser Automation` prompt fires under --dump-system-prompt too.
-        let chrome_config_default = settings::load_and_merge(&cwd)
-            .ok()
-            .and_then(|cfg| cfg.claude_in_chrome_default_enabled);
-        let chrome_wanted = chrome_requested(&cli, chrome_config_default);
-        if chrome_wanted {
-            browser_servers
-                .insert(crate::browser::common::CLAUDE_IN_CHROME_MCP_SERVER_NAME.to_string());
-        }
-        crate::browser::detection::install_browser_servers(browser_servers);
-
-        // Best-effort: load merged settings so --dump-system-prompt reflects
-        // language/output_style overrides without requiring full bootstrap.
-        let dump_settings = crate::config::settings::load_effective(std::path::Path::new(&cwd))
-            .ok()
-            .map(|loaded| loaded.effective);
-        let dump_lang = dump_settings.as_ref().and_then(|s| s.language.clone());
-        let dump_style = dump_settings.as_ref().and_then(|s| s.output_style.clone());
-        let (parts, _, _) = crate::engine::system_prompt::build_system_prompt(
-            cli.system_prompt.as_deref(),
-            cli.append_system_prompt.as_deref(),
-            &tools,
-            model,
-            &cwd,
-            dump_lang.as_deref(),
-            dump_style.as_deref(),
-        );
-        for part in &parts {
-            println!("{}", part);
-        }
-        return ExitCode::SUCCESS;
+        return startup::fast_paths::run_dump_system_prompt(&cli);
     }
 
     // Phase B: full initialization
@@ -888,9 +609,9 @@ async fn run_full_init(cli: Cli) -> anyhow::Result<ExitCode> {
             use std::io::Read;
             let mut buf = String::new();
             std::io::stdin().read_to_string(&mut buf)?;
-            return run_json_mode(&engine, buf.trim()).await;
+            return startup::modes::run_json_mode(&engine, buf.trim()).await;
         }
-        return run_json_mode(&engine, &prompt).await;
+        return startup::modes::run_json_mode(&engine, &prompt).await;
     }
 
     // Plain text print mode (-p without --output-format json)
@@ -900,7 +621,7 @@ async fn run_full_init(cli: Cli) -> anyhow::Result<ExitCode> {
             error!("print mode requires a prompt argument");
             return Ok(ExitCode::FAILURE);
         }
-        return run_print_mode(&engine, &prompt).await;
+        return startup::modes::run_print_mode(&engine, &prompt).await;
     }
 
     // B.10: Web UI mode
@@ -1025,176 +746,5 @@ async fn run_full_init(cli: Cli) -> anyhow::Result<ExitCode> {
             error!("TUI error: {:#}", e);
             Ok(ExitCode::FAILURE)
         }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// JSON output mode (for SDK consumers -- JSONL on stdout)
-// ---------------------------------------------------------------------------
-
-async fn run_json_mode(engine: &QueryEngine, prompt: &str) -> anyhow::Result<ExitCode> {
-    use futures::StreamExt;
-
-    let stream = engine.submit_message(prompt, QuerySource::Sdk);
-    let mut stream = std::pin::pin!(stream);
-    let mut exit_code = ExitCode::SUCCESS;
-
-    while let Some(msg) = stream.next().await {
-        let json = serde_json::to_string(&msg).context("failed to serialize SdkMessage to JSON")?;
-        println!("{}", json);
-
-        if let crate::engine::sdk_types::SdkMessage::Result(ref result) = msg {
-            if result.is_error {
-                exit_code = ExitCode::FAILURE;
-            }
-        }
-    }
-
-    Ok(exit_code)
-}
-
-// ---------------------------------------------------------------------------
-// Print mode (non-interactive)
-// ---------------------------------------------------------------------------
-
-async fn run_print_mode(engine: &QueryEngine, prompt: &str) -> anyhow::Result<ExitCode> {
-    use futures::StreamExt;
-
-    let stream = engine.submit_message(prompt, QuerySource::Sdk);
-    let mut stream = std::pin::pin!(stream);
-
-    let mut exit_code = ExitCode::SUCCESS;
-
-    while let Some(msg) = stream.next().await {
-        match &msg {
-            crate::engine::sdk_types::SdkMessage::Assistant(assistant_msg) => {
-                for block in &assistant_msg.message.content {
-                    if let crate::types::message::ContentBlock::Text { text } = block {
-                        print!("{}", text);
-                    }
-                }
-            }
-            crate::engine::sdk_types::SdkMessage::Result(result) => {
-                if result.is_error {
-                    exit_code = ExitCode::FAILURE;
-                }
-            }
-            _ => {}
-        }
-    }
-
-    println!(); // trailing newline
-    Ok(exit_code)
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/// Resolve the working directory from CLI args or environment.
-fn resolve_cwd(cli: &Cli) -> String {
-    cli.cwd.clone().unwrap_or_else(|| {
-        std::env::current_dir()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_else(|_| ".".to_string())
-    })
-}
-
-fn chrome_cli_override(cli: &Cli) -> Option<bool> {
-    if cli.chrome {
-        Some(true)
-    } else if cli.no_chrome {
-        Some(false)
-    } else {
-        None
-    }
-}
-
-fn chrome_requested(cli: &Cli, config_default: Option<bool>) -> bool {
-    matches!(
-        crate::browser::session::resolve_enablement(chrome_cli_override(cli), config_default),
-        crate::browser::session::ChromeEnablement::Enabled
-    )
-}
-
-/// Resolve the permission mode from CLI arg or config.
-fn resolve_permission_mode(cli_mode: Option<&str>, config_mode: Option<&str>) -> PermissionMode {
-    let mode_str = cli_mode.or(config_mode).unwrap_or("default");
-    PermissionMode::parse(mode_str)
-}
-
-/// Build the [`ToolPermissionContext`] from layered settings.
-///
-/// Pulls allow/ask/deny lists from `EffectiveSettings::permissions` and
-/// folds them into per-source rule maps tagged with the source of the
-/// settings layer that provided them. `enableBypassMode` /
-/// `enableAutoMode` from settings gate the corresponding modes at runtime.
-fn build_tool_permission_context(
-    mode: PermissionMode,
-    loaded: &settings::LoadedSettings,
-) -> ToolPermissionContext {
-    use settings::SettingsSource;
-
-    let merged = &loaded.effective;
-
-    let mut always_allow_rules: HashMap<String, Vec<String>> = HashMap::new();
-    let mut always_deny_rules: HashMap<String, Vec<String>> = HashMap::new();
-    let mut always_ask_rules: HashMap<String, Vec<String>> = HashMap::new();
-    let mut additional_working_directories = HashMap::new();
-
-    let push_rules =
-        |map: &mut HashMap<String, Vec<String>>, source: SettingsSource, items: &[String]| {
-            if items.is_empty() {
-                return;
-            }
-            map.entry(source.as_str().to_string())
-                .or_default()
-                .extend(items.iter().cloned());
-        };
-
-    // Pull each layer's rules into the right bucket. We iterate from
-    // lowest -> highest priority so /permissions show prints them in a
-    // stable order; the matcher itself treats sources uniformly.
-    let layers: [(
-        SettingsSource,
-        Option<&crate::config::settings::RawSettings>,
-    ); 4] = [
-        (SettingsSource::Managed, loaded.managed.as_ref()),
-        (SettingsSource::User, loaded.user.as_ref()),
-        (SettingsSource::Project, loaded.project.as_ref()),
-        (SettingsSource::Local, loaded.local.as_ref()),
-    ];
-
-    for (src, raw_opt) in layers {
-        let Some(raw) = raw_opt else { continue };
-        if let Some(perms) = raw.permissions.as_ref() {
-            push_rules(&mut always_allow_rules, src, &perms.allow);
-            push_rules(&mut always_deny_rules, src, &perms.deny);
-            push_rules(&mut always_ask_rules, src, &perms.ask);
-            for dir in &perms.additional_directories {
-                additional_working_directories.insert(
-                    dir.clone(),
-                    crate::types::tool::AdditionalWorkingDirectory {
-                        path: dir.clone(),
-                        read_only: false,
-                    },
-                );
-            }
-        }
-        if let Some(legacy) = raw.allowed_tools.as_ref() {
-            push_rules(&mut always_allow_rules, src, legacy);
-        }
-    }
-
-    ToolPermissionContext {
-        mode,
-        additional_working_directories,
-        always_allow_rules,
-        always_deny_rules,
-        always_ask_rules,
-        session_allow_rules: HashMap::new(),
-        is_bypass_permissions_mode_available: merged.permissions.enable_bypass_mode.unwrap_or(true),
-        is_auto_mode_available: Some(merged.permissions.enable_auto_mode.unwrap_or(true)),
-        pre_plan_mode: None,
     }
 }

--- a/src/startup/fast_paths.rs
+++ b/src/startup/fast_paths.rs
@@ -1,0 +1,104 @@
+//! Fast-path handlers that short-circuit full initialization.
+//!
+//! These run before Phase B so we can bypass tool registration, MCP
+//! discovery, settings layering, etc. when the user only wants a quick
+//! one-shot (e.g. `--version`, `--dump-system-prompt`) or a
+//! special-purpose bridge (`--chrome-native-host`,
+//! `--claude-in-chrome-mcp`).
+
+use std::process::ExitCode;
+
+use crate::cli::Cli;
+use crate::config::settings;
+use crate::startup::runtime_config::{chrome_requested, resolve_cwd};
+use crate::tools::registry;
+
+/// Run the Chrome native-messaging host bridge. Does NOT set up tracing or
+/// register tools — Chrome captures stderr as error logs, so we skip every
+/// side-effect beyond bridging stdin↔socket.
+pub fn run_chrome_native_host() -> ExitCode {
+    let rt = tokio::runtime::Runtime::new().expect("create tokio runtime");
+    rt.block_on(async {
+        match crate::browser::native_host::run().await {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(e) => {
+                eprintln!("chrome-native-host error: {e:#}");
+                ExitCode::FAILURE
+            }
+        }
+    })
+}
+
+/// Run the Claude-in-Chrome stdio MCP bridge. Spawned as an MCP subprocess
+/// by the cc-rust MCP manager when `--chrome` is active.
+pub fn run_claude_in_chrome_mcp() -> ExitCode {
+    let rt = tokio::runtime::Runtime::new().expect("create tokio runtime");
+    rt.block_on(async {
+        match crate::browser::mcp_bridge::run().await {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(e) => {
+                eprintln!("claude-in-chrome-mcp error: {e:#}");
+                ExitCode::FAILURE
+            }
+        }
+    })
+}
+
+/// Print the resolved system prompt and exit. Populates the minimum state
+/// required for the prompt builder (tools, MCP/browser detection, merged
+/// language/style) without running the full Phase B pipeline.
+pub fn run_dump_system_prompt(cli: &Cli) -> ExitCode {
+    crate::plugins::init_plugins();
+    let tools = registry::get_all_tools();
+    let provider_default =
+        crate::api::client::ApiClient::from_env().map(|c| c.config().default_model.clone());
+    let model_owned = cli
+        .model
+        .clone()
+        .or(provider_default)
+        .unwrap_or_else(|| "claude-sonnet-4-20250514".to_string());
+    let model = model_owned.as_str();
+    let cwd = resolve_cwd(cli);
+
+    // Populate the browser MCP server registry from config alone (no live
+    // connection). Config-flagged servers (`"browserMcp": true`) are
+    // authoritative; the heuristic half would need connected tools and
+    // isn't exercised here; use `--init-only` for that path.
+    let cwd_path = std::path::Path::new(&cwd);
+    let server_configs =
+        crate::mcp::discovery::discover_mcp_servers(cwd_path).unwrap_or_default();
+    let mut browser_servers =
+        crate::browser::detection::detect_browser_servers(&server_configs, &tools);
+    // Mirror the full-init path: when Chrome subsystem is requested via
+    // CLI / env, pre-register the first-party server name so the
+    // `# Browser Automation` prompt fires under --dump-system-prompt too.
+    let chrome_config_default = settings::load_and_merge(&cwd)
+        .ok()
+        .and_then(|cfg| cfg.claude_in_chrome_default_enabled);
+    if chrome_requested(cli, chrome_config_default) {
+        browser_servers
+            .insert(crate::browser::common::CLAUDE_IN_CHROME_MCP_SERVER_NAME.to_string());
+    }
+    crate::browser::detection::install_browser_servers(browser_servers);
+
+    // Best-effort: load merged settings so --dump-system-prompt reflects
+    // language/output_style overrides without requiring full bootstrap.
+    let dump_settings = crate::config::settings::load_effective(std::path::Path::new(&cwd))
+        .ok()
+        .map(|loaded| loaded.effective);
+    let dump_lang = dump_settings.as_ref().and_then(|s| s.language.clone());
+    let dump_style = dump_settings.as_ref().and_then(|s| s.output_style.clone());
+    let (parts, _, _) = crate::engine::system_prompt::build_system_prompt(
+        cli.system_prompt.as_deref(),
+        cli.append_system_prompt.as_deref(),
+        &tools,
+        model,
+        &cwd,
+        dump_lang.as_deref(),
+        dump_style.as_deref(),
+    );
+    for part in &parts {
+        println!("{}", part);
+    }
+    ExitCode::SUCCESS
+}

--- a/src/startup/logging.rs
+++ b/src/startup/logging.rs
@@ -1,0 +1,75 @@
+//! Tracing setup + log file housekeeping.
+
+use tracing_appender::non_blocking::WorkerGuard;
+
+const LOG_RETENTION_DAYS: u64 = 7;
+
+/// Delete log files older than `retention_days` in the given directory.
+/// Only removes files matching the `cc-rust.log.YYYY-MM-DD` pattern.
+fn cleanup_old_logs(log_dir: &std::path::Path, retention_days: u64) {
+    let cutoff =
+        std::time::SystemTime::now() - std::time::Duration::from_secs(retention_days * 86400);
+    let entries = match std::fs::read_dir(log_dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if !name.starts_with("cc-rust.log.") {
+            continue;
+        }
+        if let Ok(meta) = entry.metadata() {
+            let modified = meta.modified().unwrap_or(std::time::SystemTime::now());
+            if modified < cutoff {
+                let _ = std::fs::remove_file(entry.path());
+            }
+        }
+    }
+}
+
+/// Initialize the dual-layer tracing subscriber (stderr + file), run log
+/// housekeeping, and return a guard that must stay alive for the life of
+/// the process so the non-blocking file writer can flush on drop.
+pub fn init_tracing(verbose: bool) -> WorkerGuard {
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+    use tracing_subscriber::Layer;
+
+    // stderr layer respects --verbose / RUST_LOG; file layer always debug.
+    let log_level = if verbose { "debug" } else { "warn" };
+    let stderr_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(log_level));
+
+    let log_dir = crate::config::paths::logs_dir();
+    if let Err(e) = std::fs::create_dir_all(&log_dir) {
+        eprintln!(
+            "warning: failed to create log directory {}: {}. File logging disabled.",
+            log_dir.display(),
+            e
+        );
+    }
+    cleanup_old_logs(&log_dir, LOG_RETENTION_DAYS);
+    let file_appender = tracing_appender::rolling::daily(&log_dir, "cc-rust.log");
+    let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_target(false)
+                .with_filter(stderr_filter),
+        )
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(non_blocking)
+                .with_ansi(false)
+                .with_target(true)
+                .with_line_number(true)
+                .with_filter(tracing_subscriber::EnvFilter::new(
+                    "debug,reqwest=warn,hyper_util=warn,hyper=warn,h2=warn,rustls=warn,ignore=warn,globset=warn",
+                )),
+        )
+        .init();
+
+    guard
+}

--- a/src/startup/mod.rs
+++ b/src/startup/mod.rs
@@ -1,0 +1,31 @@
+//! Startup helpers — env loading, tracing setup, fast-path handlers,
+//! runtime-config assembly, and non-interactive output modes.
+//!
+//! Entry point is [`main.rs`]; this module owns the pieces main would
+//! otherwise inline. Split out of the monolithic `main.rs` per issue #22
+//! to keep the entry point focused on orchestration.
+
+pub mod fast_paths;
+pub mod logging;
+pub mod modes;
+pub mod runtime_config;
+
+use crate::config::settings;
+
+/// Load `.env` files in priority order (later loads do NOT override earlier):
+///   1. `~/.cc-rust/.env`        (global user config)
+///   2. `<exe-dir>/.env`         (portable, next to the binary)
+///   3. `<cwd>/.env`             (project-local)
+pub fn load_env_files() {
+    if let Ok(global_dir) = settings::global_claude_dir() {
+        let global_env = global_dir.join(".env");
+        let _ = dotenvy::from_path(&global_env);
+    }
+    if let Ok(exe_path) = std::env::current_exe() {
+        if let Some(exe_dir) = exe_path.parent() {
+            let exe_env = exe_dir.join(".env");
+            let _ = dotenvy::from_path(&exe_env);
+        }
+    }
+    let _ = dotenvy::dotenv();
+}

--- a/src/startup/modes.rs
+++ b/src/startup/modes.rs
@@ -1,0 +1,64 @@
+//! Non-interactive output modes — `--output-format json` (JSONL on stdout)
+//! and `-p` plain print mode. Both consume the same SDK message stream and
+//! map `SdkMessage::Result::is_error` onto the process exit code.
+
+use std::process::ExitCode;
+
+use anyhow::Context;
+
+use crate::engine::lifecycle::QueryEngine;
+use crate::types::config::QuerySource;
+
+/// JSON output mode (for SDK consumers — JSONL on stdout).
+pub async fn run_json_mode(engine: &QueryEngine, prompt: &str) -> anyhow::Result<ExitCode> {
+    use futures::StreamExt;
+
+    let stream = engine.submit_message(prompt, QuerySource::Sdk);
+    let mut stream = std::pin::pin!(stream);
+    let mut exit_code = ExitCode::SUCCESS;
+
+    while let Some(msg) = stream.next().await {
+        let json = serde_json::to_string(&msg).context("failed to serialize SdkMessage to JSON")?;
+        println!("{}", json);
+
+        if let crate::engine::sdk_types::SdkMessage::Result(ref result) = msg {
+            if result.is_error {
+                exit_code = ExitCode::FAILURE;
+            }
+        }
+    }
+
+    Ok(exit_code)
+}
+
+/// Plain-text print mode (non-interactive `-p`). Emits assistant text
+/// blocks as they arrive and a trailing newline at the end.
+pub async fn run_print_mode(engine: &QueryEngine, prompt: &str) -> anyhow::Result<ExitCode> {
+    use futures::StreamExt;
+
+    let stream = engine.submit_message(prompt, QuerySource::Sdk);
+    let mut stream = std::pin::pin!(stream);
+
+    let mut exit_code = ExitCode::SUCCESS;
+
+    while let Some(msg) = stream.next().await {
+        match &msg {
+            crate::engine::sdk_types::SdkMessage::Assistant(assistant_msg) => {
+                for block in &assistant_msg.message.content {
+                    if let crate::types::message::ContentBlock::Text { text } = block {
+                        print!("{}", text);
+                    }
+                }
+            }
+            crate::engine::sdk_types::SdkMessage::Result(result) => {
+                if result.is_error {
+                    exit_code = ExitCode::FAILURE;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    println!(); // trailing newline
+    Ok(exit_code)
+}

--- a/src/startup/runtime_config.rs
+++ b/src/startup/runtime_config.rs
@@ -1,0 +1,124 @@
+//! CLI → runtime config assembly (Phase B helpers).
+//!
+//! Extracted from `main.rs`: small pieces of logic that map CLI/config
+//! layers onto the long-lived runtime surfaces — working directory,
+//! permission mode, Chrome enablement, tool permission context.
+
+use std::collections::HashMap;
+
+use crate::cli::Cli;
+use crate::config::settings;
+use crate::types::tool::{PermissionMode, ToolPermissionContext};
+
+/// Resolve the working directory from CLI args or the current process cwd.
+pub fn resolve_cwd(cli: &Cli) -> String {
+    cli.cwd.clone().unwrap_or_else(|| {
+        std::env::current_dir()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|_| ".".to_string())
+    })
+}
+
+/// Map `--chrome` / `--no-chrome` flags onto an explicit Option<bool>.
+/// `None` means "defer to config / env defaults".
+pub fn chrome_cli_override(cli: &Cli) -> Option<bool> {
+    if cli.chrome {
+        Some(true)
+    } else if cli.no_chrome {
+        Some(false)
+    } else {
+        None
+    }
+}
+
+/// True iff Chrome integration is enabled after layering CLI over config.
+pub fn chrome_requested(cli: &Cli, config_default: Option<bool>) -> bool {
+    matches!(
+        crate::browser::session::resolve_enablement(chrome_cli_override(cli), config_default),
+        crate::browser::session::ChromeEnablement::Enabled
+    )
+}
+
+/// Resolve the permission mode from CLI arg or config.
+pub fn resolve_permission_mode(
+    cli_mode: Option<&str>,
+    config_mode: Option<&str>,
+) -> PermissionMode {
+    let mode_str = cli_mode.or(config_mode).unwrap_or("default");
+    PermissionMode::parse(mode_str)
+}
+
+/// Build the [`ToolPermissionContext`] from layered settings.
+///
+/// Pulls allow/ask/deny lists from `EffectiveSettings::permissions` and
+/// folds them into per-source rule maps tagged with the source of the
+/// settings layer that provided them. `enableBypassMode` /
+/// `enableAutoMode` from settings gate the corresponding modes at runtime.
+pub fn build_tool_permission_context(
+    mode: PermissionMode,
+    loaded: &settings::LoadedSettings,
+) -> ToolPermissionContext {
+    use settings::SettingsSource;
+
+    let merged = &loaded.effective;
+
+    let mut always_allow_rules: HashMap<String, Vec<String>> = HashMap::new();
+    let mut always_deny_rules: HashMap<String, Vec<String>> = HashMap::new();
+    let mut always_ask_rules: HashMap<String, Vec<String>> = HashMap::new();
+    let mut additional_working_directories = HashMap::new();
+
+    let push_rules =
+        |map: &mut HashMap<String, Vec<String>>, source: SettingsSource, items: &[String]| {
+            if items.is_empty() {
+                return;
+            }
+            map.entry(source.as_str().to_string())
+                .or_default()
+                .extend(items.iter().cloned());
+        };
+
+    // Iterate lowest -> highest priority so /permissions show prints them
+    // in a stable order; the matcher itself treats sources uniformly.
+    let layers: [(
+        SettingsSource,
+        Option<&crate::config::settings::RawSettings>,
+    ); 4] = [
+        (SettingsSource::Managed, loaded.managed.as_ref()),
+        (SettingsSource::User, loaded.user.as_ref()),
+        (SettingsSource::Project, loaded.project.as_ref()),
+        (SettingsSource::Local, loaded.local.as_ref()),
+    ];
+
+    for (src, raw_opt) in layers {
+        let Some(raw) = raw_opt else { continue };
+        if let Some(perms) = raw.permissions.as_ref() {
+            push_rules(&mut always_allow_rules, src, &perms.allow);
+            push_rules(&mut always_deny_rules, src, &perms.deny);
+            push_rules(&mut always_ask_rules, src, &perms.ask);
+            for dir in &perms.additional_directories {
+                additional_working_directories.insert(
+                    dir.clone(),
+                    crate::types::tool::AdditionalWorkingDirectory {
+                        path: dir.clone(),
+                        read_only: false,
+                    },
+                );
+            }
+        }
+        if let Some(legacy) = raw.allowed_tools.as_ref() {
+            push_rules(&mut always_allow_rules, src, legacy);
+        }
+    }
+
+    ToolPermissionContext {
+        mode,
+        additional_working_directories,
+        always_allow_rules,
+        always_deny_rules,
+        always_ask_rules,
+        session_allow_rules: HashMap::new(),
+        is_bypass_permissions_mode_available: merged.permissions.enable_bypass_mode.unwrap_or(true),
+        is_auto_mode_available: Some(merged.permissions.enable_auto_mode.unwrap_or(true)),
+        pre_plan_mode: None,
+    }
+}

--- a/ui/src/components/InputPrompt.tsx
+++ b/ui/src/components/InputPrompt.tsx
@@ -1,10 +1,9 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useKeyboard, useRenderer } from '@opentui/react'
-import type { KeyEvent, PasteEvent } from '@opentui/core'
+import type { KeyEvent } from '@opentui/core'
 import {
   matchesShortcut,
   shortcutLabel,
-  type KeyLike,
   type ViewMode,
 } from '../keybindings.js'
 import { c } from '../theme.js'
@@ -15,57 +14,22 @@ import { VimState } from '../vim/index.js'
 import { CommandHint } from './CommandHint.js'
 import {
   formatPasteSize,
-  insertAtCursor,
-  isPasteInput,
-  isPlainTextInput,
   promptPlaceholder,
   summarizeQueuedSubmissions,
 } from './input-prompt-utils.js'
+import {
+  extractInput,
+  formatWorkedDuration,
+  toShortcutKey,
+} from './input-prompt-keys.js'
+import {
+  useBusyTimer,
+  useComposerState,
+  useInputHistoryNav,
+  usePasteHandler,
+} from './input-prompt-hooks.js'
 
 const PASTE_COMPACT_CHARS = 200
-
-function formatWorkedDuration(ms: number): string {
-  const totalSeconds = Math.max(0, Math.floor(ms / 1000))
-  const minutes = Math.floor(totalSeconds / 60)
-  const seconds = totalSeconds % 60
-  return minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`
-}
-
-function extractInput(event: KeyEvent): string {
-  const seq = event.sequence ?? ''
-  if (seq.length === 1 && seq.charCodeAt(0) >= 32) return seq
-  if (!event.ctrl && !event.meta && isPlainTextInput(seq)) return seq
-  if (event.ctrl && (event.name?.length ?? 0) === 1) return event.name ?? ''
-  if ((event.name?.length ?? 0) === 1 && !event.ctrl && !event.meta) return event.name ?? ''
-  return ''
-}
-
-function toShortcutKey(event: KeyEvent): KeyLike & {
-  backspace?: boolean
-  delete?: boolean
-  wheelUp?: boolean
-  wheelDown?: boolean
-} {
-  const name = event.name ?? ''
-  return {
-    ctrl: event.ctrl ?? false,
-    meta: event.meta ?? false,
-    shift: event.shift ?? false,
-    return: name === 'return' || name === 'enter',
-    escape: name === 'escape',
-    tab: name === 'tab',
-    upArrow: name === 'up',
-    downArrow: name === 'down',
-    pageUp: name === 'pageup',
-    pageDown: name === 'pagedown',
-    home: name === 'home',
-    end: name === 'end',
-    backspace: name === 'backspace',
-    delete: name === 'delete',
-    wheelUp: name === 'wheel_up' || name === 'scrollup',
-    wheelDown: name === 'wheel_down' || name === 'scrolldown',
-  }
-}
 
 interface InputPromptProps {
   isActive?: boolean
@@ -82,10 +46,6 @@ export function InputPrompt({
   onStatusChange,
   viewMode,
 }: InputPromptProps) {
-  const [text, setText] = useState('')
-  const [cursorPos, setCursorPos] = useState(0)
-  const [undoStack, setUndoStack] = useState<Array<{ text: string; cursor: number }>>([])
-  const [isPasted, setIsPasted] = useState(false)
   const [hintIndex, setHintIndex] = useState(0)
   const [subMode, setSubMode] = useState<{ cmd: CommandDef; options: string[] } | null>(null)
   const [subIndex, setSubIndex] = useState(0)
@@ -103,14 +63,49 @@ export function InputPrompt({
   const dispatch = useAppDispatch()
   const renderer = useRenderer()
   const vimRef = useRef<VimState>(new VimState())
-  const textRef = useRef('')
-  textRef.current = text
-  const cursorRef = useRef(0)
-  cursorRef.current = cursorPos
 
   const isBusy = isWaiting || isStreaming
   const isBusyRef = useRef(false)
   isBusyRef.current = isBusy
+
+  const focusInput = useCallback(() => {
+    if (isReadOnly || viewMode !== 'prompt') {
+      return false
+    }
+    onActivate?.()
+    return true
+  }, [isReadOnly, onActivate, viewMode])
+
+  const clearSubMode = useCallback(() => {
+    setSubMode(null)
+    setSubIndex(0)
+  }, [])
+
+  const composer = useComposerState({
+    focusInput,
+    onInsert: () => {
+      if (subMode) clearSubMode()
+    },
+  })
+  const {
+    text,
+    setText,
+    cursorPos,
+    setCursorPos,
+    cursorRef,
+    undoStack,
+    setUndoStack,
+    isPasted,
+    setIsPasted,
+    saveUndo,
+    insertText,
+    reset: resetBuffer,
+  } = composer
+
+  const resetComposer = useCallback(() => {
+    resetBuffer()
+    clearSubMode()
+  }, [clearSubMode, resetBuffer])
 
   const slashPrefix = viewMode === 'prompt' && text.startsWith('/') && !text.includes(' ') && !subMode
   const cmdPartial = slashPrefix ? text.slice(1) : ''
@@ -123,29 +118,10 @@ export function InputPrompt({
     setHintIndex(0)
   }, [cmdPartial])
 
-  const [time, setTime] = useState(0)
-  const startRef = useRef(Date.now())
-  useEffect(() => {
-    if (!isBusy) return
-    const id = setInterval(() => setTime(Date.now() - startRef.current), 250)
-    return () => clearInterval(id)
-  }, [isBusy])
+  const { time, busyStartedAtRef, lastWorkedMs } = useBusyTimer(isBusy)
 
-  const busyStartedAtRef = useRef<number | null>(null)
-  const [lastWorkedMs, setLastWorkedMs] = useState(0)
   const inputActive = viewMode === 'prompt' && isActive && !isReadOnly
   const showHint = (slashPrefix || !!subMode) && !isBusy && inputActive
-
-  useEffect(() => {
-    if (isBusy) {
-      if (busyStartedAtRef.current === null) busyStartedAtRef.current = time
-      return
-    }
-    if (busyStartedAtRef.current !== null) {
-      setLastWorkedMs(Math.max(0, time - busyStartedAtRef.current))
-      busyStartedAtRef.current = null
-    }
-  }, [isBusy, time])
 
   const vim = vimRef.current
   if (vimEnabled && !vim.enabled) {
@@ -155,50 +131,7 @@ export function InputPrompt({
     vim.disable()
   }
 
-  const saveUndo = useCallback(() => {
-    setUndoStack(stack => [...stack.slice(-50), {
-      text: textRef.current,
-      cursor: cursorRef.current,
-    }])
-  }, [])
-
-  const focusInput = useCallback(() => {
-    if (isReadOnly || viewMode !== 'prompt') {
-      return false
-    }
-    onActivate?.()
-    return true
-  }, [isReadOnly, onActivate, viewMode])
-
-  const resetComposer = useCallback(() => {
-    setText('')
-    setCursorPos(0)
-    setUndoStack([])
-    setIsPasted(false)
-    setSubMode(null)
-    setSubIndex(0)
-  }, [])
-
-  const insertText = useCallback((value: string, options?: { pasted?: boolean }) => {
-    if (!value || !focusInput()) {
-      return false
-    }
-
-    saveUndo()
-    const next = insertAtCursor(textRef.current, cursorRef.current, value)
-    textRef.current = next.text
-    cursorRef.current = next.cursorPos
-    setText(next.text)
-    setCursorPos(next.cursorPos)
-    if (options?.pasted || isPasteInput(value.length)) {
-      setIsPasted(true)
-    }
-    if (subMode) {
-      setSubMode(null)
-      setSubIndex(0)
-    }
-    return true
-  }, [focusInput, saveUndo, subMode])
+  usePasteHandler({ viewMode, isReadOnly, insertText })
 
   const activateInput = useCallback(() => {
     if (isReadOnly || viewMode !== 'prompt') {
@@ -221,30 +154,11 @@ export function InputPrompt({
     isBusy,
     isReadOnly,
     onActivate,
+    setCursorPos,
+    setText,
     text.length,
     viewMode,
   ])
-
-  useEffect(() => {
-    const handlePaste = (event: PasteEvent) => {
-      if (viewMode !== 'prompt' || isReadOnly) {
-        return
-      }
-
-      const value = new TextDecoder().decode(event.bytes)
-      if (!value) {
-        return
-      }
-
-      event.preventDefault()
-      insertText(value, { pasted: true })
-    }
-
-    renderer._internalKeyInput.onInternal('paste', handlePaste)
-    return () => {
-      renderer._internalKeyInput.offInternal('paste', handlePaste)
-    }
-  }, [insertText, isReadOnly, renderer, viewMode])
 
   const sendCommand = useCallback((raw: string) => {
     if (isBusyRef.current) {
@@ -288,7 +202,6 @@ export function InputPrompt({
       return
     }
 
-    // Answer a pending question via the explicit QuestionResponse protocol
     if (pendingQuestion) {
       dispatch({ type: 'ADD_USER_MESSAGE', id: `answer-${pendingQuestion.id}`, text: trimmed })
       dispatch({ type: 'PUSH_HISTORY', text: trimmed })
@@ -328,33 +241,12 @@ export function InputPrompt({
     }
 
     sendCommand(`/${cmd.name}`)
-  }, [sendCommand])
+  }, [sendCommand, setCursorPos, setText])
 
-  const navigateHistoryUp = useCallback(() => {
-    if (inputHistory.length === 0) return false
-    const nextIndex = historyIndex === -1 ? inputHistory.length - 1 : Math.max(0, historyIndex - 1)
-    dispatch({ type: 'SET_HISTORY_INDEX', index: nextIndex })
-    const historyText = inputHistory[nextIndex] || ''
-    setText(historyText)
-    setCursorPos(historyText.length)
-    return true
-  }, [dispatch, historyIndex, inputHistory])
-
-  const navigateHistoryDown = useCallback(() => {
-    if (historyIndex === -1) return false
-    const nextIndex = historyIndex + 1
-    if (nextIndex >= inputHistory.length) {
-      dispatch({ type: 'SET_HISTORY_INDEX', index: -1 })
-      setText('')
-      setCursorPos(0)
-      return true
-    }
-    dispatch({ type: 'SET_HISTORY_INDEX', index: nextIndex })
-    const historyText = inputHistory[nextIndex] || ''
-    setText(historyText)
-    setCursorPos(historyText.length)
-    return true
-  }, [dispatch, historyIndex, inputHistory])
+  const { navigateUp: navigateHistoryUp, navigateDown: navigateHistoryDown } = useInputHistoryNav({
+    setText,
+    setCursorPos,
+  })
 
   useKeyboard((event: KeyEvent) => {
     if (event.eventType === 'release') {

--- a/ui/src/components/input-prompt-hooks.ts
+++ b/ui/src/components/input-prompt-hooks.ts
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { PasteEvent } from '@opentui/core'
+import { useRenderer } from '@opentui/react'
+import { useAppDispatch, useAppState } from '../store/app-store.js'
+import type { ViewMode } from '../keybindings.js'
+import { insertAtCursor, isPasteInput } from './input-prompt-utils.js'
+
+/**
+ * Composer state: text buffer, cursor, undo stack, paste indicator.
+ *
+ * Exposes live refs for the text/cursor so the keyboard handler can read
+ * the latest values without going through a re-render. `insertText` /
+ * `reset` take care of resetting the paste indicator and any sub-mode the
+ * caller opts into via `onInsert`.
+ */
+export interface ComposerState {
+  text: string
+  setText: (value: string | ((prev: string) => string)) => void
+  cursorPos: number
+  setCursorPos: (value: number | ((prev: number) => number)) => void
+  textRef: React.MutableRefObject<string>
+  cursorRef: React.MutableRefObject<number>
+  undoStack: Array<{ text: string; cursor: number }>
+  setUndoStack: React.Dispatch<React.SetStateAction<Array<{ text: string; cursor: number }>>>
+  isPasted: boolean
+  setIsPasted: (value: boolean) => void
+  saveUndo: () => void
+  insertText: (value: string, options?: { pasted?: boolean }) => boolean
+  reset: () => void
+}
+
+export function useComposerState(params: {
+  focusInput: () => boolean
+  onInsert?: () => void
+}): ComposerState {
+  const { focusInput, onInsert } = params
+  const [text, setText] = useState('')
+  const [cursorPos, setCursorPos] = useState(0)
+  const [undoStack, setUndoStack] = useState<Array<{ text: string; cursor: number }>>([])
+  const [isPasted, setIsPasted] = useState(false)
+
+  const textRef = useRef('')
+  textRef.current = text
+  const cursorRef = useRef(0)
+  cursorRef.current = cursorPos
+
+  const saveUndo = useCallback(() => {
+    setUndoStack(stack => [...stack.slice(-50), {
+      text: textRef.current,
+      cursor: cursorRef.current,
+    }])
+  }, [])
+
+  const insertText = useCallback((value: string, options?: { pasted?: boolean }) => {
+    if (!value || !focusInput()) {
+      return false
+    }
+    saveUndo()
+    const next = insertAtCursor(textRef.current, cursorRef.current, value)
+    textRef.current = next.text
+    cursorRef.current = next.cursorPos
+    setText(next.text)
+    setCursorPos(next.cursorPos)
+    if (options?.pasted || isPasteInput(value.length)) {
+      setIsPasted(true)
+    }
+    onInsert?.()
+    return true
+  }, [focusInput, onInsert, saveUndo])
+
+  const reset = useCallback(() => {
+    setText('')
+    setCursorPos(0)
+    setUndoStack([])
+    setIsPasted(false)
+  }, [])
+
+  return {
+    text,
+    setText,
+    cursorPos,
+    setCursorPos,
+    textRef,
+    cursorRef,
+    undoStack,
+    setUndoStack,
+    isPasted,
+    setIsPasted,
+    saveUndo,
+    insertText,
+    reset,
+  }
+}
+
+/**
+ * Busy timer: tracks elapsed time for the current busy run, emitting the
+ * final elapsed duration into `lastWorkedMs` when the run ends.
+ */
+export function useBusyTimer(isBusy: boolean) {
+  const [time, setTime] = useState(0)
+  const startRef = useRef(Date.now())
+  useEffect(() => {
+    if (!isBusy) return
+    const id = setInterval(() => setTime(Date.now() - startRef.current), 250)
+    return () => clearInterval(id)
+  }, [isBusy])
+
+  const busyStartedAtRef = useRef<number | null>(null)
+  const [lastWorkedMs, setLastWorkedMs] = useState(0)
+
+  useEffect(() => {
+    if (isBusy) {
+      if (busyStartedAtRef.current === null) busyStartedAtRef.current = time
+      return
+    }
+    if (busyStartedAtRef.current !== null) {
+      setLastWorkedMs(Math.max(0, time - busyStartedAtRef.current))
+      busyStartedAtRef.current = null
+    }
+  }, [isBusy, time])
+
+  return { time, busyStartedAtRef, lastWorkedMs }
+}
+
+/**
+ * Paste handler: subscribes to the renderer's internal paste event while
+ * the prompt is the active input. The caller supplies `insertText` so the
+ * paste is routed through the same composer path as typed input.
+ */
+export function usePasteHandler(params: {
+  viewMode: ViewMode
+  isReadOnly: boolean
+  insertText: (value: string, options?: { pasted?: boolean }) => boolean
+}) {
+  const { viewMode, isReadOnly, insertText } = params
+  const renderer = useRenderer()
+
+  useEffect(() => {
+    const handlePaste = (event: PasteEvent) => {
+      if (viewMode !== 'prompt' || isReadOnly) {
+        return
+      }
+      const value = new TextDecoder().decode(event.bytes)
+      if (!value) {
+        return
+      }
+      event.preventDefault()
+      insertText(value, { pasted: true })
+    }
+
+    renderer._internalKeyInput.onInternal('paste', handlePaste)
+    return () => {
+      renderer._internalKeyInput.offInternal('paste', handlePaste)
+    }
+  }, [insertText, isReadOnly, renderer, viewMode])
+}
+
+/**
+ * Input history navigation: up/down cycling through `state.inputHistory`
+ * with the store's `historyIndex` as the cursor.
+ */
+export function useInputHistoryNav(params: {
+  setText: (value: string) => void
+  setCursorPos: (value: number) => void
+}) {
+  const { setText, setCursorPos } = params
+  const { inputHistory, historyIndex } = useAppState()
+  const dispatch = useAppDispatch()
+
+  const navigateUp = useCallback(() => {
+    if (inputHistory.length === 0) return false
+    const nextIndex = historyIndex === -1 ? inputHistory.length - 1 : Math.max(0, historyIndex - 1)
+    dispatch({ type: 'SET_HISTORY_INDEX', index: nextIndex })
+    const historyText = inputHistory[nextIndex] || ''
+    setText(historyText)
+    setCursorPos(historyText.length)
+    return true
+  }, [dispatch, historyIndex, inputHistory, setCursorPos, setText])
+
+  const navigateDown = useCallback(() => {
+    if (historyIndex === -1) return false
+    const nextIndex = historyIndex + 1
+    if (nextIndex >= inputHistory.length) {
+      dispatch({ type: 'SET_HISTORY_INDEX', index: -1 })
+      setText('')
+      setCursorPos(0)
+      return true
+    }
+    dispatch({ type: 'SET_HISTORY_INDEX', index: nextIndex })
+    const historyText = inputHistory[nextIndex] || ''
+    setText(historyText)
+    setCursorPos(historyText.length)
+    return true
+  }, [dispatch, historyIndex, inputHistory, setCursorPos, setText])
+
+  return { navigateUp, navigateDown }
+}

--- a/ui/src/components/input-prompt-keys.ts
+++ b/ui/src/components/input-prompt-keys.ts
@@ -1,0 +1,48 @@
+import type { KeyEvent } from '@opentui/core'
+import type { KeyLike } from '../keybindings.js'
+import { isPlainTextInput } from './input-prompt-utils.js'
+
+export type ShortcutKey = KeyLike & {
+  backspace?: boolean
+  delete?: boolean
+  wheelUp?: boolean
+  wheelDown?: boolean
+}
+
+export function extractInput(event: KeyEvent): string {
+  const seq = event.sequence ?? ''
+  if (seq.length === 1 && seq.charCodeAt(0) >= 32) return seq
+  if (!event.ctrl && !event.meta && isPlainTextInput(seq)) return seq
+  if (event.ctrl && (event.name?.length ?? 0) === 1) return event.name ?? ''
+  if ((event.name?.length ?? 0) === 1 && !event.ctrl && !event.meta) return event.name ?? ''
+  return ''
+}
+
+export function toShortcutKey(event: KeyEvent): ShortcutKey {
+  const name = event.name ?? ''
+  return {
+    ctrl: event.ctrl ?? false,
+    meta: event.meta ?? false,
+    shift: event.shift ?? false,
+    return: name === 'return' || name === 'enter',
+    escape: name === 'escape',
+    tab: name === 'tab',
+    upArrow: name === 'up',
+    downArrow: name === 'down',
+    pageUp: name === 'pageup',
+    pageDown: name === 'pagedown',
+    home: name === 'home',
+    end: name === 'end',
+    backspace: name === 'backspace',
+    delete: name === 'delete',
+    wheelUp: name === 'wheel_up' || name === 'scrollup',
+    wheelDown: name === 'wheel_down' || name === 'scrolldown',
+  }
+}
+
+export function formatWorkedDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000))
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`
+}

--- a/ui/src/store/app-state.ts
+++ b/ui/src/store/app-state.ts
@@ -1,0 +1,211 @@
+import type {
+  AgentNode,
+  FrontendContentBlock,
+  LspServerInfo,
+  McpServerStatusInfo,
+  PluginInfo,
+  SkillInfo,
+  TeamMemberInfo,
+} from '../ipc/protocol.js'
+import type { ViewMode } from '../keybindings.js'
+import type { RawMessage } from './message-model.js'
+
+export interface Usage {
+  inputTokens: number
+  outputTokens: number
+  costUsd: number
+}
+
+export interface PermissionRequest {
+  toolUseId: string
+  tool: string
+  command: string
+  options: string[]
+}
+
+export interface BackgroundAgent {
+  agentId: string
+  description: string
+  startedAt: number
+  completedAt?: number
+  resultPreview?: string
+  hadError?: boolean
+  durationMs?: number
+}
+
+export interface PendingQuestion {
+  id: string
+  text: string
+}
+
+export interface QueuedSubmission {
+  id: string
+  kind: 'prompt'
+  text: string
+  queuedAt: number
+}
+
+export interface AgentStreamState {
+  text: string
+  thinking: string
+}
+
+export interface TeamState {
+  name: string
+  members: TeamMemberInfo[]
+  pendingMessages: number
+  recentMessages: Array<{ from: string; to: string; summary: string; timestamp: number }>
+}
+
+export interface SubsystemState {
+  lsp: LspServerInfo[]
+  mcp: McpServerStatusInfo[]
+  plugins: PluginInfo[]
+  skills: SkillInfo[]
+  lastUpdated: number
+}
+
+export interface AppState {
+  messages: RawMessage[]
+  streamingText: string
+  streamingThinking: string
+  streamingMessageId: string | null
+  isStreaming: boolean
+  isWaiting: boolean
+  model: string
+  sessionId: string
+  cwd: string
+  usage: Usage
+  permissionRequest: PermissionRequest | null
+  pendingQuestion: PendingQuestion | null
+  suggestions: string[]
+  inputHistory: string[]
+  historyIndex: number
+  vimEnabled: boolean
+  vimMode: string
+  backgroundAgents: BackgroundAgent[]
+  queuedSubmissions: QueuedSubmission[]
+  viewMode: ViewMode
+  agentTree: AgentNode[]
+  agentStreams: Record<string, AgentStreamState>
+  teams: Record<string, TeamState>
+  subsystems: SubsystemState
+}
+
+export const initialState: AppState = {
+  messages: [],
+  streamingText: '',
+  streamingThinking: '',
+  streamingMessageId: null,
+  isStreaming: false,
+  isWaiting: false,
+  model: '',
+  sessionId: '',
+  cwd: '',
+  usage: { inputTokens: 0, outputTokens: 0, costUsd: 0 },
+  permissionRequest: null,
+  pendingQuestion: null,
+  suggestions: [],
+  inputHistory: [],
+  historyIndex: -1,
+  vimEnabled: false,
+  vimMode: 'NORMAL',
+  backgroundAgents: [],
+  queuedSubmissions: [],
+  viewMode: 'prompt',
+  agentTree: [],
+  agentStreams: {},
+  teams: {},
+  subsystems: { lsp: [], mcp: [], plugins: [], skills: [], lastUpdated: 0 },
+}
+
+export type CoreAction =
+  | { type: 'READY'; model: string; sessionId: string; cwd: string }
+  | { type: 'REPLACE_MESSAGES'; messages: RawMessage[] }
+  | { type: 'ADD_USER_MESSAGE'; id: string; text: string }
+  | { type: 'ADD_COMMAND_MESSAGE'; id: string; text: string }
+  | { type: 'STREAM_START'; messageId: string }
+  | { type: 'STREAM_DELTA'; text: string }
+  | { type: 'THINKING_DELTA'; thinking: string }
+  | { type: 'STREAM_END' }
+  | {
+      type: 'ASSISTANT_MESSAGE'
+      id: string
+      content: string
+      contentBlocks?: FrontendContentBlock[]
+      costUsd: number
+      thinking?: string
+    }
+  | { type: 'PERMISSION_REQUEST'; request: PermissionRequest }
+  | { type: 'PERMISSION_DISMISS' }
+  | { type: 'QUESTION_REQUEST'; question: PendingQuestion }
+  | { type: 'QUESTION_DISMISS' }
+  | { type: 'SYSTEM_INFO'; text: string; level: string }
+  | { type: 'USAGE_UPDATE'; usage: Usage }
+  | { type: 'SUGGESTIONS'; items: string[] }
+  | { type: 'ERROR'; message: string }
+
+export type ToolActivityAction =
+  | { type: 'TOOL_USE'; id: string; name: string; input: any }
+  | { type: 'TOOL_RESULT'; toolUseId: string; output: string; isError: boolean }
+
+export type BackgroundAgentAction =
+  | { type: 'BG_AGENT_STARTED'; agentId: string; description: string }
+  | {
+      type: 'BG_AGENT_COMPLETE'
+      agentId: string
+      description: string
+      resultPreview: string
+      hadError: boolean
+      durationMs: number
+    }
+
+export type AgentTreeAction =
+  | { type: 'AGENT_TREE_SNAPSHOT'; roots: AgentNode[] }
+  | {
+      type: 'AGENT_SPAWNED'
+      agentId: string
+      description: string
+      parentAgentId?: string
+      agentType?: string
+      model?: string
+      isBackground: boolean
+      depth: number
+    }
+  | { type: 'AGENT_COMPLETED'; agentId: string; resultPreview: string; hadError: boolean; durationMs: number }
+  | { type: 'AGENT_ERROR'; agentId: string; error: string; durationMs: number }
+  | { type: 'AGENT_ABORTED'; agentId: string }
+  | { type: 'AGENT_STREAM_DELTA'; agentId: string; text: string }
+  | { type: 'AGENT_THINKING_DELTA'; agentId: string; thinking: string }
+
+export type TeamAction =
+  | { type: 'TEAM_MEMBER_JOINED'; teamName: string; agentId: string; agentName: string; role: string }
+  | { type: 'TEAM_MEMBER_LEFT'; teamName: string; agentId: string }
+  | { type: 'TEAM_MESSAGE_ROUTED'; teamName: string; from: string; to: string; summary: string; timestamp: number }
+  | { type: 'TEAM_STATUS_SNAPSHOT'; teamName: string; members: TeamMemberInfo[]; pendingMessages: number }
+
+export type SubsystemAction =
+  | { type: 'SUBSYSTEM_STATUS'; lsp: LspServerInfo[]; mcp: McpServerStatusInfo[]; plugins: PluginInfo[]; skills: SkillInfo[] }
+  | { type: 'LSP_SERVER_STATE'; languageId: string; state: string; error?: string }
+  | { type: 'MCP_SERVER_STATE'; serverName: string; state: string; error?: string }
+  | { type: 'PLUGIN_STATUS'; pluginId: string; name: string; status: string; error?: string }
+  | { type: 'SKILLS_LOADED'; count: number }
+
+export type InputAction =
+  | { type: 'PUSH_HISTORY'; text: string }
+  | { type: 'SET_HISTORY_INDEX'; index: number }
+  | { type: 'SET_VIM_MODE'; mode: string }
+  | { type: 'TOGGLE_VIM' }
+  | { type: 'QUEUE_SUBMISSION'; submission: QueuedSubmission }
+  | { type: 'DEQUEUE_SUBMISSION' }
+  | { type: 'SET_VIEW_MODE'; viewMode: ViewMode }
+  | { type: 'TOGGLE_VIEW_MODE' }
+
+export type AppAction =
+  | CoreAction
+  | ToolActivityAction
+  | BackgroundAgentAction
+  | AgentTreeAction
+  | TeamAction
+  | SubsystemAction
+  | InputAction

--- a/ui/src/store/app-store.tsx
+++ b/ui/src/store/app-store.tsx
@@ -1,612 +1,91 @@
 import React, { createContext, useContext, useReducer, type Dispatch } from 'react'
-import type {
-  AgentNode,
-  FrontendContentBlock,
-  LspServerInfo,
-  McpServerStatusInfo,
-  PluginInfo,
-  SkillInfo,
-  TeamMemberInfo,
-} from '../ipc/protocol.js'
-import type { ViewMode } from '../keybindings.js'
-import type { RawMessage } from './message-model.js'
+import {
+  initialState,
+  type AppAction,
+  type AppState,
+} from './app-state.js'
+import { reduceAgentTree } from './reducers/agent-tree.js'
+import { reduceBackgroundAgents } from './reducers/background-agents.js'
+import { reduceCore } from './reducers/core.js'
+import { reduceInput } from './reducers/input.js'
+import { reduceSubsystems } from './reducers/subsystems.js'
+import { reduceTeams } from './reducers/teams.js'
+import { reduceToolActivity } from './reducers/tool-activity.js'
 
-export interface Usage {
-  inputTokens: number
-  outputTokens: number
-  costUsd: number
-}
-
-export interface PermissionRequest {
-  toolUseId: string
-  tool: string
-  command: string
-  options: string[]
-}
-
-export interface BackgroundAgent {
-  agentId: string
-  description: string
-  startedAt: number
-  completedAt?: number
-  resultPreview?: string
-  hadError?: boolean
-  durationMs?: number
-}
-
-export interface PendingQuestion {
-  id: string
-  text: string
-}
-
-export interface QueuedSubmission {
-  id: string
-  kind: 'prompt'
-  text: string
-  queuedAt: number
-}
-
-// ---------------------------------------------------------------------------
-// Agent tree state
-// ---------------------------------------------------------------------------
-
-export interface AgentStreamState {
-  text: string
-  thinking: string
-}
-
-// ---------------------------------------------------------------------------
-// Team state
-// ---------------------------------------------------------------------------
-
-export interface TeamState {
-  name: string
-  members: TeamMemberInfo[]
-  pendingMessages: number
-  recentMessages: Array<{ from: string; to: string; summary: string; timestamp: number }>
-}
-
-// ---------------------------------------------------------------------------
-// Subsystem state
-// ---------------------------------------------------------------------------
-
-export interface SubsystemState {
-  lsp: LspServerInfo[]
-  mcp: McpServerStatusInfo[]
-  plugins: PluginInfo[]
-  skills: SkillInfo[]
-  lastUpdated: number
-}
-
-export interface AppState {
-  messages: RawMessage[]
-  streamingText: string
-  streamingThinking: string
-  streamingMessageId: string | null
-  isStreaming: boolean
-  isWaiting: boolean
-  model: string
-  sessionId: string
-  cwd: string
-  usage: Usage
-  permissionRequest: PermissionRequest | null
-  pendingQuestion: PendingQuestion | null
-  suggestions: string[]
-  inputHistory: string[]
-  historyIndex: number
-  vimEnabled: boolean
-  vimMode: string
-  backgroundAgents: BackgroundAgent[]
-  queuedSubmissions: QueuedSubmission[]
-  viewMode: ViewMode
-  // Agent tree
-  agentTree: AgentNode[]
-  agentStreams: Record<string, AgentStreamState>
-  // Teams
-  teams: Record<string, TeamState>
-  // Subsystems
-  subsystems: SubsystemState
-}
-
-export const initialState: AppState = {
-  messages: [],
-  streamingText: '',
-  streamingThinking: '',
-  streamingMessageId: null,
-  isStreaming: false,
-  isWaiting: false,
-  model: '',
-  sessionId: '',
-  cwd: '',
-  usage: { inputTokens: 0, outputTokens: 0, costUsd: 0 },
-  permissionRequest: null,
-  pendingQuestion: null,
-  suggestions: [],
-  inputHistory: [],
-  historyIndex: -1,
-  vimEnabled: false,
-  vimMode: 'NORMAL',
-  backgroundAgents: [],
-  queuedSubmissions: [],
-  viewMode: 'prompt',
-  agentTree: [],
-  agentStreams: {},
-  teams: {},
-  subsystems: { lsp: [], mcp: [], plugins: [], skills: [], lastUpdated: 0 },
-}
-
-export type AppAction =
-  | { type: 'READY'; model: string; sessionId: string; cwd: string }
-  | { type: 'REPLACE_MESSAGES'; messages: RawMessage[] }
-  | { type: 'ADD_USER_MESSAGE'; id: string; text: string }
-  | { type: 'ADD_COMMAND_MESSAGE'; id: string; text: string }
-  | { type: 'STREAM_START'; messageId: string }
-  | { type: 'STREAM_DELTA'; text: string }
-  | { type: 'THINKING_DELTA'; thinking: string }
-  | { type: 'STREAM_END' }
-  | {
-      type: 'ASSISTANT_MESSAGE'
-      id: string
-      content: string
-      contentBlocks?: FrontendContentBlock[]
-      costUsd: number
-      thinking?: string
-    }
-  | { type: 'TOOL_USE'; id: string; name: string; input: any }
-  | { type: 'TOOL_RESULT'; toolUseId: string; output: string; isError: boolean }
-  | { type: 'PERMISSION_REQUEST'; request: PermissionRequest }
-  | { type: 'PERMISSION_DISMISS' }
-  | { type: 'QUESTION_REQUEST'; question: PendingQuestion }
-  | { type: 'QUESTION_DISMISS' }
-  | { type: 'SYSTEM_INFO'; text: string; level: string }
-  | { type: 'USAGE_UPDATE'; usage: Usage }
-  | { type: 'SUGGESTIONS'; items: string[] }
-  | { type: 'ERROR'; message: string }
-  | { type: 'BG_AGENT_STARTED'; agentId: string; description: string }
-  | {
-      type: 'BG_AGENT_COMPLETE'
-      agentId: string
-      description: string
-      resultPreview: string
-      hadError: boolean
-      durationMs: number
-    }
-  | { type: 'PUSH_HISTORY'; text: string }
-  | { type: 'SET_HISTORY_INDEX'; index: number }
-  | { type: 'SET_VIM_MODE'; mode: string }
-  | { type: 'TOGGLE_VIM' }
-  | { type: 'QUEUE_SUBMISSION'; submission: QueuedSubmission }
-  | { type: 'DEQUEUE_SUBMISSION' }
-  | { type: 'SET_VIEW_MODE'; viewMode: ViewMode }
-  | { type: 'TOGGLE_VIEW_MODE' }
-  // Agent tree
-  | { type: 'AGENT_TREE_SNAPSHOT'; roots: AgentNode[] }
-  | { type: 'AGENT_SPAWNED'; agentId: string; description: string; parentAgentId?: string; agentType?: string; model?: string; isBackground: boolean; depth: number }
-  | { type: 'AGENT_COMPLETED'; agentId: string; resultPreview: string; hadError: boolean; durationMs: number }
-  | { type: 'AGENT_ERROR'; agentId: string; error: string; durationMs: number }
-  | { type: 'AGENT_ABORTED'; agentId: string }
-  | { type: 'AGENT_STREAM_DELTA'; agentId: string; text: string }
-  | { type: 'AGENT_THINKING_DELTA'; agentId: string; thinking: string }
-  // Teams
-  | { type: 'TEAM_MEMBER_JOINED'; teamName: string; agentId: string; agentName: string; role: string }
-  | { type: 'TEAM_MEMBER_LEFT'; teamName: string; agentId: string }
-  | { type: 'TEAM_MESSAGE_ROUTED'; teamName: string; from: string; to: string; summary: string; timestamp: number }
-  | { type: 'TEAM_STATUS_SNAPSHOT'; teamName: string; members: TeamMemberInfo[]; pendingMessages: number }
-  // Subsystems
-  | { type: 'SUBSYSTEM_STATUS'; lsp: LspServerInfo[]; mcp: McpServerStatusInfo[]; plugins: PluginInfo[]; skills: SkillInfo[] }
-  | { type: 'LSP_SERVER_STATE'; languageId: string; state: string; error?: string }
-  | { type: 'MCP_SERVER_STATE'; serverName: string; state: string; error?: string }
-  | { type: 'PLUGIN_STATUS'; pluginId: string; name: string; status: string; error?: string }
-  | { type: 'SKILLS_LOADED'; count: number }
+export type {
+  AgentStreamState,
+  AppAction,
+  AppState,
+  BackgroundAgent,
+  PendingQuestion,
+  PermissionRequest,
+  QueuedSubmission,
+  SubsystemState,
+  TeamState,
+  Usage,
+} from './app-state.js'
+export { initialState } from './app-state.js'
 
 export function appReducer(state: AppState, action: AppAction): AppState {
   switch (action.type) {
     case 'READY':
-      return { ...state, model: action.model, sessionId: action.sessionId, cwd: action.cwd }
-
     case 'REPLACE_MESSAGES':
-      return {
-        ...state,
-        isStreaming: false,
-        isWaiting: false,
-        streamingText: '',
-        streamingThinking: '',
-        streamingMessageId: null,
-        messages: action.messages,
-      }
-
     case 'ADD_USER_MESSAGE':
-      return {
-        ...state,
-        isWaiting: true,
-        messages: [...state.messages, {
-          id: action.id,
-          role: 'user',
-          content: action.text,
-          timestamp: Date.now(),
-        }],
-      }
-
     case 'ADD_COMMAND_MESSAGE':
-      return {
-        ...state,
-        messages: [...state.messages, {
-          id: action.id,
-          role: 'user',
-          content: action.text,
-          timestamp: Date.now(),
-        }],
-      }
-
     case 'STREAM_START':
-      return {
-        ...state,
-        isStreaming: true,
-        isWaiting: false,
-        streamingText: '',
-        streamingThinking: '',
-        streamingMessageId: action.messageId,
-      }
-
     case 'STREAM_DELTA':
-      return { ...state, streamingText: state.streamingText + action.text }
-
     case 'THINKING_DELTA':
-      return { ...state, streamingThinking: state.streamingThinking + action.thinking }
-
     case 'STREAM_END':
-      return {
-        ...state,
-        isStreaming: false,
-        isWaiting: false,
-        streamingText: '',
-        streamingThinking: '',
-        streamingMessageId: null,
-      }
-
     case 'ASSISTANT_MESSAGE':
-      return {
-        ...state,
-        isStreaming: false,
-        isWaiting: false,
-        streamingText: '',
-        streamingThinking: '',
-        streamingMessageId: null,
-        messages: [...state.messages, {
-          id: action.id,
-          role: 'assistant',
-          content: action.content,
-          timestamp: Date.now(),
-          contentBlocks: action.contentBlocks,
-          costUsd: action.costUsd,
-          thinking: action.thinking,
-        }],
-      }
+    case 'PERMISSION_REQUEST':
+    case 'PERMISSION_DISMISS':
+    case 'QUESTION_REQUEST':
+    case 'QUESTION_DISMISS':
+    case 'SYSTEM_INFO':
+    case 'USAGE_UPDATE':
+    case 'SUGGESTIONS':
+    case 'ERROR':
+      return reduceCore(state, action)
 
     case 'TOOL_USE':
-      return {
-        ...state,
-        messages: [...state.messages, {
-          id: action.id,
-          role: 'tool_use',
-          content: `Tool: ${action.name}`,
-          timestamp: Date.now(),
-          toolName: action.name,
-          toolInput: action.input,
-          toolUseId: action.id,
-        }],
-      }
-
     case 'TOOL_RESULT':
-      return {
-        ...state,
-        messages: [...state.messages, {
-          id: `result-${action.toolUseId}-${Date.now()}`,
-          role: 'tool_result',
-          content: action.output,
-          timestamp: Date.now(),
-          toolUseId: action.toolUseId,
-          isError: action.isError,
-        }],
-      }
+      return reduceToolActivity(state, action)
 
-    case 'PERMISSION_REQUEST':
-      return { ...state, permissionRequest: action.request }
+    case 'BG_AGENT_STARTED':
+    case 'BG_AGENT_COMPLETE':
+      return reduceBackgroundAgents(state, action)
 
-    case 'PERMISSION_DISMISS':
-      return { ...state, permissionRequest: null }
+    case 'AGENT_TREE_SNAPSHOT':
+    case 'AGENT_SPAWNED':
+    case 'AGENT_COMPLETED':
+    case 'AGENT_ERROR':
+    case 'AGENT_ABORTED':
+    case 'AGENT_STREAM_DELTA':
+    case 'AGENT_THINKING_DELTA':
+      return reduceAgentTree(state, action)
 
-    case 'QUESTION_REQUEST':
-      return {
-        ...state,
-        pendingQuestion: action.question,
-        messages: [...state.messages, {
-          id: `question-${action.question.id}`,
-          role: 'system',
-          content: action.question.text,
-          timestamp: Date.now(),
-          level: 'question',
-        }],
-      }
+    case 'TEAM_MEMBER_JOINED':
+    case 'TEAM_MEMBER_LEFT':
+    case 'TEAM_MESSAGE_ROUTED':
+    case 'TEAM_STATUS_SNAPSHOT':
+      return reduceTeams(state, action)
 
-    case 'QUESTION_DISMISS':
-      return { ...state, pendingQuestion: null }
-
-    case 'SYSTEM_INFO':
-      return {
-        ...state,
-        messages: [...state.messages, {
-          id: `sys-${Date.now()}`,
-          role: 'system',
-          content: action.text,
-          timestamp: Date.now(),
-          level: action.level,
-        }],
-      }
-
-    case 'USAGE_UPDATE':
-      return { ...state, usage: action.usage }
-
-    case 'SUGGESTIONS':
-      return { ...state, suggestions: action.items }
-
-    case 'ERROR':
-      return {
-        ...state,
-        isStreaming: false,
-        isWaiting: false,
-        streamingText: '',
-        streamingThinking: '',
-        streamingMessageId: null,
-        messages: [...state.messages, {
-          id: `err-${Date.now()}`,
-          role: 'system',
-          content: action.message,
-          timestamp: Date.now(),
-          level: 'error',
-        }],
-      }
-
-    case 'BG_AGENT_STARTED': {
-      const agent: BackgroundAgent = {
-        agentId: action.agentId,
-        description: action.description,
-        startedAt: Date.now(),
-      }
-      return {
-        ...state,
-        backgroundAgents: [...state.backgroundAgents, agent],
-        messages: [...state.messages, {
-          id: `bg-start-${action.agentId}`,
-          role: 'system',
-          content: `Background agent started: ${action.description}`,
-          timestamp: Date.now(),
-          level: 'info',
-        }],
-      }
-    }
-
-    case 'BG_AGENT_COMPLETE': {
-      const durationSec = (action.durationMs / 1000).toFixed(1)
-      const statusLabel = action.hadError ? 'FAILED' : 'DONE'
-      return {
-        ...state,
-        backgroundAgents: state.backgroundAgents.map(agent =>
-          agent.agentId === action.agentId
-            ? {
-                ...agent,
-                completedAt: Date.now(),
-                resultPreview: action.resultPreview,
-                hadError: action.hadError,
-                durationMs: action.durationMs,
-              }
-            : agent,
-        ),
-        messages: [...state.messages, {
-          id: `bg-done-${action.agentId}`,
-          role: 'system',
-          content: `${statusLabel} background agent "${action.description}" completed in ${durationSec}s\n\n${action.resultPreview}`,
-          timestamp: Date.now(),
-          level: action.hadError ? 'error' : 'info',
-        }],
-      }
-    }
+    case 'SUBSYSTEM_STATUS':
+    case 'LSP_SERVER_STATE':
+    case 'MCP_SERVER_STATE':
+    case 'PLUGIN_STATUS':
+    case 'SKILLS_LOADED':
+      return reduceSubsystems(state, action)
 
     case 'PUSH_HISTORY':
-      return {
-        ...state,
-        inputHistory: [...state.inputHistory, action.text],
-        historyIndex: -1,
-      }
-
     case 'SET_HISTORY_INDEX':
-      return { ...state, historyIndex: action.index }
-
     case 'SET_VIM_MODE':
-      return { ...state, vimMode: action.mode }
-
     case 'TOGGLE_VIM':
-      return {
-        ...state,
-        vimEnabled: !state.vimEnabled,
-        vimMode: state.vimEnabled ? '' : 'NORMAL',
-      }
-
     case 'QUEUE_SUBMISSION':
-      return {
-        ...state,
-        queuedSubmissions: [...state.queuedSubmissions, action.submission],
-      }
-
     case 'DEQUEUE_SUBMISSION':
-      return {
-        ...state,
-        queuedSubmissions: state.queuedSubmissions.slice(1),
-      }
-
     case 'SET_VIEW_MODE':
-      return { ...state, viewMode: action.viewMode }
-
     case 'TOGGLE_VIEW_MODE':
-      return {
-        ...state,
-        viewMode: state.viewMode === 'prompt' ? 'transcript' : 'prompt',
-      }
-
-    // ── Agent tree ──────────────────────────────────────────────
-    case 'AGENT_TREE_SNAPSHOT':
-      return { ...state, agentTree: action.roots }
-
-    case 'AGENT_SPAWNED':
-      return {
-        ...state,
-        agentStreams: { ...state.agentStreams, [action.agentId]: { text: '', thinking: '' } },
-        messages: [...state.messages, {
-          id: `agent-spawn-${action.agentId}`,
-          role: 'system',
-          content: `Agent spawned: ${action.description}${action.isBackground ? ' (background)' : ''}`,
-          timestamp: Date.now(),
-          level: 'info',
-        }],
-      }
-
-    case 'AGENT_COMPLETED': {
-      const { [action.agentId]: _removed, ...remainingStreams } = state.agentStreams
-      const durationSec = (action.durationMs / 1000).toFixed(1)
-      return {
-        ...state,
-        agentStreams: remainingStreams,
-        messages: [...state.messages, {
-          id: `agent-done-${action.agentId}`,
-          role: 'system',
-          content: `Agent ${action.hadError ? 'FAILED' : 'completed'} (${durationSec}s): ${action.resultPreview}`,
-          timestamp: Date.now(),
-          level: action.hadError ? 'error' : 'info',
-        }],
-      }
-    }
-
-    case 'AGENT_ERROR': {
-      const { [action.agentId]: _removed, ...remainingStreams } = state.agentStreams
-      return {
-        ...state,
-        agentStreams: remainingStreams,
-        messages: [...state.messages, {
-          id: `agent-err-${action.agentId}`,
-          role: 'system',
-          content: `Agent error (${(action.durationMs / 1000).toFixed(1)}s): ${action.error}`,
-          timestamp: Date.now(),
-          level: 'error',
-        }],
-      }
-    }
-
-    case 'AGENT_ABORTED': {
-      const { [action.agentId]: _removed, ...remainingStreams } = state.agentStreams
-      return {
-        ...state,
-        agentStreams: remainingStreams,
-        messages: [...state.messages, {
-          id: `agent-abort-${action.agentId}`,
-          role: 'system',
-          content: `Agent aborted: ${action.agentId}`,
-          timestamp: Date.now(),
-          level: 'warning',
-        }],
-      }
-    }
-
-    case 'AGENT_STREAM_DELTA': {
-      const prev = state.agentStreams[action.agentId] ?? { text: '', thinking: '' }
-      return {
-        ...state,
-        agentStreams: { ...state.agentStreams, [action.agentId]: { ...prev, text: prev.text + action.text } },
-      }
-    }
-
-    case 'AGENT_THINKING_DELTA': {
-      const prev = state.agentStreams[action.agentId] ?? { text: '', thinking: '' }
-      return {
-        ...state,
-        agentStreams: { ...state.agentStreams, [action.agentId]: { ...prev, thinking: prev.thinking + action.thinking } },
-      }
-    }
-
-    // ── Teams ───────────────────────────────────────────────────
-    case 'TEAM_MEMBER_JOINED': {
-      const team = state.teams[action.teamName] ?? { name: action.teamName, members: [], pendingMessages: 0, recentMessages: [] }
-      const newMember: TeamMemberInfo = { agent_id: action.agentId, agent_name: action.agentName, role: action.role, is_active: true, unread_messages: 0 }
-      return {
-        ...state,
-        teams: { ...state.teams, [action.teamName]: { ...team, members: [...team.members, newMember] } },
-      }
-    }
-
-    case 'TEAM_MEMBER_LEFT': {
-      const team = state.teams[action.teamName]
-      if (!team) return state
-      return {
-        ...state,
-        teams: { ...state.teams, [action.teamName]: { ...team, members: team.members.filter(m => m.agent_id !== action.agentId) } },
-      }
-    }
-
-    case 'TEAM_MESSAGE_ROUTED': {
-      const team = state.teams[action.teamName] ?? { name: action.teamName, members: [], pendingMessages: 0, recentMessages: [] }
-      const msg = { from: action.from, to: action.to, summary: action.summary, timestamp: action.timestamp }
-      return {
-        ...state,
-        teams: { ...state.teams, [action.teamName]: { ...team, recentMessages: [...team.recentMessages.slice(-19), msg] } },
-      }
-    }
-
-    case 'TEAM_STATUS_SNAPSHOT': {
-      const team = state.teams[action.teamName] ?? { name: action.teamName, members: [], pendingMessages: 0, recentMessages: [] }
-      return {
-        ...state,
-        teams: { ...state.teams, [action.teamName]: { ...team, members: action.members, pendingMessages: action.pendingMessages } },
-      }
-    }
-
-    // ── Subsystems ──────────────────────────────────────────────
-    case 'SUBSYSTEM_STATUS':
-      return {
-        ...state,
-        subsystems: { lsp: action.lsp, mcp: action.mcp, plugins: action.plugins, skills: action.skills, lastUpdated: Date.now() },
-      }
-
-    case 'LSP_SERVER_STATE':
-      return {
-        ...state,
-        subsystems: {
-          ...state.subsystems,
-          lsp: upsertBy(state.subsystems.lsp, 'language_id', action.languageId, s => ({ ...s, state: action.state, error: action.error })),
-          lastUpdated: Date.now(),
-        },
-      }
-
-    case 'MCP_SERVER_STATE':
-      return {
-        ...state,
-        subsystems: {
-          ...state.subsystems,
-          mcp: upsertBy(state.subsystems.mcp, 'name', action.serverName, s => ({ ...s, state: action.state, error: action.error })),
-          lastUpdated: Date.now(),
-        },
-      }
-
-    case 'PLUGIN_STATUS':
-      return {
-        ...state,
-        subsystems: {
-          ...state.subsystems,
-          plugins: upsertBy(state.subsystems.plugins, 'id', action.pluginId, s => ({ ...s, name: action.name, status: action.status, error: action.error })),
-          lastUpdated: Date.now(),
-        },
-      }
-
-    case 'SKILLS_LOADED':
-      return state // informational only — real data arrives via SUBSYSTEM_STATUS
+      return reduceInput(state, action)
 
     default:
       return state
@@ -633,24 +112,4 @@ export function useAppState(): AppState {
 
 export function useAppDispatch(): Dispatch<AppAction> {
   return useContext(DispatchContext)
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** Update an item in an array by key, or append a stub if missing. */
-function upsertBy<T extends Record<string, any>>(
-  arr: T[],
-  key: keyof T,
-  value: any,
-  updater: (existing: T) => T,
-): T[] {
-  const idx = arr.findIndex(item => item[key] === value)
-  if (idx >= 0) {
-    const copy = [...arr]
-    copy[idx] = updater(copy[idx]!)
-    return copy
-  }
-  return [...arr, updater({ [key]: value } as T)]
 }

--- a/ui/src/store/reducers/agent-tree.ts
+++ b/ui/src/store/reducers/agent-tree.ts
@@ -1,0 +1,83 @@
+import type { AgentTreeAction, AppState } from '../app-state.js'
+
+export function reduceAgentTree(state: AppState, action: AgentTreeAction): AppState {
+  switch (action.type) {
+    case 'AGENT_TREE_SNAPSHOT':
+      return { ...state, agentTree: action.roots }
+
+    case 'AGENT_SPAWNED':
+      return {
+        ...state,
+        agentStreams: { ...state.agentStreams, [action.agentId]: { text: '', thinking: '' } },
+        messages: [...state.messages, {
+          id: `agent-spawn-${action.agentId}`,
+          role: 'system',
+          content: `Agent spawned: ${action.description}${action.isBackground ? ' (background)' : ''}`,
+          timestamp: Date.now(),
+          level: 'info',
+        }],
+      }
+
+    case 'AGENT_COMPLETED': {
+      const { [action.agentId]: _removed, ...remainingStreams } = state.agentStreams
+      const durationSec = (action.durationMs / 1000).toFixed(1)
+      return {
+        ...state,
+        agentStreams: remainingStreams,
+        messages: [...state.messages, {
+          id: `agent-done-${action.agentId}`,
+          role: 'system',
+          content: `Agent ${action.hadError ? 'FAILED' : 'completed'} (${durationSec}s): ${action.resultPreview}`,
+          timestamp: Date.now(),
+          level: action.hadError ? 'error' : 'info',
+        }],
+      }
+    }
+
+    case 'AGENT_ERROR': {
+      const { [action.agentId]: _removed, ...remainingStreams } = state.agentStreams
+      return {
+        ...state,
+        agentStreams: remainingStreams,
+        messages: [...state.messages, {
+          id: `agent-err-${action.agentId}`,
+          role: 'system',
+          content: `Agent error (${(action.durationMs / 1000).toFixed(1)}s): ${action.error}`,
+          timestamp: Date.now(),
+          level: 'error',
+        }],
+      }
+    }
+
+    case 'AGENT_ABORTED': {
+      const { [action.agentId]: _removed, ...remainingStreams } = state.agentStreams
+      return {
+        ...state,
+        agentStreams: remainingStreams,
+        messages: [...state.messages, {
+          id: `agent-abort-${action.agentId}`,
+          role: 'system',
+          content: `Agent aborted: ${action.agentId}`,
+          timestamp: Date.now(),
+          level: 'warning',
+        }],
+      }
+    }
+
+    case 'AGENT_STREAM_DELTA': {
+      const prev = state.agentStreams[action.agentId] ?? { text: '', thinking: '' }
+      return {
+        ...state,
+        agentStreams: { ...state.agentStreams, [action.agentId]: { ...prev, text: prev.text + action.text } },
+      }
+    }
+
+    case 'AGENT_THINKING_DELTA': {
+      const prev = state.agentStreams[action.agentId] ?? { text: '', thinking: '' }
+      return {
+        ...state,
+        agentStreams: { ...state.agentStreams, [action.agentId]: { ...prev, thinking: prev.thinking + action.thinking } },
+      }
+    }
+  }
+}

--- a/ui/src/store/reducers/background-agents.ts
+++ b/ui/src/store/reducers/background-agents.ts
@@ -1,0 +1,50 @@
+import type { AppState, BackgroundAgent, BackgroundAgentAction } from '../app-state.js'
+
+export function reduceBackgroundAgents(state: AppState, action: BackgroundAgentAction): AppState {
+  switch (action.type) {
+    case 'BG_AGENT_STARTED': {
+      const agent: BackgroundAgent = {
+        agentId: action.agentId,
+        description: action.description,
+        startedAt: Date.now(),
+      }
+      return {
+        ...state,
+        backgroundAgents: [...state.backgroundAgents, agent],
+        messages: [...state.messages, {
+          id: `bg-start-${action.agentId}`,
+          role: 'system',
+          content: `Background agent started: ${action.description}`,
+          timestamp: Date.now(),
+          level: 'info',
+        }],
+      }
+    }
+
+    case 'BG_AGENT_COMPLETE': {
+      const durationSec = (action.durationMs / 1000).toFixed(1)
+      const statusLabel = action.hadError ? 'FAILED' : 'DONE'
+      return {
+        ...state,
+        backgroundAgents: state.backgroundAgents.map(agent =>
+          agent.agentId === action.agentId
+            ? {
+                ...agent,
+                completedAt: Date.now(),
+                resultPreview: action.resultPreview,
+                hadError: action.hadError,
+                durationMs: action.durationMs,
+              }
+            : agent,
+        ),
+        messages: [...state.messages, {
+          id: `bg-done-${action.agentId}`,
+          role: 'system',
+          content: `${statusLabel} background agent "${action.description}" completed in ${durationSec}s\n\n${action.resultPreview}`,
+          timestamp: Date.now(),
+          level: action.hadError ? 'error' : 'info',
+        }],
+      }
+    }
+  }
+}

--- a/ui/src/store/reducers/core.ts
+++ b/ui/src/store/reducers/core.ts
@@ -1,0 +1,144 @@
+import type { AppState, CoreAction } from '../app-state.js'
+
+export function reduceCore(state: AppState, action: CoreAction): AppState {
+  switch (action.type) {
+    case 'READY':
+      return { ...state, model: action.model, sessionId: action.sessionId, cwd: action.cwd }
+
+    case 'REPLACE_MESSAGES':
+      return {
+        ...state,
+        isStreaming: false,
+        isWaiting: false,
+        streamingText: '',
+        streamingThinking: '',
+        streamingMessageId: null,
+        messages: action.messages,
+      }
+
+    case 'ADD_USER_MESSAGE':
+      return {
+        ...state,
+        isWaiting: true,
+        messages: [...state.messages, {
+          id: action.id,
+          role: 'user',
+          content: action.text,
+          timestamp: Date.now(),
+        }],
+      }
+
+    case 'ADD_COMMAND_MESSAGE':
+      return {
+        ...state,
+        messages: [...state.messages, {
+          id: action.id,
+          role: 'user',
+          content: action.text,
+          timestamp: Date.now(),
+        }],
+      }
+
+    case 'STREAM_START':
+      return {
+        ...state,
+        isStreaming: true,
+        isWaiting: false,
+        streamingText: '',
+        streamingThinking: '',
+        streamingMessageId: action.messageId,
+      }
+
+    case 'STREAM_DELTA':
+      return { ...state, streamingText: state.streamingText + action.text }
+
+    case 'THINKING_DELTA':
+      return { ...state, streamingThinking: state.streamingThinking + action.thinking }
+
+    case 'STREAM_END':
+      return {
+        ...state,
+        isStreaming: false,
+        isWaiting: false,
+        streamingText: '',
+        streamingThinking: '',
+        streamingMessageId: null,
+      }
+
+    case 'ASSISTANT_MESSAGE':
+      return {
+        ...state,
+        isStreaming: false,
+        isWaiting: false,
+        streamingText: '',
+        streamingThinking: '',
+        streamingMessageId: null,
+        messages: [...state.messages, {
+          id: action.id,
+          role: 'assistant',
+          content: action.content,
+          timestamp: Date.now(),
+          contentBlocks: action.contentBlocks,
+          costUsd: action.costUsd,
+          thinking: action.thinking,
+        }],
+      }
+
+    case 'PERMISSION_REQUEST':
+      return { ...state, permissionRequest: action.request }
+
+    case 'PERMISSION_DISMISS':
+      return { ...state, permissionRequest: null }
+
+    case 'QUESTION_REQUEST':
+      return {
+        ...state,
+        pendingQuestion: action.question,
+        messages: [...state.messages, {
+          id: `question-${action.question.id}`,
+          role: 'system',
+          content: action.question.text,
+          timestamp: Date.now(),
+          level: 'question',
+        }],
+      }
+
+    case 'QUESTION_DISMISS':
+      return { ...state, pendingQuestion: null }
+
+    case 'SYSTEM_INFO':
+      return {
+        ...state,
+        messages: [...state.messages, {
+          id: `sys-${Date.now()}`,
+          role: 'system',
+          content: action.text,
+          timestamp: Date.now(),
+          level: action.level,
+        }],
+      }
+
+    case 'USAGE_UPDATE':
+      return { ...state, usage: action.usage }
+
+    case 'SUGGESTIONS':
+      return { ...state, suggestions: action.items }
+
+    case 'ERROR':
+      return {
+        ...state,
+        isStreaming: false,
+        isWaiting: false,
+        streamingText: '',
+        streamingThinking: '',
+        streamingMessageId: null,
+        messages: [...state.messages, {
+          id: `err-${Date.now()}`,
+          role: 'system',
+          content: action.message,
+          timestamp: Date.now(),
+          level: 'error',
+        }],
+      }
+  }
+}

--- a/ui/src/store/reducers/input.ts
+++ b/ui/src/store/reducers/input.ts
@@ -1,0 +1,46 @@
+import type { AppState, InputAction } from '../app-state.js'
+
+export function reduceInput(state: AppState, action: InputAction): AppState {
+  switch (action.type) {
+    case 'PUSH_HISTORY':
+      return {
+        ...state,
+        inputHistory: [...state.inputHistory, action.text],
+        historyIndex: -1,
+      }
+
+    case 'SET_HISTORY_INDEX':
+      return { ...state, historyIndex: action.index }
+
+    case 'SET_VIM_MODE':
+      return { ...state, vimMode: action.mode }
+
+    case 'TOGGLE_VIM':
+      return {
+        ...state,
+        vimEnabled: !state.vimEnabled,
+        vimMode: state.vimEnabled ? '' : 'NORMAL',
+      }
+
+    case 'QUEUE_SUBMISSION':
+      return {
+        ...state,
+        queuedSubmissions: [...state.queuedSubmissions, action.submission],
+      }
+
+    case 'DEQUEUE_SUBMISSION':
+      return {
+        ...state,
+        queuedSubmissions: state.queuedSubmissions.slice(1),
+      }
+
+    case 'SET_VIEW_MODE':
+      return { ...state, viewMode: action.viewMode }
+
+    case 'TOGGLE_VIEW_MODE':
+      return {
+        ...state,
+        viewMode: state.viewMode === 'prompt' ? 'transcript' : 'prompt',
+      }
+  }
+}

--- a/ui/src/store/reducers/subsystems.ts
+++ b/ui/src/store/reducers/subsystems.ts
@@ -1,0 +1,45 @@
+import type { AppState, SubsystemAction } from '../app-state.js'
+import { upsertBy } from './upsert.js'
+
+export function reduceSubsystems(state: AppState, action: SubsystemAction): AppState {
+  switch (action.type) {
+    case 'SUBSYSTEM_STATUS':
+      return {
+        ...state,
+        subsystems: { lsp: action.lsp, mcp: action.mcp, plugins: action.plugins, skills: action.skills, lastUpdated: Date.now() },
+      }
+
+    case 'LSP_SERVER_STATE':
+      return {
+        ...state,
+        subsystems: {
+          ...state.subsystems,
+          lsp: upsertBy(state.subsystems.lsp, 'language_id', action.languageId, s => ({ ...s, state: action.state, error: action.error })),
+          lastUpdated: Date.now(),
+        },
+      }
+
+    case 'MCP_SERVER_STATE':
+      return {
+        ...state,
+        subsystems: {
+          ...state.subsystems,
+          mcp: upsertBy(state.subsystems.mcp, 'name', action.serverName, s => ({ ...s, state: action.state, error: action.error })),
+          lastUpdated: Date.now(),
+        },
+      }
+
+    case 'PLUGIN_STATUS':
+      return {
+        ...state,
+        subsystems: {
+          ...state.subsystems,
+          plugins: upsertBy(state.subsystems.plugins, 'id', action.pluginId, s => ({ ...s, name: action.name, status: action.status, error: action.error })),
+          lastUpdated: Date.now(),
+        },
+      }
+
+    case 'SKILLS_LOADED':
+      return state // informational only — real data arrives via SUBSYSTEM_STATUS
+  }
+}

--- a/ui/src/store/reducers/teams.ts
+++ b/ui/src/store/reducers/teams.ts
@@ -1,0 +1,41 @@
+import type { TeamMemberInfo } from '../../ipc/protocol.js'
+import type { AppState, TeamAction } from '../app-state.js'
+
+export function reduceTeams(state: AppState, action: TeamAction): AppState {
+  switch (action.type) {
+    case 'TEAM_MEMBER_JOINED': {
+      const team = state.teams[action.teamName] ?? { name: action.teamName, members: [], pendingMessages: 0, recentMessages: [] }
+      const newMember: TeamMemberInfo = { agent_id: action.agentId, agent_name: action.agentName, role: action.role, is_active: true, unread_messages: 0 }
+      return {
+        ...state,
+        teams: { ...state.teams, [action.teamName]: { ...team, members: [...team.members, newMember] } },
+      }
+    }
+
+    case 'TEAM_MEMBER_LEFT': {
+      const team = state.teams[action.teamName]
+      if (!team) return state
+      return {
+        ...state,
+        teams: { ...state.teams, [action.teamName]: { ...team, members: team.members.filter(m => m.agent_id !== action.agentId) } },
+      }
+    }
+
+    case 'TEAM_MESSAGE_ROUTED': {
+      const team = state.teams[action.teamName] ?? { name: action.teamName, members: [], pendingMessages: 0, recentMessages: [] }
+      const msg = { from: action.from, to: action.to, summary: action.summary, timestamp: action.timestamp }
+      return {
+        ...state,
+        teams: { ...state.teams, [action.teamName]: { ...team, recentMessages: [...team.recentMessages.slice(-19), msg] } },
+      }
+    }
+
+    case 'TEAM_STATUS_SNAPSHOT': {
+      const team = state.teams[action.teamName] ?? { name: action.teamName, members: [], pendingMessages: 0, recentMessages: [] }
+      return {
+        ...state,
+        teams: { ...state.teams, [action.teamName]: { ...team, members: action.members, pendingMessages: action.pendingMessages } },
+      }
+    }
+  }
+}

--- a/ui/src/store/reducers/tool-activity.ts
+++ b/ui/src/store/reducers/tool-activity.ts
@@ -1,0 +1,32 @@
+import type { AppState, ToolActivityAction } from '../app-state.js'
+
+export function reduceToolActivity(state: AppState, action: ToolActivityAction): AppState {
+  switch (action.type) {
+    case 'TOOL_USE':
+      return {
+        ...state,
+        messages: [...state.messages, {
+          id: action.id,
+          role: 'tool_use',
+          content: `Tool: ${action.name}`,
+          timestamp: Date.now(),
+          toolName: action.name,
+          toolInput: action.input,
+          toolUseId: action.id,
+        }],
+      }
+
+    case 'TOOL_RESULT':
+      return {
+        ...state,
+        messages: [...state.messages, {
+          id: `result-${action.toolUseId}-${Date.now()}`,
+          role: 'tool_result',
+          content: action.output,
+          timestamp: Date.now(),
+          toolUseId: action.toolUseId,
+          isError: action.isError,
+        }],
+      }
+  }
+}

--- a/ui/src/store/reducers/upsert.ts
+++ b/ui/src/store/reducers/upsert.ts
@@ -1,0 +1,15 @@
+/** Update an item in an array by key, or append a stub if missing. */
+export function upsertBy<T extends Record<string, any>>(
+  arr: T[],
+  key: keyof T,
+  value: any,
+  updater: (existing: T) => T,
+): T[] {
+  const idx = arr.findIndex(item => item[key] === value)
+  if (idx >= 0) {
+    const copy = [...arr]
+    copy[idx] = updater(copy[idx]!)
+    return copy
+  }
+  return [...arr, updater({ [key]: value } as T)]
+}


### PR DESCRIPTION
Fixes #22.

## Summary

Collapse three hotspot files into focused modules while keeping external APIs and behaviour unchanged.

| File | Before | After | Extracted to |
|------|-------:|------:|--------------|
| `src/main.rs` | 1200 | 750 | `src/cli.rs`, `src/startup/` (logging, fast_paths, runtime_config, modes) |
| `ui/src/store/app-store.tsx` | 656 | 115 | `app-state.ts` + `reducers/{core,tool-activity,background-agents,agent-tree,teams,subsystems,input,upsert}.ts` |
| `ui/src/components/InputPrompt.tsx` | 709 | 601 | `input-prompt-keys.ts`, `input-prompt-hooks.ts` (4 hooks) |

### `src/main.rs`
- `Cli` struct → [`src/cli.rs`](src/cli.rs)
- env loading + tracing setup + log housekeeping → [`src/startup/mod.rs`](src/startup/mod.rs) + [`src/startup/logging.rs`](src/startup/logging.rs)
- `--chrome-native-host`, `--claude-in-chrome-mcp`, `--dump-system-prompt` → [`src/startup/fast_paths.rs`](src/startup/fast_paths.rs)
- `resolve_cwd`, `resolve_permission_mode`, `build_tool_permission_context`, chrome helpers → [`src/startup/runtime_config.rs`](src/startup/runtime_config.rs)
- `run_json_mode`, `run_print_mode` → [`src/startup/modes.rs`](src/startup/modes.rs)
- `main.rs` retains `main()`, `run_full_init()`, and mod declarations only.

### `ui/src/store/app-store.tsx`
- All types + `initialState` + `AppAction` union → `app-state.ts`
- Reducer split into 7 slices under `reducers/`, routed by a switch in `appReducer`
- `AppStateProvider`, `useAppState`, `useAppDispatch`, `appReducer`, `initialState`, and all previously exported types remain available via re-export — no caller changes needed.

### `ui/src/components/InputPrompt.tsx`
- Key-event helpers (`extractInput`, `toShortcutKey`, `formatWorkedDuration`) → `input-prompt-keys.ts`
- `useComposerState` (text/cursor/undo + `insertText`/`reset`), `useBusyTimer`, `usePasteHandler`, `useInputHistoryNav` → `input-prompt-hooks.ts`
- Main component now owns keyboard dispatch + render; the inline `useKeyboard` callback is left intact because its branches are tightly coupled to local setters — further decomposition would obscure rather than clarify.

## Why

Per issue #22: these files were accumulating complexity at the entry point, state centre, and core interaction component. Splitting along natural responsibilities stops the bleed without widening diff risk.

## Behaviour

Existing tests lock behaviour — no new tests added, no tests modified:
- `bun test`: **23/23** reducer + paste-display tests pass. The 1 failing test (`RustBackend IPC (headless)`) is pre-existing, needs a compiled binary.
- `cargo check`: no new warnings in touched files. The 3 errors in `src/web/static_files.rs` and 6 `unused_*` warnings in `src/observability/*` and `src/web/handlers.rs` are pre-existing (reproducible by stashing this PR).
- `tsc --noEmit`: no new errors in touched files. Remaining TS errors are all pre-existing (`DiffView`, `MessageBubble`, `ToolActivity`, test `bun:test` typing).

## Test plan

- [ ] `cd ui && bun test src/store/app-store.test.ts src/components/__tests__/paste-display.test.ts` — 23/23 pass
- [ ] `cargo check` — no new warnings/errors
- [ ] `cargo build --release && ./target/release/claude-code-rs --version` still works (fast path)
- [ ] Launch the TUI, submit a prompt, send `/` command — core interaction flows unchanged