### PR TITLE
feat(commands): add /review, /security-review, /recap prompt-wrapper commands

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -24,6 +24,9 @@ pub mod version;
 // Git & workflow
 pub mod branch;
 pub mod commit;
+pub mod recap;
+pub mod review;
+pub mod security_review;
 
 // Model control
 pub mod effort;
@@ -450,6 +453,24 @@ pub fn get_all_commands() -> Vec<Command> {
             description: "Manage Agent Teams (create, list, spawn, send, kill, leave, delete)"
                 .into(),
             handler: Box::new(team_cmd::TeamHandler),
+        },
+        Command {
+            name: "review".into(),
+            aliases: vec![],
+            description: "Review a pull request using a local gh pr workflow".into(),
+            handler: Box::new(review::ReviewHandler),
+        },
+        Command {
+            name: "security-review".into(),
+            aliases: vec!["secreview".into()],
+            description: "Run a focused security review of the current branch diff".into(),
+            handler: Box::new(security_review::SecurityReviewHandler),
+        },
+        Command {
+            name: "recap".into(),
+            aliases: vec![],
+            description: "Summarize the current session (short | long)".into(),
+            handler: Box::new(recap::RecapHandler),
         },
     ]
 }

--- a/src/commands/recap.rs
+++ b/src/commands/recap.rs
@@ -1,0 +1,256 @@
+//! `/recap` command — one-line or short-paragraph summary of the current session.
+//!
+//! Uses the current conversation history (already in `CommandContext.messages`)
+//! to ask the model for a tight recap. Optional argument: `short` (default) or
+//! `long` to pick granularity.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use super::{CommandContext, CommandHandler, CommandResult};
+use crate::types::message::{
+    ContentBlock, Message, MessageContent, ToolResultContent, UserMessage,
+};
+
+pub struct RecapHandler;
+
+#[derive(Copy, Clone)]
+enum Granularity {
+    Short,
+    Long,
+}
+
+#[async_trait]
+impl CommandHandler for RecapHandler {
+    async fn execute(&self, args: &str, ctx: &mut CommandContext) -> Result<CommandResult> {
+        let granularity = match args.trim().to_ascii_lowercase().as_str() {
+            "" | "short" | "brief" | "line" => Granularity::Short,
+            "long" | "full" | "detailed" => Granularity::Long,
+            other => {
+                return Ok(CommandResult::Output(format!(
+                    "Unknown recap style: {:?}. Use `/recap` or `/recap long`.",
+                    other
+                )));
+            }
+        };
+
+        let turns = count_user_turns(&ctx.messages);
+        if turns == 0 {
+            return Ok(CommandResult::Output(
+                "Nothing to recap yet — the session has no user messages.".to_string(),
+            ));
+        }
+
+        let prompt = build_recap_prompt(granularity, turns);
+
+        let msg = Message::User(UserMessage {
+            uuid: Uuid::new_v4(),
+            role: "user".to_string(),
+            content: MessageContent::Text(prompt),
+            timestamp: chrono::Utc::now().timestamp(),
+            is_meta: false,
+            tool_use_result: None,
+            source_tool_assistant_uuid: None,
+        });
+
+        Ok(CommandResult::Query(vec![msg]))
+    }
+}
+
+/// Count user messages that contribute to the conversation (exclude meta
+/// messages and pure tool results).
+fn count_user_turns(messages: &[Message]) -> usize {
+    messages
+        .iter()
+        .filter(|m| match m {
+            Message::User(u) => !u.is_meta && !is_tool_result_only(u),
+            _ => false,
+        })
+        .count()
+}
+
+fn is_tool_result_only(u: &UserMessage) -> bool {
+    if u.tool_use_result.is_some() {
+        return true;
+    }
+    match &u.content {
+        MessageContent::Blocks(blocks) => {
+            !blocks.is_empty()
+                && blocks.iter().all(|b| {
+                    matches!(
+                        b,
+                        ContentBlock::ToolResult {
+                            content: ToolResultContent::Text(_),
+                            ..
+                        } | ContentBlock::ToolResult {
+                            content: ToolResultContent::Blocks(_),
+                            ..
+                        }
+                    )
+                })
+        }
+        MessageContent::Text(_) => false,
+    }
+}
+
+fn build_recap_prompt(g: Granularity, turns: usize) -> String {
+    match g {
+        Granularity::Short => format!(
+            "Summarize the current session in one short sentence (max ~25 words). \
+             The session has {turns} user turn(s). \
+             Focus on what the user was trying to accomplish and the current state. \
+             No preamble, no trailing notes — just the sentence."
+        ),
+        Granularity::Long => format!(
+            "Summarize the current session as a short paragraph (3-5 sentences). \
+             The session has {turns} user turn(s). \
+             Cover:\n\
+             1. What the user asked for.\n\
+             2. What has been done.\n\
+             3. What is still open, if anything.\n\
+             Do not speculate about future work the user did not request."
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bootstrap::SessionId;
+    use crate::types::app_state::AppState;
+    use std::path::PathBuf;
+
+    fn test_ctx(messages: Vec<Message>) -> CommandContext {
+        CommandContext {
+            messages,
+            cwd: PathBuf::from("."),
+            app_state: AppState::default(),
+            session_id: SessionId::from_string("test-session"),
+        }
+    }
+
+    fn user_text(text: &str) -> Message {
+        Message::User(UserMessage {
+            uuid: Uuid::new_v4(),
+            role: "user".to_string(),
+            content: MessageContent::Text(text.to_string()),
+            timestamp: 0,
+            is_meta: false,
+            tool_use_result: None,
+            source_tool_assistant_uuid: None,
+        })
+    }
+
+    fn meta_user(text: &str) -> Message {
+        Message::User(UserMessage {
+            uuid: Uuid::new_v4(),
+            role: "user".to_string(),
+            content: MessageContent::Text(text.to_string()),
+            timestamp: 0,
+            is_meta: true,
+            tool_use_result: None,
+            source_tool_assistant_uuid: None,
+        })
+    }
+
+    fn tool_result_user() -> Message {
+        Message::User(UserMessage {
+            uuid: Uuid::new_v4(),
+            role: "user".to_string(),
+            content: MessageContent::Blocks(vec![ContentBlock::ToolResult {
+                tool_use_id: "tu_1".to_string(),
+                content: ToolResultContent::Text("ok".to_string()),
+                is_error: false,
+            }]),
+            timestamp: 0,
+            is_meta: false,
+            tool_use_result: Some("ok".to_string()),
+            source_tool_assistant_uuid: None,
+        })
+    }
+
+    #[tokio::test]
+    async fn recap_empty_session_returns_output() {
+        let handler = RecapHandler;
+        let mut ctx = test_ctx(Vec::new());
+        let result = handler.execute("", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(text) => {
+                assert!(text.contains("Nothing to recap"));
+            }
+            _ => panic!("Expected Output"),
+        }
+    }
+
+    #[tokio::test]
+    async fn recap_short_default_includes_turn_count() {
+        let handler = RecapHandler;
+        let mut ctx = test_ctx(vec![user_text("hello"), user_text("and again")]);
+        let result = handler.execute("", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Query(msgs) => {
+                if let Message::User(UserMessage {
+                    content: MessageContent::Text(body),
+                    ..
+                }) = &msgs[0]
+                {
+                    assert!(body.contains("2 user turn"));
+                    assert!(body.contains("one short sentence"));
+                } else {
+                    panic!("Expected User(Text)");
+                }
+            }
+            _ => panic!("Expected Query"),
+        }
+    }
+
+    #[tokio::test]
+    async fn recap_long_switches_template() {
+        let handler = RecapHandler;
+        let mut ctx = test_ctx(vec![user_text("hello")]);
+        let result = handler.execute("long", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Query(msgs) => {
+                if let Message::User(UserMessage {
+                    content: MessageContent::Text(body),
+                    ..
+                }) = &msgs[0]
+                {
+                    assert!(body.contains("short paragraph"));
+                } else {
+                    panic!("Expected User(Text)");
+                }
+            }
+            _ => panic!("Expected Query"),
+        }
+    }
+
+    #[tokio::test]
+    async fn recap_unknown_style_returns_error_output() {
+        let handler = RecapHandler;
+        let mut ctx = test_ctx(vec![user_text("hello")]);
+        let result = handler.execute("super-long", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(text) => {
+                assert!(text.contains("Unknown recap style"));
+            }
+            _ => panic!("Expected Output"),
+        }
+    }
+
+    #[test]
+    fn count_user_turns_ignores_meta_and_tool_results() {
+        let msgs = vec![
+            user_text("one"),
+            meta_user("system-injected context"),
+            tool_result_user(),
+            user_text("two"),
+        ];
+        assert_eq!(count_user_turns(&msgs), 2);
+    }
+}

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -1,0 +1,152 @@
+//! `/review` command — local PR review prompt wrapper.
+//!
+//! Thin wrapper that injects a structured code-review prompt guiding the model
+//! through a local `gh pr` inspection workflow. Optional argument `[pr]` is a
+//! pull request number/branch/URL passed to `gh pr view`.
+//!
+//! Mirrors the Bun reference `src/commands/review.ts` behavior.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use super::{CommandContext, CommandHandler, CommandResult};
+use crate::types::message::{Message, MessageContent, UserMessage};
+
+pub struct ReviewHandler;
+
+#[async_trait]
+impl CommandHandler for ReviewHandler {
+    async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> Result<CommandResult> {
+        let target = args.trim();
+        let prompt = build_review_prompt(target);
+
+        let msg = Message::User(UserMessage {
+            uuid: Uuid::new_v4(),
+            role: "user".to_string(),
+            content: MessageContent::Text(prompt),
+            timestamp: chrono::Utc::now().timestamp(),
+            is_meta: false,
+            tool_use_result: None,
+            source_tool_assistant_uuid: None,
+        });
+
+        Ok(CommandResult::Query(vec![msg]))
+    }
+}
+
+/// Build the review prompt. When `target` is empty, the model will pick the
+/// current branch's PR via `gh pr list`. Otherwise the target is forwarded to
+/// `gh pr view`.
+fn build_review_prompt(target: &str) -> String {
+    let header = if target.is_empty() {
+        "You are an expert code reviewer. Review the pull request for the current branch.\n\n\
+         Use the `gh` CLI to gather context:\n\
+           1. Run `gh pr list --head $(git branch --show-current) --state open --json number,title,headRefName` to find the PR.\n\
+           2. If no PR is associated with the branch, say so and stop.\n\
+           3. Otherwise use `gh pr view <number>` and `gh pr diff <number>` to read the PR.\n".to_string()
+    } else {
+        format!(
+            "You are an expert code reviewer. Review pull request `{}`.\n\n\
+             Use the `gh` CLI to gather context:\n\
+               1. Run `gh pr view {}` to read the description and metadata.\n\
+               2. Run `gh pr diff {}` to read the full diff.\n",
+            target, target, target
+        )
+    };
+
+    format!(
+        "{}\n\
+         When you review:\n\
+         - Focus on correctness, security, performance, and clarity.\n\
+         - Quote specific files and lines when giving feedback.\n\
+         - Separate must-fix issues from suggestions.\n\
+         - Keep feedback concise and actionable — no filler.\n\
+         - If tests are missing for a change, call it out.\n\n\
+         Output format:\n\
+         ## Summary\n\
+         <1-2 sentence overview>\n\n\
+         ## Must fix\n\
+         <list, or 'None'>\n\n\
+         ## Suggestions\n\
+         <list, or 'None'>\n\n\
+         ## Questions\n\
+         <list, or 'None'>\n",
+        header
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bootstrap::SessionId;
+    use crate::types::app_state::AppState;
+    use std::path::PathBuf;
+
+    fn test_ctx() -> CommandContext {
+        CommandContext {
+            messages: Vec::new(),
+            cwd: PathBuf::from("."),
+            app_state: AppState::default(),
+            session_id: SessionId::from_string("test-session"),
+        }
+    }
+
+    #[tokio::test]
+    async fn review_without_target_mentions_current_branch() {
+        let handler = ReviewHandler;
+        let mut ctx = test_ctx();
+        let result = handler.execute("", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Query(msgs) => {
+                assert_eq!(msgs.len(), 1);
+                if let Message::User(UserMessage {
+                    content: MessageContent::Text(body),
+                    ..
+                }) = &msgs[0]
+                {
+                    assert!(body.contains("current branch"));
+                    assert!(body.contains("gh pr list"));
+                    assert!(body.contains("## Summary"));
+                } else {
+                    panic!("Expected User(Text) message");
+                }
+            }
+            _ => panic!("Expected Query"),
+        }
+    }
+
+    #[tokio::test]
+    async fn review_with_target_threads_identifier_into_prompt() {
+        let handler = ReviewHandler;
+        let mut ctx = test_ctx();
+        let result = handler.execute("123", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Query(msgs) => {
+                if let Message::User(UserMessage {
+                    content: MessageContent::Text(body),
+                    ..
+                }) = &msgs[0]
+                {
+                    assert!(body.contains("gh pr view 123"));
+                    assert!(body.contains("gh pr diff 123"));
+                } else {
+                    panic!("Expected User(Text) message");
+                }
+            }
+            _ => panic!("Expected Query"),
+        }
+    }
+
+    #[test]
+    fn build_review_prompt_branch_fallback_has_output_sections() {
+        let p = build_review_prompt("");
+        assert!(p.contains("## Must fix"));
+        assert!(p.contains("## Suggestions"));
+        assert!(p.contains("## Questions"));
+    }
+}

--- a/src/commands/security_review.rs
+++ b/src/commands/security_review.rs
@@ -1,0 +1,169 @@
+//! `/security-review` command — local security-review prompt wrapper.
+//!
+//! Gathers git branch/diff/log context and feeds it into a focused
+//! security-review prompt. Mirrors the Bun reference
+//! `src/commands/security-review.ts`.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use super::{CommandContext, CommandHandler, CommandResult};
+use crate::types::message::{Message, MessageContent, UserMessage};
+use crate::utils::git;
+
+pub struct SecurityReviewHandler;
+
+#[async_trait]
+impl CommandHandler for SecurityReviewHandler {
+    async fn execute(&self, args: &str, ctx: &mut CommandContext) -> Result<CommandResult> {
+        let cwd = &ctx.cwd;
+
+        if !git::is_git_repo(cwd) {
+            return Ok(CommandResult::Output(
+                "Error: /security-review must be run inside a git repository.".to_string(),
+            ));
+        }
+
+        let context_block = collect_git_context(cwd);
+        let focus = args.trim();
+
+        let prompt = build_security_prompt(&context_block, focus);
+
+        let msg = Message::User(UserMessage {
+            uuid: Uuid::new_v4(),
+            role: "user".to_string(),
+            content: MessageContent::Text(prompt),
+            timestamp: chrono::Utc::now().timestamp(),
+            is_meta: false,
+            tool_use_result: None,
+            source_tool_assistant_uuid: None,
+        });
+
+        Ok(CommandResult::Query(vec![msg]))
+    }
+}
+
+/// Collect a compact summary of the current branch, working-tree status, and
+/// recent commits to seed the security-review prompt.
+fn collect_git_context(cwd: &std::path::Path) -> String {
+    let mut lines = Vec::new();
+
+    if let Ok(branch) = git::current_branch(cwd) {
+        lines.push(format!("Branch: {}", branch));
+    }
+
+    if let Ok(status) = git::get_status(cwd) {
+        lines.push(format!(
+            "Working tree: {} staged, {} unstaged, {} untracked",
+            status.staged.len(),
+            status.unstaged.len(),
+            status.untracked.len()
+        ));
+    }
+
+    if let Ok(log) = git::get_log(cwd, 5) {
+        if !log.is_empty() {
+            lines.push("Recent commits:".to_string());
+            for entry in log {
+                let summary: String = entry.summary.chars().take(100).collect();
+                lines.push(format!("  {} {}", entry.short_sha, summary));
+            }
+        }
+    }
+
+    if lines.is_empty() {
+        "(no git context available)".to_string()
+    } else {
+        lines.join("\n")
+    }
+}
+
+fn build_security_prompt(context: &str, focus: &str) -> String {
+    let focus_block = if focus.is_empty() {
+        String::new()
+    } else {
+        format!("\nUser focus area: {}\n", focus)
+    };
+
+    format!(
+        "You are a senior application security engineer performing a focused \
+         security review of the changes on the current branch.\n\n\
+         Git context:\n{context}\n{focus_block}\n\
+         Review procedure:\n\
+         1. Read the diff. Use the `Bash` tool to run `git diff --staged`, \
+            `git diff`, and `git log --oneline -n 20` as needed.\n\
+         2. For each changed file, inspect the surrounding code with `Read` so \
+            findings are grounded in context, not diff hunks alone.\n\
+         3. Consider common web-app risks: injection (SQL, shell, XSS), \
+            authn/authz bypass, insecure deserialization, SSRF, path traversal, \
+            unsafe file handling, secrets in code, weak crypto, logging of \
+            sensitive data, dependency risks, and race conditions.\n\
+         4. Do NOT suggest stylistic or non-security changes.\n\n\
+         Output format (Markdown):\n\
+         ## Verdict\n\
+         <APPROVE | CHANGES REQUESTED | BLOCKED — one line rationale>\n\n\
+         ## Findings\n\
+         For each finding:\n\
+         - **Severity:** Critical | High | Medium | Low\n\
+         - **Location:** path:line\n\
+         - **Issue:** one sentence\n\
+         - **Impact:** what an attacker can do\n\
+         - **Fix:** concrete remediation\n\n\
+         If there are no findings, write `None found` and justify briefly.\n"
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bootstrap::SessionId;
+    use crate::types::app_state::AppState;
+    use std::path::PathBuf;
+
+    fn test_ctx(cwd: PathBuf) -> CommandContext {
+        CommandContext {
+            messages: Vec::new(),
+            cwd,
+            app_state: AppState::default(),
+            session_id: SessionId::from_string("test-session"),
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_non_git_dir() {
+        let handler = SecurityReviewHandler;
+        let mut ctx = test_ctx(PathBuf::from("/nonexistent/path/definitely-not-a-repo"));
+        let result = handler.execute("", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(text) => {
+                assert!(text.contains("git repository"));
+            }
+            _ => panic!("Expected Output for non-git dir"),
+        }
+    }
+
+    #[test]
+    fn prompt_contains_output_template() {
+        let prompt = build_security_prompt("Branch: main", "");
+        assert!(prompt.contains("## Verdict"));
+        assert!(prompt.contains("## Findings"));
+        assert!(prompt.contains("Severity"));
+    }
+
+    #[test]
+    fn focus_text_is_threaded_through() {
+        let prompt = build_security_prompt("Branch: main", "authentication flow");
+        assert!(prompt.contains("User focus area: authentication flow"));
+    }
+
+    #[test]
+    fn empty_focus_omits_focus_block() {
+        let prompt = build_security_prompt("Branch: main", "");
+        assert!(!prompt.contains("User focus area"));
+    }
+}


### PR DESCRIPTION
## Summary

Implements three user-facing slash commands as thin prompt wrappers that return `CommandResult::Query`, matching the pattern already used by `/commit`. Closes the three simplest "Implement /X" issues in the tracker.

- `/review [pr]` — drives a local `gh pr view` / `gh pr diff` review flow. Falls back to `gh pr list --head $(git branch --show-current) ...` when no argument is given. Closes #59.
- `/security-review [focus]` (alias `/secreview`) — injects current branch / working-tree counts / last-5-commits context into a focused security-review prompt; rejects non-git directories up front. Optional trailing `focus` is threaded into the prompt. Closes #61.
- `/recap [short|long]` — short sentence (default) or 3–5 sentence paragraph summary of the current session. Empty-session guard returns a direct `Output` without a model round-trip. Turn counter ignores meta and tool-result messages so system-injected context does not inflate it. Closes #48.

All three are registered in `src/commands/mod.rs` with description + alias metadata.

## Why

These are called out in the issue bodies as "suggested approach: implement a simple prompt/skill wrapper first, then extend the command model later if needed." They don't need any new Rust scaffolding — just the command registration and prompt construction — so they're the cheapest way to make three previously-missing user commands available.

## What's intentionally NOT in scope

- Frontmatter-driven `allowed-tools` / model-override metadata on commands (issues #59, #61 flag this as future work).
- Generic slash → skill bridge (issue #59 flags as future work).
- Resume / away-summary semantics for `/recap` (time-window and new-message recap after long gaps) — left for when resume flow needs them.

## Tests

12 new unit tests, all passing:

| Module | Tests |
|---|---|
| `commands::review` | 3 — prompt contains branch fallback, target threading, output sections |
| `commands::security_review` | 4 — non-git-dir rejection, output template, focus threading, empty-focus branch |
| `commands::recap` | 5 — empty-session guard, short-default template, long switch, unknown-style error, meta/tool-result filtering |

The 4 existing `commands::tests::*` registry tests also pass.

Pre-existing test failures (`config_cmd::test_config_set_model_in_memory`, `test_config_set_permission_mode_updates_live_context`, `model_add::test_model_add_unknown_model_no_price_errors`) are reproducible on `rust-lite` without this change (verified via `git stash`) and are not touched here.

## Build

`cargo build` clean — no new warnings from this change. The 5 pre-existing warnings in `src/web/handlers.rs` and `src/observability/*` are unchanged.

## Test plan

- [x] cargo build
- [x] cargo test --bin claude-code-rs commands::review (3 passed)
- [x] cargo test --bin claude-code-rs commands::security_review (4 passed)
- [x] cargo test --bin claude-code-rs commands::recap (5 passed)
- [x] cargo test --bin claude-code-rs commands::tests (4 passed — registry)
- [ ] Manual smoke: /review, /security-review, /recap inside the REPL (reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)