### PR TITLE
feat(commands): add /hooks /agents /doctor /tasks read-only browsers

### DIFF
--- a/src/commands/agents_cmd.rs
+++ b/src/commands/agents_cmd.rs
@@ -1,0 +1,511 @@
+//! `/agents` slash command — read-only browser for agent definitions.
+//!
+//! Rust issue #34. Surfaces every agent the engine can dispatch, grouped
+//! by source, with override/shadow visibility when multiple sources define
+//! the same name.
+//!
+//! In cc-rust "agent" is a superset that covers:
+//! * the built-in subagent types the engine always honours (general-purpose,
+//!   Explore, Plan, code-reviewer);
+//! * user-invocable skills whose frontmatter flips them into forked
+//!   (`context: Fork`) or agent-backed execution;
+//! * active team members from `TeamContext`.
+//!
+//! The browser is intentionally read-only. CRUD flows can be layered on top
+//! of this aggregator later; the data model we assemble already carries
+//! enough metadata (source, path, active state) to support that without a
+//! rewrite.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use super::{CommandContext, CommandHandler, CommandResult};
+use crate::skills::{self, SkillContext, SkillDefinition, SkillSource};
+use crate::ui::browser::{render_with_footer, shorten_path, TreeNode};
+
+pub struct AgentsHandler;
+
+#[async_trait]
+impl CommandHandler for AgentsHandler {
+    async fn execute(&self, args: &str, ctx: &mut CommandContext) -> Result<CommandResult> {
+        let mut parts = args.split_whitespace();
+        let sub = parts.next().unwrap_or("").to_ascii_lowercase();
+
+        match sub.as_str() {
+            "" | "list" => {
+                let agents = collect_agents(ctx);
+                Ok(CommandResult::Output(render_agent_tree(&agents)))
+            }
+            "show" | "info" => {
+                let name = parts.next().unwrap_or("").trim();
+                if name.is_empty() {
+                    return Ok(CommandResult::Output(
+                        "Usage: /agents show <name>".to_string(),
+                    ));
+                }
+                let agents = collect_agents(ctx);
+                Ok(CommandResult::Output(render_agent_detail(&agents, name)))
+            }
+            "sources" => Ok(CommandResult::Output(render_sources(ctx))),
+            other => Ok(CommandResult::Output(format!(
+                "Unknown /agents subcommand '{}'.\n\n\
+                 Usage:\n  \
+                 /agents                — list every agent grouped by source\n  \
+                 /agents show <name>    — show details for one agent\n  \
+                 /agents sources        — show where agents are loaded from\n",
+                other
+            ))),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Data model
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum AgentSource {
+    Builtin,
+    Skill(SkillSource),
+    Team,
+}
+
+impl AgentSource {
+    fn tag(&self) -> String {
+        match self {
+            AgentSource::Builtin => "built-in".to_string(),
+            AgentSource::Skill(SkillSource::Bundled) => "bundled".to_string(),
+            AgentSource::Skill(SkillSource::User) => "user".to_string(),
+            AgentSource::Skill(SkillSource::Project) => "project".to_string(),
+            AgentSource::Skill(SkillSource::Plugin(name)) => format!("plugin:{}", name),
+            AgentSource::Skill(SkillSource::Mcp(name)) => format!("mcp:{}", name),
+            AgentSource::Team => "team".to_string(),
+        }
+    }
+
+    fn group_order(&self) -> u8 {
+        match self {
+            AgentSource::Builtin => 0,
+            AgentSource::Skill(SkillSource::Bundled) => 1,
+            AgentSource::Skill(SkillSource::User) => 2,
+            AgentSource::Skill(SkillSource::Project) => 3,
+            AgentSource::Skill(SkillSource::Plugin(_)) => 4,
+            AgentSource::Skill(SkillSource::Mcp(_)) => 5,
+            AgentSource::Team => 6,
+        }
+    }
+
+    fn group_label(&self) -> &'static str {
+        match self {
+            AgentSource::Builtin => "Built-in subagent types",
+            AgentSource::Skill(SkillSource::Bundled) => "Bundled skills",
+            AgentSource::Skill(SkillSource::User) => "User skills",
+            AgentSource::Skill(SkillSource::Project) => "Project skills",
+            AgentSource::Skill(SkillSource::Plugin(_)) => "Plugin-provided",
+            AgentSource::Skill(SkillSource::Mcp(_)) => "MCP-provided",
+            AgentSource::Team => "Active team members",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct AgentEntry {
+    name: String,
+    description: String,
+    source: AgentSource,
+    path: Option<PathBuf>,
+    /// `true` when the agent is currently usable (e.g. skill is enabled, team
+    /// member is active). Built-ins are always active.
+    active: bool,
+    /// How this agent executes: `"inline"`, `"fork"`, `"built-in"`, `"team"`.
+    execution: &'static str,
+}
+
+// ---------------------------------------------------------------------------
+// Collection
+// ---------------------------------------------------------------------------
+
+fn collect_agents(ctx: &CommandContext) -> Vec<AgentEntry> {
+    let mut out = Vec::new();
+
+    // 1. Built-in subagent types. The Rust engine currently accepts any
+    //    `subagent_type` string, but the system prompt advertises this
+    //    fixed palette. Surface them so users know what the model can ask
+    //    for without needing to grep the prompt.
+    for (name, desc) in BUILTIN_SUBAGENTS {
+        out.push(AgentEntry {
+            name: (*name).to_string(),
+            description: (*desc).to_string(),
+            source: AgentSource::Builtin,
+            path: None,
+            active: true,
+            execution: "built-in",
+        });
+    }
+
+    // 2. Skills with agent-like execution. A skill is treated as an agent
+    //    when it forks into a child QueryEngine or names a specific
+    //    subagent type in frontmatter. Inline-expanding skills are excluded
+    //    — they're visible in `/skills` and don't behave like agents.
+    for skill in skills::get_all_skills() {
+        if !is_agent_skill(&skill) {
+            continue;
+        }
+        let execution = match skill.frontmatter.context {
+            SkillContext::Fork => "fork",
+            SkillContext::Inline => "inline",
+        };
+        out.push(AgentEntry {
+            name: skill.name.clone(),
+            description: skill.frontmatter.description.clone(),
+            source: AgentSource::Skill(skill.source.clone()),
+            path: skill.base_dir.clone(),
+            active: skill.is_model_invocable() || skill.is_user_invocable(),
+            execution,
+        });
+    }
+
+    // 3. Active team members — these are runtime agents registered under
+    //    the current team context. They are explicitly active (not just
+    //    available), so flag them that way.
+    if let Some(team_ctx) = ctx.app_state.team_context.as_ref() {
+        for member in load_team_members(team_ctx) {
+            out.push(member);
+        }
+    }
+
+    out
+}
+
+fn is_agent_skill(skill: &SkillDefinition) -> bool {
+    matches!(skill.frontmatter.context, SkillContext::Fork)
+        || skill.frontmatter.agent.is_some()
+}
+
+fn load_team_members(team_ctx: &crate::teams::types::TeamContext) -> Vec<AgentEntry> {
+    // Read the team file and enumerate members. This is best-effort — if
+    // the file is gone or malformed the browser simply skips it.
+    let path = PathBuf::from(&team_ctx.team_file_path);
+    let Ok(raw) = std::fs::read_to_string(&path) else {
+        return vec![];
+    };
+    let Ok(team_file) = serde_json::from_str::<crate::teams::types::TeamFile>(&raw) else {
+        return vec![];
+    };
+
+    team_file
+        .members
+        .iter()
+        .map(|m| AgentEntry {
+            name: m.name.clone(),
+            description: m
+                .prompt
+                .clone()
+                .unwrap_or_else(|| format!("Team member ({})", m.agent_id)),
+            source: AgentSource::Team,
+            path: Some(path.clone()),
+            active: m.is_active.unwrap_or(true),
+            execution: "team",
+        })
+        .collect()
+}
+
+/// Built-in subagent types the engine supports out of the box. Keep this
+/// list in sync with the docstrings in `src/tools/agent/mod.rs` and the
+/// system prompt copy.
+const BUILTIN_SUBAGENTS: &[(&str, &str)] = &[
+    (
+        "general-purpose",
+        "Default agent for multi-step research and coding tasks",
+    ),
+    (
+        "Explore",
+        "Fast codebase exploration — globbing, grepping, and file reads",
+    ),
+    (
+        "Plan",
+        "Software architect — produces an implementation plan without editing code",
+    ),
+    (
+        "code-reviewer",
+        "Reviews a completed change against the plan and coding standards",
+    ),
+];
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+fn render_agent_tree(agents: &[AgentEntry]) -> String {
+    // Count occurrences per name so we can tag later entries as "shadowed".
+    let mut name_counts: HashMap<String, usize> = HashMap::new();
+    for a in agents {
+        *name_counts.entry(a.name.clone()).or_default() += 1;
+    }
+
+    // Bucket by source group, preserving group precedence.
+    let mut buckets: Vec<(AgentSource, Vec<&AgentEntry>)> = Vec::new();
+    let mut seen: Vec<AgentSource> = Vec::new();
+    // A stable, predictable order — built-in first so new users see the
+    // defaults before their own overrides.
+    let mut sorted: Vec<&AgentEntry> = agents.iter().collect();
+    sorted.sort_by(|a, b| {
+        a.source
+            .group_order()
+            .cmp(&b.source.group_order())
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    for entry in &sorted {
+        if !seen.contains(&entry.source) {
+            seen.push(entry.source.clone());
+            buckets.push((entry.source.clone(), Vec::new()));
+        }
+        if let Some(b) = buckets.iter_mut().find(|(s, _)| s == &entry.source) {
+            b.1.push(entry);
+        }
+    }
+
+    // Track names that have already appeared in a higher-precedence bucket.
+    // First occurrence is "active", subsequent ones are "shadowed".
+    let mut winners: HashMap<String, &AgentSource> = HashMap::new();
+
+    let mut roots: Vec<TreeNode> = Vec::new();
+    for (source, entries) in &buckets {
+        let mut group = TreeNode::leaf(source.group_label().to_string());
+        for entry in entries {
+            let is_shadowed = winners
+                .get(&entry.name)
+                .map(|src| *src != source)
+                .unwrap_or(false);
+            if !is_shadowed {
+                winners.insert(entry.name.clone(), source);
+            }
+
+            let status = if !entry.active {
+                "disabled"
+            } else if is_shadowed {
+                "shadowed"
+            } else if name_counts.get(&entry.name).copied().unwrap_or(1) > 1 {
+                "overrides"
+            } else {
+                entry.execution
+            };
+
+            let detail = if entry.description.is_empty() {
+                format!("[{}]", status)
+            } else {
+                format!("[{}] {}", status, entry.description)
+            };
+
+            let label = if let Some(path) = entry.path.as_ref() {
+                format!("{}  ({})", entry.name, shorten_path(path))
+            } else {
+                entry.name.clone()
+            };
+
+            group.push_child(
+                TreeNode::leaf(label)
+                    .with_badge(source.tag())
+                    .with_detail(detail),
+            );
+        }
+        roots.push(group);
+    }
+
+    let footer = "\
+Active agents are the first occurrence in precedence order; later entries with \
+the same name are tagged `shadowed`. Use `/agents show <name>` for the full \
+description and path.";
+    render_with_footer("Agents", &roots, footer)
+}
+
+fn render_agent_detail(agents: &[AgentEntry], name: &str) -> String {
+    let matches: Vec<&AgentEntry> = agents.iter().filter(|a| a.name == name).collect();
+    if matches.is_empty() {
+        return format!(
+            "No agent named '{}'. Run `/agents` to see every registered agent.",
+            name
+        );
+    }
+
+    let mut out = String::new();
+    out.push_str(&format!("Agent: {}\n", name));
+    out.push_str(&"─".repeat(name.len() + 7));
+    out.push('\n');
+    for (i, entry) in matches.iter().enumerate() {
+        if i > 0 {
+            out.push('\n');
+            out.push_str(&format!("--- shadowed by above ({}) ---\n", i));
+        }
+        out.push_str(&format!("  Source:      {}\n", entry.source.tag()));
+        out.push_str(&format!("  Active:      {}\n", entry.active));
+        out.push_str(&format!("  Execution:   {}\n", entry.execution));
+        if let Some(path) = &entry.path {
+            out.push_str(&format!("  Location:    {}\n", shorten_path(path)));
+        }
+        out.push_str(&format!(
+            "  Description: {}\n",
+            if entry.description.is_empty() {
+                "(none)"
+            } else {
+                &entry.description
+            }
+        ));
+    }
+    out
+}
+
+fn render_sources(ctx: &CommandContext) -> String {
+    let mut out = String::new();
+    out.push_str("Agent discovery sources\n");
+    out.push_str("──────────────────────\n");
+    out.push_str("  [built-in]   Engine-provided subagent types (always available)\n");
+    out.push_str(
+        "  [bundled]    Skills compiled into cc-rust (`src/skills/bundled.rs`)\n",
+    );
+    out.push_str(&format!(
+        "  [user]       {}\n",
+        shorten_path(&crate::config::paths::skills_dir_global())
+    ));
+    let project_skills = ctx.cwd.join(".cc-rust").join("skills");
+    out.push_str(&format!(
+        "  [project]    {}\n",
+        shorten_path(&project_skills)
+    ));
+    out.push_str("  [plugin:*]   Plugin-contributed skills (see `/plugin list`)\n");
+    out.push_str("  [team]       Active team members (see `/team members`)\n");
+    out.push_str(
+        "\nOnly skills whose frontmatter opts into forked execution \
+         (`context: Fork`) are listed as agents.\n",
+    );
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bootstrap::SessionId;
+    use crate::types::app_state::AppState;
+
+    fn make_ctx() -> CommandContext {
+        CommandContext {
+            messages: vec![],
+            cwd: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+            app_state: AppState::default(),
+            session_id: SessionId::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn default_lists_builtins_at_minimum() {
+        let handler = AgentsHandler;
+        let mut ctx = make_ctx();
+        let result = handler.execute("", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(s) => {
+                assert!(s.contains("Agents"));
+                assert!(s.contains("general-purpose"));
+                assert!(s.contains("Explore"));
+                assert!(s.contains("Plan"));
+                // The built-in bucket should always be rendered.
+                assert!(s.contains("Built-in subagent types"));
+            }
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[tokio::test]
+    async fn show_requires_name() {
+        let handler = AgentsHandler;
+        let mut ctx = make_ctx();
+        let result = handler.execute("show", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(s) => assert!(s.contains("Usage")),
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[tokio::test]
+    async fn show_returns_details_for_builtin() {
+        let handler = AgentsHandler;
+        let mut ctx = make_ctx();
+        let result = handler
+            .execute("show general-purpose", &mut ctx)
+            .await
+            .unwrap();
+        match result {
+            CommandResult::Output(s) => {
+                assert!(s.contains("Agent: general-purpose"));
+                assert!(s.contains("Source:"));
+                assert!(s.contains("built-in"));
+            }
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[tokio::test]
+    async fn show_unknown_reports_missing() {
+        let handler = AgentsHandler;
+        let mut ctx = make_ctx();
+        let result = handler.execute("show nope-no-way", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(s) => assert!(s.contains("No agent named")),
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_subcommand_lists_usage() {
+        let handler = AgentsHandler;
+        let mut ctx = make_ctx();
+        let result = handler.execute("banana", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(s) => {
+                assert!(s.contains("Unknown /agents"));
+                assert!(s.contains("/agents show"));
+            }
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[test]
+    fn agent_source_group_order_is_stable() {
+        assert!(AgentSource::Builtin.group_order() < AgentSource::Team.group_order());
+        assert!(
+            AgentSource::Skill(SkillSource::Bundled).group_order()
+                < AgentSource::Skill(SkillSource::Project).group_order()
+        );
+    }
+
+    #[test]
+    fn tree_marks_shadowed_when_name_appears_twice() {
+        let agents = vec![
+            AgentEntry {
+                name: "dup".into(),
+                description: "builtin".into(),
+                source: AgentSource::Builtin,
+                path: None,
+                active: true,
+                execution: "built-in",
+            },
+            AgentEntry {
+                name: "dup".into(),
+                description: "user".into(),
+                source: AgentSource::Skill(SkillSource::User),
+                path: None,
+                active: true,
+                execution: "fork",
+            },
+        ];
+        let out = render_agent_tree(&agents);
+        assert!(out.contains("overrides"));
+        assert!(out.contains("shadowed"));
+    }
+}

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -1,0 +1,600 @@
+//! `/doctor` slash command — aggregated diagnostics.
+//!
+//! Rust issue #39. Walks the configuration, auth, MCP, keybindings, and
+//! terminal surfaces to produce a unified health report without a model
+//! round-trip. Every row carries a severity badge so the user can scan for
+//! red flags before reaching for `/terminal-setup`, `/config show`,
+//! `/keybindings`, or `/mcp` individually.
+//!
+//! The aggregator is pure data extraction — it does not mutate anything.
+//! Rendering lives in `render_report` and uses the shared tree-view helper
+//! so the layout stays consistent with `/hooks`, `/agents`, and `/tasks`.
+
+use std::path::Path;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use super::{CommandContext, CommandHandler, CommandResult};
+use crate::auth::{resolve_auth, AuthMethod};
+use crate::config::paths;
+use crate::config::settings::{load_effective, SettingsSource};
+use crate::config::validation::{validate_settings, WarningSeverity};
+use crate::ui::browser::{render_with_footer, shorten_path, TreeNode};
+
+use super::terminal_setup::TerminalLabel;
+
+pub struct DoctorHandler;
+
+#[async_trait]
+impl CommandHandler for DoctorHandler {
+    async fn execute(&self, args: &str, ctx: &mut CommandContext) -> Result<CommandResult> {
+        let args = args.trim().to_ascii_lowercase();
+        let report = DoctorReport::build(ctx);
+        let body = match args.as_str() {
+            "" | "all" | "full" => report.render_full(),
+            "summary" => report.render_summary(),
+            "raw" | "json" => serde_json::to_string_pretty(&report.to_json())
+                .unwrap_or_else(|e| format!("(serialisation error: {})", e)),
+            other => format!(
+                "Unknown /doctor subcommand '{}'.\n\n\
+                 Usage:\n  \
+                 /doctor           — full aggregated diagnostics\n  \
+                 /doctor summary   — just the status counts + headline issues\n  \
+                 /doctor raw       — machine-readable JSON payload\n",
+                other
+            ),
+        };
+        Ok(CommandResult::Output(body))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Severity + Rows
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Status {
+    Ok,
+    Warn,
+    Fail,
+    Info,
+}
+
+impl Status {
+    fn tag(self) -> &'static str {
+        match self {
+            Status::Ok => "ok",
+            Status::Warn => "warn",
+            Status::Fail => "fail",
+            Status::Info => "info",
+        }
+    }
+
+    fn rank(self) -> u8 {
+        match self {
+            Status::Ok => 0,
+            Status::Info => 1,
+            Status::Warn => 2,
+            Status::Fail => 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Row {
+    name: String,
+    status: Status,
+    detail: String,
+}
+
+impl Row {
+    fn new(name: &str, status: Status, detail: impl Into<String>) -> Self {
+        Self {
+            name: name.to_string(),
+            status,
+            detail: detail.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Section {
+    name: String,
+    rows: Vec<Row>,
+}
+
+impl Section {
+    fn worst(&self) -> Status {
+        self.rows
+            .iter()
+            .map(|r| r.status)
+            .max_by_key(|s| s.rank())
+            .unwrap_or(Status::Ok)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+struct DoctorReport {
+    sections: Vec<Section>,
+}
+
+impl DoctorReport {
+    fn build(ctx: &CommandContext) -> Self {
+        let mut sections = Vec::new();
+        sections.push(build_install_section());
+        sections.push(build_auth_section());
+        sections.push(build_settings_section(&ctx.cwd, ctx));
+        sections.push(build_mcp_section(&ctx.cwd));
+        sections.push(build_keybindings_section(ctx));
+        sections.push(build_sandbox_section(ctx));
+        sections.push(build_terminal_section());
+        Self { sections }
+    }
+
+    fn counts(&self) -> (usize, usize, usize, usize) {
+        let (mut ok, mut warn, mut fail, mut info) = (0, 0, 0, 0);
+        for s in &self.sections {
+            for r in &s.rows {
+                match r.status {
+                    Status::Ok => ok += 1,
+                    Status::Warn => warn += 1,
+                    Status::Fail => fail += 1,
+                    Status::Info => info += 1,
+                }
+            }
+        }
+        (ok, warn, fail, info)
+    }
+
+    fn render_summary(&self) -> String {
+        let (ok, warn, fail, info) = self.counts();
+        let mut out = String::new();
+        out.push_str("Doctor summary\n");
+        out.push_str("──────────────\n");
+        out.push_str(&format!(
+            "  ok: {}   warn: {}   fail: {}   info: {}\n",
+            ok, warn, fail, info
+        ));
+        if fail == 0 && warn == 0 {
+            out.push_str("  All checks passed.\n");
+            return out;
+        }
+        out.push_str("\nHeadline issues:\n");
+        for section in &self.sections {
+            for row in &section.rows {
+                if matches!(row.status, Status::Fail | Status::Warn) {
+                    out.push_str(&format!(
+                        "  [{}] {} / {}: {}\n",
+                        row.status.tag(),
+                        section.name,
+                        row.name,
+                        row.detail
+                    ));
+                }
+            }
+        }
+        out
+    }
+
+    fn render_full(&self) -> String {
+        let mut roots = Vec::new();
+        for section in &self.sections {
+            let mut section_node = TreeNode::leaf(section.name.clone())
+                .with_badge(section.worst().tag().to_string());
+            for row in &section.rows {
+                section_node.push_child(
+                    TreeNode::leaf(row.name.clone())
+                        .with_badge(row.status.tag().to_string())
+                        .with_detail(row.detail.clone()),
+                );
+            }
+            roots.push(section_node);
+        }
+
+        let (ok, warn, fail, _info) = self.counts();
+        let footer = format!(
+            "Counts: {} ok, {} warn, {} fail.\n\
+             Use `/doctor summary` for just the red flags, \
+             or `/doctor raw` for JSON.",
+            ok, warn, fail
+        );
+        render_with_footer("Doctor", &roots, &footer)
+    }
+
+    fn to_json(&self) -> serde_json::Value {
+        let sections: Vec<_> = self
+            .sections
+            .iter()
+            .map(|s| {
+                serde_json::json!({
+                    "name": s.name,
+                    "status": s.worst().tag(),
+                    "rows": s.rows.iter().map(|r| serde_json::json!({
+                        "name": r.name,
+                        "status": r.status.tag(),
+                        "detail": r.detail,
+                    })).collect::<Vec<_>>()
+                })
+            })
+            .collect();
+        let (ok, warn, fail, info) = self.counts();
+        serde_json::json!({
+            "counts": { "ok": ok, "warn": warn, "fail": fail, "info": info },
+            "sections": sections,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Section builders
+// ---------------------------------------------------------------------------
+
+fn build_install_section() -> Section {
+    let mut rows = Vec::new();
+    let root = paths::data_root();
+    let exists = root.is_dir();
+    rows.push(Row::new(
+        "data root",
+        if exists { Status::Ok } else { Status::Warn },
+        if exists {
+            format!("{}", shorten_path(&root))
+        } else {
+            format!("not created yet ({})", shorten_path(&root))
+        },
+    ));
+
+    if let Ok(override_dir) = std::env::var("CC_RUST_HOME") {
+        let trimmed = override_dir.trim();
+        if !trimmed.is_empty() {
+            rows.push(Row::new(
+                "CC_RUST_HOME",
+                Status::Info,
+                format!("override active: {}", trimmed),
+            ));
+        }
+    }
+
+    rows.push(Row::new(
+        "cc-rust version",
+        Status::Info,
+        env!("CARGO_PKG_VERSION").to_string(),
+    ));
+
+    Section {
+        name: "Install".to_string(),
+        rows,
+    }
+}
+
+fn build_auth_section() -> Section {
+    let mut rows = Vec::new();
+    let method = resolve_auth();
+    let (status, detail) = match &method {
+        AuthMethod::ApiKey(_) => (Status::Ok, "ANTHROPIC_API_KEY / keychain".to_string()),
+        AuthMethod::ExternalToken(_) => (Status::Ok, "ANTHROPIC_AUTH_TOKEN".to_string()),
+        AuthMethod::OAuthToken { method, .. } => (Status::Ok, format!("OAuth ({})", method)),
+        AuthMethod::None => (
+            Status::Fail,
+            "no credential found — run `/login` to authenticate".to_string(),
+        ),
+    };
+    rows.push(Row::new("credential", status, detail));
+
+    let cred_path = paths::credentials_path();
+    if cred_path.exists() {
+        rows.push(Row::new(
+            "credentials.json",
+            Status::Info,
+            shorten_path(&cred_path),
+        ));
+    }
+    Section {
+        name: "Auth".to_string(),
+        rows,
+    }
+}
+
+fn build_settings_section(cwd: &Path, ctx: &CommandContext) -> Section {
+    let mut rows = Vec::new();
+    match load_effective(cwd) {
+        Ok(loaded) => {
+            for (source, path) in &loaded.loaded_paths {
+                let label = match source {
+                    SettingsSource::Managed => "managed",
+                    SettingsSource::User => "user",
+                    SettingsSource::Project => "project",
+                    SettingsSource::Local => "local",
+                    other => other.as_str(),
+                };
+                rows.push(Row::new(label, Status::Ok, shorten_path(path)));
+            }
+            if loaded.loaded_paths.is_empty() {
+                rows.push(Row::new(
+                    "layers loaded",
+                    Status::Info,
+                    "none found — running on defaults".to_string(),
+                ));
+            }
+        }
+        Err(e) => {
+            rows.push(Row::new("load", Status::Fail, e.to_string()));
+        }
+    }
+
+    for w in validate_settings(&ctx.app_state.settings) {
+        let status = match w.severity {
+            WarningSeverity::Info => Status::Info,
+            WarningSeverity::Warning => Status::Warn,
+            WarningSeverity::Error => Status::Fail,
+        };
+        rows.push(Row::new(&w.field, status, w.message));
+    }
+
+    if rows.iter().all(|r| r.status == Status::Ok || r.status == Status::Info) {
+        rows.push(Row::new(
+            "validation",
+            Status::Ok,
+            "no validation warnings".to_string(),
+        ));
+    }
+
+    Section {
+        name: "Settings".to_string(),
+        rows,
+    }
+}
+
+fn build_mcp_section(cwd: &Path) -> Section {
+    let mut rows = Vec::new();
+    match crate::mcp::discovery::discover_mcp_servers(cwd) {
+        Ok(servers) => {
+            if servers.is_empty() {
+                rows.push(Row::new(
+                    "discovered",
+                    Status::Info,
+                    "no MCP servers configured".to_string(),
+                ));
+            } else {
+                for server in &servers {
+                    let cmd = server
+                        .command
+                        .as_deref()
+                        .unwrap_or("(no command — URL-based transport)");
+                    rows.push(Row::new(
+                        &server.name,
+                        Status::Ok,
+                        format!("command: {}", cmd),
+                    ));
+                }
+            }
+        }
+        Err(e) => {
+            rows.push(Row::new(
+                "discovery",
+                Status::Warn,
+                format!("could not enumerate MCP servers: {}", e),
+            ));
+        }
+    }
+    Section {
+        name: "MCP".to_string(),
+        rows,
+    }
+}
+
+fn build_keybindings_section(ctx: &CommandContext) -> Section {
+    let mut rows = Vec::new();
+    let reg = ctx.app_state.keybindings.clone();
+    reg.refresh_if_changed();
+    let path = reg.user_path().unwrap_or_else(paths::keybindings_path);
+    let exists = path.exists();
+    rows.push(Row::new(
+        "config",
+        if exists { Status::Ok } else { Status::Info },
+        if exists {
+            shorten_path(&path)
+        } else {
+            format!("not created ({})", shorten_path(&path))
+        },
+    ));
+    rows.push(Row::new(
+        "effective bindings",
+        Status::Ok,
+        reg.all_bindings().len().to_string(),
+    ));
+    for issue in reg.last_issues() {
+        rows.push(Row::new("issue", Status::Warn, issue));
+    }
+    Section {
+        name: "Keybindings".to_string(),
+        rows,
+    }
+}
+
+fn build_sandbox_section(ctx: &CommandContext) -> Section {
+    let mut rows = Vec::new();
+    let sandbox = &ctx.app_state.settings.sandbox;
+    let enabled = sandbox.enabled.unwrap_or(false);
+    rows.push(Row::new(
+        "enabled",
+        if enabled { Status::Ok } else { Status::Info },
+        enabled.to_string(),
+    ));
+    if let Some(mode) = sandbox.mode.as_ref() {
+        rows.push(Row::new("mode", Status::Info, mode.clone()));
+    }
+    if let Some(fail) = sandbox.fail_if_unavailable {
+        rows.push(Row::new(
+            "failIfUnavailable",
+            Status::Info,
+            fail.to_string(),
+        ));
+    }
+    if !sandbox.network.allowed_domains.is_empty() {
+        rows.push(Row::new(
+            "allowedDomains",
+            Status::Info,
+            format!("{} entries", sandbox.network.allowed_domains.len()),
+        ));
+    }
+    Section {
+        name: "Sandbox".to_string(),
+        rows,
+    }
+}
+
+fn build_terminal_section() -> Section {
+    let mut rows = Vec::new();
+    let probe = super::terminal_setup::EnvProbe::from_env();
+    let label = probe.terminal_label();
+    rows.push(Row::new(
+        "terminal",
+        if matches!(label, TerminalLabel::Unknown) {
+            Status::Info
+        } else {
+            Status::Ok
+        },
+        label.as_str().to_string(),
+    ));
+    if let Some(shell) = probe.shell.as_deref() {
+        rows.push(Row::new("shell", Status::Info, shell.to_string()));
+    }
+    if probe.tmux.is_some() {
+        rows.push(Row::new("tmux", Status::Info, "active".to_string()));
+    }
+    if let (None, None) = (&probe.visual, &probe.editor) {
+        rows.push(Row::new(
+            "editor",
+            Status::Warn,
+            "$VISUAL / $EDITOR unset — commands that shell out to an editor will fall back to printing the path".to_string(),
+        ));
+    } else {
+        rows.push(Row::new(
+            "editor",
+            Status::Ok,
+            probe
+                .visual
+                .as_deref()
+                .or(probe.editor.as_deref())
+                .unwrap_or("")
+                .to_string(),
+        ));
+    }
+    Section {
+        name: "Terminal".to_string(),
+        rows,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bootstrap::SessionId;
+    use crate::types::app_state::AppState;
+    use std::path::PathBuf;
+
+    fn make_ctx() -> CommandContext {
+        CommandContext {
+            messages: vec![],
+            cwd: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+            app_state: AppState::default(),
+            session_id: SessionId::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn full_report_contains_every_section() {
+        let handler = DoctorHandler;
+        let mut ctx = make_ctx();
+        let result = handler.execute("", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(s) => {
+                for section in [
+                    "Install",
+                    "Auth",
+                    "Settings",
+                    "MCP",
+                    "Keybindings",
+                    "Sandbox",
+                    "Terminal",
+                ] {
+                    assert!(s.contains(section), "missing section `{}`: {}", section, s);
+                }
+                assert!(s.contains("Counts:"));
+            }
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[tokio::test]
+    async fn summary_includes_counts() {
+        let handler = DoctorHandler;
+        let mut ctx = make_ctx();
+        let result = handler.execute("summary", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(s) => {
+                assert!(s.contains("Doctor summary"));
+                assert!(s.contains("ok:"));
+            }
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[tokio::test]
+    async fn raw_emits_valid_json() {
+        let handler = DoctorHandler;
+        let mut ctx = make_ctx();
+        let result = handler.execute("raw", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(s) => {
+                let parsed: serde_json::Value = serde_json::from_str(&s)
+                    .expect("raw should be valid JSON");
+                assert!(parsed.get("sections").is_some());
+                assert!(parsed.get("counts").is_some());
+            }
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_subcommand_returns_usage() {
+        let handler = DoctorHandler;
+        let mut ctx = make_ctx();
+        let result = handler.execute("zzz", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(s) => {
+                assert!(s.contains("Unknown /doctor"));
+                assert!(s.contains("Usage"));
+            }
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[test]
+    fn status_rank_orders_correctly() {
+        assert!(Status::Ok.rank() < Status::Info.rank());
+        assert!(Status::Info.rank() < Status::Warn.rank());
+        assert!(Status::Warn.rank() < Status::Fail.rank());
+    }
+
+    #[test]
+    fn section_worst_picks_highest_rank() {
+        let section = Section {
+            name: "x".into(),
+            rows: vec![
+                Row::new("a", Status::Ok, ""),
+                Row::new("b", Status::Warn, ""),
+                Row::new("c", Status::Info, ""),
+            ],
+        };
+        assert_eq!(section.worst(), Status::Warn);
+    }
+}

--- a/src/commands/hooks_cmd.rs
+++ b/src/commands/hooks_cmd.rs
@@ -1,0 +1,438 @@
+//! `/hooks` slash command — read-only browser for the merged hook tree.
+//!
+//! Rust issue #40. The command aggregates hooks declared across every
+//! settings layer (managed / user / project / local) plus the subagent
+//! hooks that the engine fires internally, then renders the result as an
+//! indented tree grouped by event → matcher → hook command.
+//!
+//! This is intentionally read-only: in-TUI editing is cheap for keybindings
+//! (one flat file) but error-prone for hooks, where the same event key is
+//! spread across multiple files. The browser instead surfaces every source
+//! with a badge and offers an editor-jump subcommand that opens the
+//! settings file that owns each layer.
+//!
+//! ## Subcommands
+//!
+//! | Command                         | Behavior                              |
+//! |---------------------------------|---------------------------------------|
+//! | `/hooks`                        | full merged tree (all layers)         |
+//! | `/hooks list [event]`           | tree filtered to a single event       |
+//! | `/hooks path <managed|user|project|local>` | print settings file path     |
+//! | `/hooks open <managed|user|project|local>` | open the settings file in `$EDITOR` |
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::Value;
+
+use super::{CommandContext, CommandHandler, CommandResult};
+use crate::config::settings::{
+    load_effective, local_settings_path, managed_settings_path, project_settings_path,
+    user_settings_path, SettingsSource,
+};
+use crate::ui::browser::{ensure_and_open, format_open_outcome, render_with_footer, TreeNode};
+
+/// Recognised hook event names the tree groups on. Unknown events are still
+/// rendered — this list only controls the display order and helps us render
+/// empty sections when the user is scanning for "does event X fire at all?".
+const KNOWN_EVENTS: &[&str] = &[
+    "PreToolUse",
+    "PostToolUse",
+    "PostToolUseFailure",
+    "Stop",
+    "SubagentStart",
+    "SubagentStop",
+    "Notification",
+];
+
+pub struct HooksHandler;
+
+#[async_trait]
+impl CommandHandler for HooksHandler {
+    async fn execute(&self, args: &str, ctx: &mut CommandContext) -> Result<CommandResult> {
+        let args = args.trim();
+        let mut parts = args.split_whitespace();
+        let sub = parts.next().unwrap_or("").to_ascii_lowercase();
+
+        match sub.as_str() {
+            "" | "list" | "show" => {
+                let event_filter = parts.next();
+                Ok(CommandResult::Output(render_tree(&ctx.cwd, event_filter)))
+            }
+            "path" => {
+                let layer = parts.next().unwrap_or("");
+                Ok(CommandResult::Output(render_path(&ctx.cwd, layer)))
+            }
+            "open" | "edit" => {
+                let layer = parts.next().unwrap_or("");
+                Ok(CommandResult::Output(open_layer(&ctx.cwd, layer)))
+            }
+            other => Ok(CommandResult::Output(format!(
+                "Unknown /hooks subcommand '{}'.\n\n\
+                 Usage:\n  \
+                 /hooks                       — merged hook tree (event → matcher → hook)\n  \
+                 /hooks list [event]          — filter to a single event (e.g. PreToolUse)\n  \
+                 /hooks path <layer>          — print settings file path\n  \
+                 /hooks open <layer>          — create (if missing) and open in $EDITOR\n\n\
+                 Layers: managed, user, project, local",
+                other
+            ))),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation
+// ---------------------------------------------------------------------------
+
+/// One hook entry flattened out of the settings tree, tagged with which
+/// layer contributed it. The browser walks every layer and produces one of
+/// these per hook entry — later grouped by event and matcher.
+#[derive(Debug, Clone)]
+struct FlatHook {
+    event: String,
+    matcher: String,
+    hook_type: String,
+    command: String,
+    timeout: Option<u64>,
+    source: SettingsSource,
+}
+
+fn collect_hooks(cwd: &Path) -> (Vec<FlatHook>, Vec<String>) {
+    let mut out = Vec::new();
+    let mut issues = Vec::new();
+    let loaded = match load_effective(cwd) {
+        Ok(l) => l,
+        Err(e) => {
+            issues.push(format!("failed to load settings: {}", e));
+            return (out, issues);
+        }
+    };
+
+    for (source, raw) in [
+        (SettingsSource::Managed, loaded.managed.as_ref()),
+        (SettingsSource::User, loaded.user.as_ref()),
+        (SettingsSource::Project, loaded.project.as_ref()),
+        (SettingsSource::Local, loaded.local.as_ref()),
+    ] {
+        let Some(raw) = raw else { continue };
+        let Some(hooks) = raw.hooks.as_ref() else {
+            continue;
+        };
+        for (event, value) in hooks {
+            flatten_event(event, value, source, &mut out, &mut issues);
+        }
+    }
+
+    (out, issues)
+}
+
+fn flatten_event(
+    event: &str,
+    value: &Value,
+    source: SettingsSource,
+    out: &mut Vec<FlatHook>,
+    issues: &mut Vec<String>,
+) {
+    let Some(arr) = value.as_array() else {
+        issues.push(format!(
+            "{}: event '{}' is not an array",
+            source.as_str(),
+            event
+        ));
+        return;
+    };
+
+    for config in arr {
+        let matcher = config
+            .get("matcher")
+            .and_then(|v| v.as_str())
+            .unwrap_or("*")
+            .to_string();
+        let hooks = config.get("hooks").and_then(|v| v.as_array());
+        let Some(hooks) = hooks else {
+            issues.push(format!(
+                "{}: '{}' config missing 'hooks' array",
+                source.as_str(),
+                event
+            ));
+            continue;
+        };
+        for entry in hooks {
+            let hook_type = entry
+                .get("type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("command")
+                .to_string();
+            let command = entry
+                .get("command")
+                .and_then(|v| v.as_str())
+                .unwrap_or("(missing)")
+                .to_string();
+            let timeout = entry.get("timeout").and_then(|v| v.as_u64());
+            out.push(FlatHook {
+                event: event.to_string(),
+                matcher: matcher.clone(),
+                hook_type,
+                command,
+                timeout,
+                source,
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+fn render_tree(cwd: &Path, event_filter: Option<&str>) -> String {
+    let (flat, issues) = collect_hooks(cwd);
+    let filtered: Vec<&FlatHook> = match event_filter {
+        Some(ev) => flat
+            .iter()
+            .filter(|h| h.event.eq_ignore_ascii_case(ev))
+            .collect(),
+        None => flat.iter().collect(),
+    };
+
+    // Group by event, then by matcher, preserving original source order.
+    // BTreeMap ensures stable, deterministic rendering.
+    let mut by_event: BTreeMap<String, BTreeMap<String, Vec<&FlatHook>>> = BTreeMap::new();
+    for h in &filtered {
+        by_event
+            .entry(h.event.clone())
+            .or_default()
+            .entry(h.matcher.clone())
+            .or_default()
+            .push(h);
+    }
+
+    // Preserve "known event" ordering, then append unknown events.
+    let mut event_order: Vec<String> = KNOWN_EVENTS
+        .iter()
+        .filter(|ev| by_event.contains_key(**ev))
+        .map(|ev| ev.to_string())
+        .collect();
+    for ev in by_event.keys() {
+        if !event_order.contains(ev) {
+            event_order.push(ev.clone());
+        }
+    }
+
+    let mut roots: Vec<TreeNode> = Vec::new();
+    for event in &event_order {
+        let Some(matchers) = by_event.get(event) else {
+            continue;
+        };
+        let mut event_node = TreeNode::leaf(event.clone());
+        for (matcher, entries) in matchers {
+            let mut matcher_node = TreeNode::leaf(format!("matcher: {}", matcher));
+            for entry in entries {
+                let mut label = format!("{}: {}", entry.hook_type, short_command(&entry.command));
+                if let Some(t) = entry.timeout {
+                    label.push_str(&format!(" (timeout {}s)", t));
+                }
+                matcher_node.push_child(
+                    TreeNode::leaf(label).with_badge(entry.source.as_str().to_string()),
+                );
+            }
+            event_node.push_child(matcher_node);
+        }
+        roots.push(event_node);
+    }
+
+    let title = match event_filter {
+        Some(ev) => format!("Hooks — {}", ev),
+        None => "Hooks".to_string(),
+    };
+    let mut footer = String::new();
+    if !issues.is_empty() {
+        footer.push_str("Issues:\n");
+        for issue in &issues {
+            footer.push_str(&format!("  - {}\n", issue));
+        }
+        footer.push('\n');
+    }
+    footer.push_str(
+        "Source precedence (low→high): managed → user → project → local.\n\
+         Use `/hooks open <layer>` to edit a specific settings file.\n",
+    );
+
+    render_with_footer(&title, &roots, &footer)
+}
+
+fn short_command(cmd: &str) -> String {
+    // Hook commands can be arbitrarily long shell pipelines; keep the tree
+    // readable by truncating while leaving enough context to recognise.
+    const MAX: usize = 80;
+    let first_line = cmd.lines().next().unwrap_or(cmd);
+    if first_line.chars().count() <= MAX {
+        return first_line.to_string();
+    }
+    let truncated: String = first_line.chars().take(MAX).collect();
+    format!("{}…", truncated)
+}
+
+fn render_path(cwd: &Path, layer: &str) -> String {
+    match resolve_layer_path(cwd, layer) {
+        Some(path) => path.display().to_string(),
+        None => usage_layers(),
+    }
+}
+
+fn open_layer(cwd: &Path, layer: &str) -> String {
+    let Some(path) = resolve_layer_path(cwd, layer) else {
+        return usage_layers();
+    };
+    // Minimal JSON skeleton — we only write if the file is absent and the
+    // user asked to open it. Matches the settings schema so downstream
+    // loaders do not trip on an empty file.
+    let template = "{\n  \"hooks\": {}\n}\n";
+    let outcome = ensure_and_open(&path, template);
+    format_open_outcome(&outcome, &path)
+}
+
+fn resolve_layer_path(cwd: &Path, layer: &str) -> Option<PathBuf> {
+    match layer.to_ascii_lowercase().as_str() {
+        "managed" | "policy" => Some(managed_settings_path()),
+        "user" | "global" => Some(user_settings_path()),
+        "project" => Some(project_settings_path(cwd)),
+        "local" | "override" => Some(local_settings_path(cwd)),
+        _ => None,
+    }
+}
+
+fn usage_layers() -> String {
+    "Usage: /hooks path|open <layer> where layer is one of: managed, user, project, local."
+        .to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bootstrap::SessionId;
+    use crate::types::app_state::AppState;
+    use serde_json::json;
+    use std::path::PathBuf;
+
+    fn make_ctx() -> CommandContext {
+        CommandContext {
+            messages: vec![],
+            cwd: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+            app_state: AppState::default(),
+            session_id: SessionId::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_subcommand_returns_usage() {
+        let handler = HooksHandler;
+        let mut ctx = make_ctx();
+        let result = handler.execute("xyzzy", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(s) => {
+                assert!(s.contains("Unknown /hooks"));
+                assert!(s.contains("Layers"));
+            }
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[tokio::test]
+    async fn default_emits_hooks_title() {
+        let handler = HooksHandler;
+        let mut ctx = make_ctx();
+        let result = handler.execute("", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(s) => assert!(s.contains("Hooks")),
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[tokio::test]
+    async fn path_requires_known_layer() {
+        let handler = HooksHandler;
+        let mut ctx = make_ctx();
+        let bogus = handler.execute("path banana", &mut ctx).await.unwrap();
+        match bogus {
+            CommandResult::Output(s) => assert!(s.contains("Usage")),
+            _ => panic!("expected Output"),
+        }
+        let good = handler.execute("path user", &mut ctx).await.unwrap();
+        match good {
+            CommandResult::Output(s) => assert!(s.contains("settings.json")),
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[test]
+    fn flatten_event_extracts_hooks() {
+        let value = json!([
+            {
+                "matcher": "Bash",
+                "hooks": [
+                    { "type": "command", "command": "echo pre", "timeout": 15 },
+                    { "type": "command", "command": "echo also-pre" }
+                ]
+            }
+        ]);
+        let mut flat = Vec::new();
+        let mut issues = Vec::new();
+        flatten_event(
+            "PreToolUse",
+            &value,
+            SettingsSource::User,
+            &mut flat,
+            &mut issues,
+        );
+        assert_eq!(flat.len(), 2);
+        assert_eq!(flat[0].event, "PreToolUse");
+        assert_eq!(flat[0].matcher, "Bash");
+        assert_eq!(flat[0].command, "echo pre");
+        assert_eq!(flat[0].timeout, Some(15));
+        assert_eq!(flat[1].timeout, None);
+        assert!(issues.is_empty());
+    }
+
+    #[test]
+    fn flatten_event_reports_bad_shape() {
+        let value = json!("not-an-array");
+        let mut flat = Vec::new();
+        let mut issues = Vec::new();
+        flatten_event(
+            "PreToolUse",
+            &value,
+            SettingsSource::Managed,
+            &mut flat,
+            &mut issues,
+        );
+        assert!(flat.is_empty());
+        assert_eq!(issues.len(), 1);
+        assert!(issues[0].contains("PreToolUse"));
+    }
+
+    #[test]
+    fn short_command_truncates_long_values() {
+        let long: String = "x".repeat(120);
+        let short = short_command(&long);
+        assert!(short.ends_with("…"));
+        assert!(short.chars().count() < long.chars().count());
+    }
+
+    #[test]
+    fn resolve_layer_path_maps_known_layers() {
+        let cwd = PathBuf::from("/tmp/nowhere");
+        assert!(resolve_layer_path(&cwd, "managed").is_some());
+        assert!(resolve_layer_path(&cwd, "user").is_some());
+        assert!(resolve_layer_path(&cwd, "project").is_some());
+        assert!(resolve_layer_path(&cwd, "local").is_some());
+        assert!(resolve_layer_path(&cwd, "banana").is_none());
+    }
+}

--- a/src/commands/keybindings_cmd.rs
+++ b/src/commands/keybindings_cmd.rs
@@ -1,18 +1,22 @@
-//! `/keybindings` slash command — open, create, list, or reload the user
+//! `/keybindings` slash command — create, open, list, or reload the user
 //! keybindings file.
 //!
+//! The default action mirrors the Bun reference: ensure the file exists
+//! (creating it from an empty template if missing) and open it in the user's
+//! `$VISUAL`/`$EDITOR`. Everything else is a named subcommand so callers who
+//! want the old status readout keep their flow.
+//!
 //! Usage:
-//!   /keybindings                 show status + file path
-//!   /keybindings open            ensure file exists and open in `$EDITOR`
+//!   /keybindings                 ensure file exists and open in editor
+//!   /keybindings status          show file path + effective binding count
+//!   /keybindings open            alias for the default action
 //!   /keybindings list [ctx]      list effective bindings (optionally for a
 //!                                context)
 //!   /keybindings reload          force a reload now
 //!   /keybindings path            print the config file path
 //!
-//! `~/.cc-rust/keybindings.json` is created from an empty template when
-//! missing.
-
-use std::io::Write;
+//! `~/.cc-rust/keybindings.json` is created from [`EMPTY_TEMPLATE`] when
+//! missing. The existing file is never overwritten.
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -22,6 +26,7 @@ use crate::config::paths;
 use crate::keybindings::config::EMPTY_TEMPLATE;
 use crate::keybindings::context::Context as KbContext;
 use crate::keybindings::registry::KeybindingRegistry;
+use crate::ui::browser::{ensure_and_open, format_open_outcome};
 
 pub struct KeybindingsHandler;
 
@@ -37,12 +42,15 @@ impl CommandHandler for KeybindingsHandler {
         let reg = ctx.app_state.keybindings.clone();
 
         match sub.as_str() {
-            "" | "status" | "show" => Ok(CommandResult::Output(render_status(&reg))),
+            // Default: editor-first flow. Matches the Bun reference where
+            // `/keybindings` creates the template (if missing) and hands the
+            // user straight to their editor rather than a status readout.
+            "" | "open" | "edit" => Ok(CommandResult::Output(open_for_edit(&reg))),
+            "status" | "show" => Ok(CommandResult::Output(render_status(&reg))),
             "path" => Ok(CommandResult::Output(format!(
                 "{}",
                 paths::keybindings_path().display()
             ))),
-            "open" | "edit" => Ok(CommandResult::Output(open_for_edit(&reg))),
             "reload" | "refresh" => Ok(CommandResult::Output(reload_now(&reg))),
             "list" => {
                 let filter_ctx = parts.next().and_then(|s| s.parse::<KbContext>().ok());
@@ -50,8 +58,8 @@ impl CommandHandler for KeybindingsHandler {
             }
             other => Ok(CommandResult::Output(format!(
                 "Unknown /keybindings subcommand '{}'.\n\nUsage:\n  \
-                 /keybindings                 — show status\n  \
-                 /keybindings open            — create (if missing) and open in $EDITOR\n  \
+                 /keybindings                 — create (if missing) and open in $EDITOR\n  \
+                 /keybindings status          — show status and effective binding count\n  \
                  /keybindings list [context]  — list effective bindings\n  \
                  /keybindings reload          — force a reload\n  \
                  /keybindings path            — print config file path",
@@ -84,7 +92,7 @@ fn render_status(reg: &KeybindingRegistry) -> String {
         }
     }
     out.push_str(
-        "\nTip: run `/keybindings open` to create and edit the file, or \
+        "\nTip: run `/keybindings` to create and edit the file, or \
          `/keybindings list` to see every effective binding.\n",
     );
     out
@@ -92,68 +100,8 @@ fn render_status(reg: &KeybindingRegistry) -> String {
 
 fn open_for_edit(reg: &KeybindingRegistry) -> String {
     let path = reg.user_path().unwrap_or_else(paths::keybindings_path);
-    if let Some(parent) = path.parent() {
-        if let Err(e) = std::fs::create_dir_all(parent) {
-            return format!(
-                "Error: could not create parent directory {}: {}",
-                parent.display(),
-                e
-            );
-        }
-    }
-    let mut created = false;
-    if !path.exists() {
-        match std::fs::File::create(&path) {
-            Ok(mut f) => {
-                if let Err(e) = f.write_all(EMPTY_TEMPLATE.as_bytes()) {
-                    return format!("Error: could not write template: {}", e);
-                }
-                created = true;
-            }
-            Err(e) => return format!("Error: could not create {}: {}", path.display(), e),
-        }
-    }
-
-    let editor = std::env::var("VISUAL")
-        .or_else(|_| std::env::var("EDITOR"))
-        .ok();
-
-    match editor {
-        Some(ed) if !ed.trim().is_empty() => {
-            // Fire-and-forget — we don't block the REPL.
-            let status = std::process::Command::new(&ed).arg(&path).status();
-            match status {
-                Ok(s) if s.success() => format!(
-                    "{}Opened {} in {}.",
-                    if created { "Created and " } else { "" },
-                    path.display(),
-                    ed
-                ),
-                Ok(s) => format!(
-                    "{} exited with status {}. File: {}",
-                    ed,
-                    s.code().unwrap_or(-1),
-                    path.display()
-                ),
-                Err(e) => format!(
-                    "Error: could not launch '{}' — {}. File: {}",
-                    ed,
-                    e,
-                    path.display()
-                ),
-            }
-        }
-        _ => format!(
-            "{}File: {}\n\
-             (Set $VISUAL or $EDITOR to auto-open in an editor.)",
-            if created {
-                "Created keybindings template.\n"
-            } else {
-                ""
-            },
-            path.display()
-        ),
-    }
+    let outcome = ensure_and_open(&path, EMPTY_TEMPLATE);
+    format_open_outcome(&outcome, &path)
 }
 
 fn reload_now(reg: &KeybindingRegistry) -> String {
@@ -223,14 +171,44 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn status_renders_path_line() {
+    async fn status_subcommand_renders_path_line() {
+        let handler = KeybindingsHandler;
+        let mut ctx = make_ctx();
+        let result = handler.execute("status", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(s) => {
+                assert!(s.contains("Config path:"));
+                assert!(s.contains("Effective bindings:"));
+            }
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[tokio::test]
+    async fn default_action_is_open_for_edit() {
+        // Default `/keybindings` should either open the file in an editor or,
+        // when no editor is set, return a path-pointing message — never the
+        // old status readout.
         let handler = KeybindingsHandler;
         let mut ctx = make_ctx();
         let result = handler.execute("", &mut ctx).await.unwrap();
         match result {
             CommandResult::Output(s) => {
-                assert!(s.contains("Config path:"));
-                assert!(s.contains("Effective bindings:"));
+                // `render_status` output contains the literal string
+                // "Effective bindings:" which the editor-first flow never
+                // emits. This is the discriminator we care about.
+                assert!(
+                    !s.contains("Effective bindings:"),
+                    "default should not show status readout, got: {}",
+                    s
+                );
+                assert!(
+                    s.contains("keybindings.json")
+                        || s.contains("Opened")
+                        || s.contains("Created"),
+                    "expected editor-first output, got: {}",
+                    s
+                );
             }
             _ => panic!("expected Output"),
         }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -51,6 +51,12 @@ pub mod sandbox_cmd;
 // Keybindings
 pub mod keybindings_cmd;
 
+// Read-only browsers (issues #34, #39, #40, #54)
+pub mod agents_cmd;
+pub mod doctor;
+pub mod hooks_cmd;
+pub mod tasks_cmd;
+
 // Scriptable status line (issue #11)
 pub mod statusline_cmd;
 
@@ -451,6 +457,30 @@ pub fn get_all_commands() -> Vec<Command> {
                 .into(),
             handler: Box::new(team_cmd::TeamHandler),
         },
+        Command {
+            name: "hooks".into(),
+            aliases: vec![],
+            description: "Read-only merged hook tree (managed + user + project + local)".into(),
+            handler: Box::new(hooks_cmd::HooksHandler),
+        },
+        Command {
+            name: "agents".into(),
+            aliases: vec![],
+            description: "Browse agent definitions with source + override visibility".into(),
+            handler: Box::new(agents_cmd::AgentsHandler),
+        },
+        Command {
+            name: "doctor".into(),
+            aliases: vec!["diagnostics".into()],
+            description: "Aggregated diagnostics (install, auth, settings, MCP, terminal)".into(),
+            handler: Box::new(doctor::DoctorHandler),
+        },
+        Command {
+            name: "tasks".into(),
+            aliases: vec![],
+            description: "List and drill into background tasks (tool + team)".into(),
+            handler: Box::new(tasks_cmd::TasksHandler),
+        },
     ]
 }
 
@@ -502,6 +532,11 @@ mod tests {
         assert!(names.contains(&"skills"));
         assert!(names.contains(&"mcp"));
         assert!(names.contains(&"plugin"));
+        // Read-only browser family (issues #34, #39, #40, #54).
+        assert!(names.contains(&"hooks"));
+        assert!(names.contains(&"agents"));
+        assert!(names.contains(&"doctor"));
+        assert!(names.contains(&"tasks"));
     }
 
     #[test]

--- a/src/commands/tasks_cmd.rs
+++ b/src/commands/tasks_cmd.rs
@@ -1,0 +1,386 @@
+//! `/tasks` slash command — background task list + detail controls.
+//!
+//! Rust issue #54. Aggregates every task surface cc-rust already tracks
+//! today (tool-driven tasks in `tools::tasks::GLOBAL_STORE`, teammate
+//! runners in `teams::in_process::TASK_REGISTRY`) and renders them as a
+//! drill-down tree.
+//!
+//! Core acceptance criteria:
+//! * `list` shows every current task, grouped by kind;
+//! * `show <id>` drills in on one task, printing full prompt / error /
+//!   subject;
+//! * `stop <id>` asks the tool-side store to mark the task stopped.
+//!
+//! Remote-agent tasks are out of scope for the rust-lite branch (the
+//! `remote` module was removed); the framing here leaves room for that
+//! bucket without pulling it in.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use chrono::{DateTime, Local, TimeZone};
+
+use super::{CommandContext, CommandHandler, CommandResult};
+use crate::teams::in_process::{InProcessBackend, TeammateTaskSnapshot};
+use crate::teams::types::TaskStatus as TeamTaskStatus;
+use crate::tools::tasks::{global_store, TaskEntry, TaskStatus as ToolTaskStatus};
+use crate::ui::browser::{render_with_footer, TreeNode};
+
+pub struct TasksHandler;
+
+#[async_trait]
+impl CommandHandler for TasksHandler {
+    async fn execute(&self, args: &str, _ctx: &mut CommandContext) -> Result<CommandResult> {
+        let mut parts = args.split_whitespace();
+        let sub = parts.next().unwrap_or("").to_ascii_lowercase();
+        match sub.as_str() {
+            "" | "list" | "ls" => Ok(CommandResult::Output(render_list())),
+            "show" | "info" => {
+                let id = parts.next().unwrap_or("").trim();
+                if id.is_empty() {
+                    return Ok(CommandResult::Output(
+                        "Usage: /tasks show <id>".to_string(),
+                    ));
+                }
+                Ok(CommandResult::Output(render_detail(id)))
+            }
+            "stop" | "kill" => {
+                let id = parts.next().unwrap_or("").trim();
+                if id.is_empty() {
+                    return Ok(CommandResult::Output(
+                        "Usage: /tasks stop <id>".to_string(),
+                    ));
+                }
+                Ok(CommandResult::Output(stop_task(id)))
+            }
+            other => Ok(CommandResult::Output(format!(
+                "Unknown /tasks subcommand '{}'.\n\n\
+                 Usage:\n  \
+                 /tasks               — list current background tasks\n  \
+                 /tasks show <id>     — drill into one task\n  \
+                 /tasks stop <id>     — mark a tool task as stopped\n",
+                other
+            ))),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+fn render_list() -> String {
+    let tool_tasks = global_store().list();
+    let team_tasks = InProcessBackend::task_snapshots();
+
+    let mut roots: Vec<TreeNode> = Vec::new();
+
+    // Tool-backed tasks: shell, tool orchestration, whatever the TaskCreate
+    // tool registered.
+    let mut tool_node = TreeNode::leaf(format!("Tool tasks ({})", tool_tasks.len()));
+    if tool_tasks.is_empty() {
+        tool_node.push_child(TreeNode::leaf("(none)"));
+    } else {
+        for task in &tool_tasks {
+            tool_node.push_child(
+                TreeNode::leaf(format!("{}  {}", task.id, task.subject))
+                    .with_badge(format!("tool:{}", task.status.as_str()))
+                    .with_detail(format_timestamp(task.created_at)),
+            );
+        }
+    }
+    roots.push(tool_node);
+
+    // Team-backed tasks: in-process teammates registered through the Team
+    // spawning flow. These are runtime-only and only appear when the user
+    // is inside a team.
+    let mut team_node = TreeNode::leaf(format!("Team tasks ({})", team_tasks.len()));
+    if team_tasks.is_empty() {
+        team_node.push_child(TreeNode::leaf("(none)"));
+    } else {
+        for task in &team_tasks {
+            let status_tag = format!(
+                "team:{}",
+                match task.status {
+                    TeamTaskStatus::Running if task.is_idle => "running-idle",
+                    TeamTaskStatus::Running => "running",
+                    TeamTaskStatus::Stopped => "stopped",
+                    TeamTaskStatus::Completed => "completed",
+                }
+            );
+            team_node.push_child(
+                TreeNode::leaf(format!(
+                    "{}  {} ({})",
+                    task.id, task.agent_name, task.team_name
+                ))
+                .with_badge(status_tag)
+                .with_detail(if task.has_error {
+                    format!(
+                        "error: {}",
+                        task.error_message.clone().unwrap_or_default()
+                    )
+                } else {
+                    format!("prompt: {}", first_line(&task.prompt))
+                }),
+            );
+        }
+    }
+    roots.push(team_node);
+
+    let footer = "\
+Tool tasks persist across turns; team tasks live for the duration of the \
+parent team. Use `/tasks show <id>` for full output, or `/tasks stop <id>` \
+to mark a tool task as stopped.";
+
+    render_with_footer("Background tasks", &roots, footer)
+}
+
+fn render_detail(id: &str) -> String {
+    if let Some(task) = global_store().get(id) {
+        return render_tool_detail(&task);
+    }
+    if let Some(task) = InProcessBackend::task_snapshots()
+        .into_iter()
+        .find(|t| t.id == id)
+    {
+        return render_team_detail(&task);
+    }
+    format!(
+        "No task with id '{}'. Run `/tasks` to list every current background task.",
+        id
+    )
+}
+
+fn render_tool_detail(task: &TaskEntry) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("Tool task {}\n", task.id));
+    out.push_str(&"─".repeat(11 + task.id.len()));
+    out.push('\n');
+    out.push_str(&format!("  Subject:     {}\n", task.subject));
+    out.push_str(&format!("  Description: {}\n", task.description));
+    out.push_str(&format!("  Status:      {}\n", task.status.as_str()));
+    out.push_str(&format!(
+        "  Created:     {}\n",
+        format_timestamp(task.created_at)
+    ));
+    out.push_str(&format!(
+        "  Updated:     {}\n",
+        format_timestamp(task.updated_at)
+    ));
+    if task.output.is_empty() {
+        out.push_str("  Output:      (empty)\n");
+    } else {
+        out.push_str("  Output:\n");
+        for line in task.output.lines() {
+            out.push_str(&format!("    {}\n", line));
+        }
+    }
+    if matches!(task.status, ToolTaskStatus::Pending | ToolTaskStatus::InProgress) {
+        out.push_str("\nTip: `/tasks stop <id>` marks the task as stopped.\n");
+    }
+    out
+}
+
+fn render_team_detail(task: &TeammateTaskSnapshot) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("Team task {}\n", task.id));
+    out.push_str(&"─".repeat(11 + task.id.len()));
+    out.push('\n');
+    out.push_str(&format!("  Agent:    {} ({})\n", task.agent_name, task.agent_id));
+    out.push_str(&format!("  Team:     {}\n", task.team_name));
+    out.push_str(&format!(
+        "  Status:   {}{}\n",
+        match task.status {
+            TeamTaskStatus::Running => "running",
+            TeamTaskStatus::Stopped => "stopped",
+            TeamTaskStatus::Completed => "completed",
+        },
+        if task.is_idle { " (idle)" } else { "" }
+    ));
+    if task.awaiting_plan_approval {
+        out.push_str("  Plan:     awaiting approval\n");
+    }
+    if let Some(model) = &task.model {
+        out.push_str(&format!("  Model:    {}\n", model));
+    }
+    if task.has_error {
+        out.push_str(&format!(
+            "  Error:    {}\n",
+            task.error_message.clone().unwrap_or_default()
+        ));
+    }
+    out.push_str("  Prompt:\n");
+    for line in task.prompt.lines() {
+        out.push_str(&format!("    {}\n", line));
+    }
+    out.push_str(
+        "\nTip: team tasks are controlled through `/team` — `/tasks stop` only \
+         applies to tool tasks.\n",
+    );
+    out
+}
+
+fn stop_task(id: &str) -> String {
+    if let Some(entry) = global_store().stop(id) {
+        return format!(
+            "Stopped tool task '{}' (was {}).",
+            entry.subject,
+            entry.status.as_str()
+        );
+    }
+    if InProcessBackend::task_snapshots().iter().any(|t| t.id == id) {
+        return format!(
+            "'{}' is a team task — use `/team kill <name>` to stop a teammate, \
+             `/tasks stop` only applies to tool tasks.",
+            id
+        );
+    }
+    format!(
+        "No task with id '{}' — run `/tasks` to see the current list.",
+        id
+    )
+}
+
+fn format_timestamp(ts: i64) -> String {
+    match Local.timestamp_opt(ts, 0) {
+        chrono::LocalResult::Single(dt) => dt.format("%Y-%m-%d %H:%M:%S").to_string(),
+        _ => {
+            // Chrono can return `None` or `Ambiguous` on DST edges; fall
+            // back to the raw timestamp so we never crash the command.
+            let as_local: DateTime<Local> = Local::now();
+            format!("unknown (now ~{})", as_local.format("%Y-%m-%d %H:%M"))
+        }
+    }
+}
+
+fn first_line(s: &str) -> String {
+    const MAX: usize = 80;
+    let line = s.lines().next().unwrap_or(s).trim();
+    if line.chars().count() <= MAX {
+        return line.to_string();
+    }
+    let truncated: String = line.chars().take(MAX).collect();
+    format!("{}…", truncated)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bootstrap::SessionId;
+    use crate::types::app_state::AppState;
+    use std::path::PathBuf;
+
+    fn make_ctx() -> CommandContext {
+        CommandContext {
+            messages: vec![],
+            cwd: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+            app_state: AppState::default(),
+            session_id: SessionId::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn list_always_has_both_buckets() {
+        let handler = TasksHandler;
+        let mut ctx = make_ctx();
+        let result = handler.execute("", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(s) => {
+                assert!(s.contains("Tool tasks"));
+                assert!(s.contains("Team tasks"));
+            }
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[tokio::test]
+    async fn show_without_id_returns_usage() {
+        let handler = TasksHandler;
+        let mut ctx = make_ctx();
+        let result = handler.execute("show", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(s) => assert!(s.contains("Usage: /tasks show")),
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[tokio::test]
+    async fn show_missing_id_reports_missing() {
+        let handler = TasksHandler;
+        let mut ctx = make_ctx();
+        let result = handler.execute("show missing-id", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(s) => assert!(s.contains("No task with id")),
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[tokio::test]
+    async fn stop_without_id_returns_usage() {
+        let handler = TasksHandler;
+        let mut ctx = make_ctx();
+        let result = handler.execute("stop", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(s) => assert!(s.contains("Usage: /tasks stop")),
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_subcommand_shows_usage() {
+        let handler = TasksHandler;
+        let mut ctx = make_ctx();
+        let result = handler.execute("banana", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(s) => {
+                assert!(s.contains("Unknown /tasks"));
+                assert!(s.contains("Usage"));
+            }
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[tokio::test]
+    async fn stop_marks_tool_task_stopped() {
+        let store = global_store();
+        let task = store.create("unit", "created-by-test");
+        let handler = TasksHandler;
+        let mut ctx = make_ctx();
+        let result = handler
+            .execute(&format!("stop {}", task.id), &mut ctx)
+            .await
+            .unwrap();
+        match result {
+            CommandResult::Output(s) => {
+                assert!(s.contains("Stopped tool task"));
+                let refreshed = store.get(&task.id).unwrap();
+                assert_eq!(refreshed.status, ToolTaskStatus::Stopped);
+            }
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[tokio::test]
+    async fn show_prints_tool_detail_fields() {
+        let store = global_store();
+        let task = store.create("detail-test", "detail description");
+        let handler = TasksHandler;
+        let mut ctx = make_ctx();
+        let result = handler
+            .execute(&format!("show {}", task.id), &mut ctx)
+            .await
+            .unwrap();
+        match result {
+            CommandResult::Output(s) => {
+                assert!(s.contains("Tool task"));
+                assert!(s.contains("detail-test"));
+                assert!(s.contains("detail description"));
+                assert!(s.contains("Status:"));
+            }
+            _ => panic!("expected Output"),
+        }
+    }
+}

--- a/src/teams/in_process.rs
+++ b/src/teams/in_process.rs
@@ -109,12 +109,54 @@ impl InProcessBackend {
         registry.keys().cloned().collect()
     }
 
+    /// Read-only snapshot of every task in the registry.
+    ///
+    /// `InProcessTeammateTaskState` holds non-`Clone` data (an abort handle
+    /// among other things), so we project the registry into a simple
+    /// struct that callers can use for display or inspection without having
+    /// to hold the registry lock.
+    pub fn task_snapshots() -> Vec<TeammateTaskSnapshot> {
+        let registry = TASK_REGISTRY.lock();
+        registry
+            .values()
+            .map(|state| TeammateTaskSnapshot {
+                id: state.id.clone(),
+                agent_id: state.identity.agent_id.clone(),
+                agent_name: state.identity.agent_name.clone(),
+                team_name: state.identity.team_name.clone(),
+                status: state.status,
+                is_idle: state.is_idle,
+                has_error: state.error.is_some(),
+                error_message: state.error.clone(),
+                prompt: state.prompt.clone(),
+                model: state.model.clone(),
+                awaiting_plan_approval: state.awaiting_plan_approval,
+            })
+            .collect()
+    }
+
     /// Clear all tasks (for testing).
     #[cfg(test)]
     pub fn clear_registry() {
         let mut registry = TASK_REGISTRY.lock();
         registry.clear();
     }
+}
+
+/// Immutable projection of an in-process teammate task, safe to move around.
+#[derive(Debug, Clone)]
+pub struct TeammateTaskSnapshot {
+    pub id: String,
+    pub agent_id: String,
+    pub agent_name: String,
+    pub team_name: String,
+    pub status: TaskStatus,
+    pub is_idle: bool,
+    pub has_error: bool,
+    pub error_message: Option<String>,
+    pub prompt: String,
+    pub model: Option<String>,
+    pub awaiting_plan_approval: bool,
 }
 
 #[async_trait]

--- a/src/tools/tasks.rs
+++ b/src/tools/tasks.rs
@@ -153,6 +153,15 @@ fn store() -> &'static TaskStore {
     &GLOBAL_STORE
 }
 
+/// Read-only handle to the global task store, exposed for command surfaces
+/// (`/tasks`) that want to enumerate tool-driven tasks without running a
+/// tool call. The store is intentionally cheap to clone (all interior state
+/// is behind `Arc`), so returning a fresh clone keeps the caller from
+/// holding a long-lived reference.
+pub fn global_store() -> TaskStore {
+    GLOBAL_STORE.clone()
+}
+
 // =============================================================================
 // TaskCreateTool
 // =============================================================================

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -1,0 +1,380 @@
+//! Shared read-only "list + drill-down" browser primitives used by
+//! `/hooks`, `/agents`, `/doctor`, `/tasks`, and `/keybindings`.
+//!
+//! These commands all render a tree of items grouped by source or category
+//! and link each leaf back to a config file the user can open in their
+//! editor. Rather than reinvent the same formatting and file-open dance in
+//! each command, they share these helpers.
+//!
+//! The module is deliberately text-only — no TUI drill-down state. Commands
+//! execute via `CommandResult::Output(String)`, so a rendered tree plus a
+//! "jump to editor" subcommand is the UX seam we actually need.
+
+use std::path::Path;
+
+// ---------------------------------------------------------------------------
+// Tree node
+// ---------------------------------------------------------------------------
+
+/// A node in a rendered tree.
+///
+/// `label` is the primary display string. `detail` is a short secondary line
+/// shown after the label (e.g. a description, a path). `badge` is a bracketed
+/// source tag printed before the label (e.g. `[user]`, `[managed]`).
+#[derive(Debug, Clone, Default)]
+pub struct TreeNode {
+    pub label: String,
+    pub detail: Option<String>,
+    pub badge: Option<String>,
+    pub children: Vec<TreeNode>,
+}
+
+impl TreeNode {
+    pub fn leaf(label: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            ..Default::default()
+        }
+    }
+
+    pub fn with_badge(mut self, badge: impl Into<String>) -> Self {
+        self.badge = Some(badge.into());
+        self
+    }
+
+    pub fn with_detail(mut self, detail: impl Into<String>) -> Self {
+        self.detail = Some(detail.into());
+        self
+    }
+
+    pub fn push_child(&mut self, child: TreeNode) {
+        self.children.push(child);
+    }
+}
+
+/// Render a list of top-level nodes as an indented tree.
+///
+/// Output uses ASCII box-drawing so it is portable across terminals without
+/// requiring specific Unicode fonts.
+pub fn render_tree(title: &str, roots: &[TreeNode]) -> String {
+    let mut out = String::new();
+    if !title.is_empty() {
+        out.push_str(title);
+        out.push('\n');
+        out.push_str(&"─".repeat(title.chars().count().min(60)));
+        out.push('\n');
+    }
+    if roots.is_empty() {
+        out.push_str("  (no entries)\n");
+        return out;
+    }
+    for node in roots {
+        render_node(&mut out, node, "", true);
+    }
+    out
+}
+
+fn render_node(out: &mut String, node: &TreeNode, prefix: &str, is_root: bool) {
+    let connector = if is_root { "" } else { "├─ " };
+    let line_prefix = if is_root {
+        String::new()
+    } else {
+        prefix.to_string()
+    };
+    let badge = node
+        .badge
+        .as_deref()
+        .map(|b| format!("[{}] ", b))
+        .unwrap_or_default();
+
+    out.push_str(&line_prefix);
+    out.push_str(connector);
+    out.push_str(&badge);
+    out.push_str(&node.label);
+    if let Some(detail) = &node.detail {
+        out.push_str(" — ");
+        out.push_str(detail);
+    }
+    out.push('\n');
+
+    let child_prefix = if is_root {
+        "  ".to_string()
+    } else {
+        format!("{}│  ", prefix)
+    };
+    let last_child_prefix = if is_root {
+        "  ".to_string()
+    } else {
+        format!("{}   ", prefix)
+    };
+    let total = node.children.len();
+    for (i, child) in node.children.iter().enumerate() {
+        let is_last = i + 1 == total;
+        let nested_prefix = if is_last {
+            &last_child_prefix
+        } else {
+            &child_prefix
+        };
+        render_child(out, child, nested_prefix, is_last);
+    }
+}
+
+fn render_child(out: &mut String, node: &TreeNode, prefix: &str, is_last: bool) {
+    let connector = if is_last { "└─ " } else { "├─ " };
+    let badge = node
+        .badge
+        .as_deref()
+        .map(|b| format!("[{}] ", b))
+        .unwrap_or_default();
+    out.push_str(prefix);
+    out.push_str(connector);
+    out.push_str(&badge);
+    out.push_str(&node.label);
+    if let Some(detail) = &node.detail {
+        out.push_str(" — ");
+        out.push_str(detail);
+    }
+    out.push('\n');
+
+    let total = node.children.len();
+    if total == 0 {
+        return;
+    }
+    let continuation = if is_last { "   " } else { "│  " };
+    let deeper_prefix = format!("{}{}", prefix, continuation);
+    for (i, child) in node.children.iter().enumerate() {
+        render_child(out, child, &deeper_prefix, i + 1 == total);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Editor-jump helper
+// ---------------------------------------------------------------------------
+
+/// Outcome of attempting to open a file in the user's editor.
+#[derive(Debug)]
+pub enum OpenOutcome {
+    /// File opened successfully (or the editor returned cleanly).
+    Opened { editor: String, created: bool },
+    /// No `$VISUAL`/`$EDITOR` is set — the caller should print the path.
+    NoEditor { created: bool },
+    /// Editor exited non-zero or failed to launch.
+    Failed { editor: String, message: String },
+    /// Failed to create parent directory or template.
+    CreateFailed { error: String },
+}
+
+/// Ensure `path` exists (creating it with `template` if not) and open it in
+/// the user's `$VISUAL`/`$EDITOR`.
+///
+/// The caller is expected to format the `OpenOutcome` for display. We don't
+/// print directly so the command layer keeps full control over messaging.
+pub fn ensure_and_open(path: &Path, template: &str) -> OpenOutcome {
+    let created = match ensure_file(path, template) {
+        Ok(c) => c,
+        Err(e) => {
+            return OpenOutcome::CreateFailed {
+                error: e.to_string(),
+            }
+        }
+    };
+
+    let editor = std::env::var("VISUAL")
+        .or_else(|_| std::env::var("EDITOR"))
+        .ok()
+        .filter(|s| !s.trim().is_empty());
+
+    match editor {
+        Some(ed) => {
+            let status = std::process::Command::new(&ed).arg(path).status();
+            match status {
+                Ok(s) if s.success() => OpenOutcome::Opened {
+                    editor: ed,
+                    created,
+                },
+                Ok(s) => OpenOutcome::Failed {
+                    editor: ed,
+                    message: format!("exited with status {}", s.code().unwrap_or(-1)),
+                },
+                Err(e) => OpenOutcome::Failed {
+                    editor: ed,
+                    message: e.to_string(),
+                },
+            }
+        }
+        None => OpenOutcome::NoEditor { created },
+    }
+}
+
+/// Render an `OpenOutcome` back to a user-facing string given the target
+/// path. Commands call this to produce the final `CommandResult::Output`.
+pub fn format_open_outcome(outcome: &OpenOutcome, path: &Path) -> String {
+    match outcome {
+        OpenOutcome::Opened { editor, created } => format!(
+            "{}Opened {} in {}.",
+            if *created { "Created and " } else { "" },
+            path.display(),
+            editor
+        ),
+        OpenOutcome::NoEditor { created } => format!(
+            "{}File: {}\n(Set $VISUAL or $EDITOR to auto-open in an editor.)",
+            if *created {
+                "Created template.\n"
+            } else {
+                ""
+            },
+            path.display()
+        ),
+        OpenOutcome::Failed { editor, message } => format!(
+            "Error launching '{}': {}. File: {}",
+            editor,
+            message,
+            path.display()
+        ),
+        OpenOutcome::CreateFailed { error } => {
+            format!("Error: could not prepare {}: {}", path.display(), error)
+        }
+    }
+}
+
+/// Ensure `path` exists, creating it (and its parent directory) from
+/// `template` when absent. Returns whether a new file was created.
+fn ensure_file(path: &Path, template: &str) -> std::io::Result<bool> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    if path.exists() {
+        return Ok(false);
+    }
+    std::fs::write(path, template)?;
+    Ok(true)
+}
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+/// Render a path suitable for display (always forward-slashed).
+pub fn display_path(p: &Path) -> String {
+    p.to_string_lossy().replace('\\', "/")
+}
+
+/// Shorten a path relative to `$HOME` using the `~` convention when possible.
+pub fn shorten_path(p: &Path) -> String {
+    if let Some(home) = dirs::home_dir() {
+        if let Ok(rel) = p.strip_prefix(&home) {
+            let rel = rel.to_string_lossy().replace('\\', "/");
+            if rel.is_empty() {
+                return "~".to_string();
+            }
+            return format!("~/{}", rel);
+        }
+    }
+    display_path(p)
+}
+
+/// Convenience: turn a `Vec<TreeNode>` plus optional header/footer into a
+/// single string.
+pub fn render_with_footer(title: &str, roots: &[TreeNode], footer: &str) -> String {
+    let mut out = render_tree(title, roots);
+    if !footer.is_empty() {
+        if !out.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push('\n');
+        out.push_str(footer);
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn render_tree_prints_title_and_nodes() {
+        let mut node = TreeNode::leaf("alpha")
+            .with_badge("user")
+            .with_detail("first entry");
+        node.push_child(TreeNode::leaf("a-child"));
+        let out = render_tree("Things", &[node]);
+        assert!(out.contains("Things"));
+        assert!(out.contains("[user]"));
+        assert!(out.contains("alpha"));
+        assert!(out.contains("first entry"));
+        assert!(out.contains("a-child"));
+    }
+
+    #[test]
+    fn render_tree_empty_says_no_entries() {
+        let out = render_tree("Hooks", &[]);
+        assert!(out.contains("Hooks"));
+        assert!(out.contains("(no entries)"));
+    }
+
+    #[test]
+    fn ensure_and_open_creates_template_when_missing() {
+        let dir = std::env::temp_dir().join(format!(
+            "cc-rust-browser-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let path = dir.join("config.json");
+        // Keep editor empty so the helper returns NoEditor without spawning.
+        let prev_visual = std::env::var_os("VISUAL");
+        let prev_editor = std::env::var_os("EDITOR");
+        std::env::remove_var("VISUAL");
+        std::env::remove_var("EDITOR");
+
+        let outcome = ensure_and_open(&path, "{}");
+        match &outcome {
+            OpenOutcome::NoEditor { created } => assert!(*created),
+            _ => panic!("expected NoEditor, got {:?}", outcome),
+        }
+        assert!(path.exists(), "template should be created");
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "{}");
+
+        // Running again should not recreate.
+        let second = ensure_and_open(&path, "{\"changed\": true}");
+        match &second {
+            OpenOutcome::NoEditor { created } => assert!(!*created),
+            _ => panic!("expected NoEditor, got {:?}", second),
+        }
+        // Template must be preserved — no overwrite.
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "{}");
+
+        // Restore env.
+        if let Some(v) = prev_visual {
+            std::env::set_var("VISUAL", v);
+        }
+        if let Some(v) = prev_editor {
+            std::env::set_var("EDITOR", v);
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn format_open_outcome_prints_path() {
+        let path = PathBuf::from("/tmp/x.json");
+        let out = format_open_outcome(&OpenOutcome::NoEditor { created: true }, &path);
+        assert!(out.contains("/tmp/x.json"));
+        assert!(out.contains("Created template"));
+    }
+
+    #[test]
+    fn shorten_path_strips_home_prefix() {
+        if let Some(home) = dirs::home_dir() {
+            let inside = home.join(".cc-rust/settings.json");
+            let short = shorten_path(&inside);
+            assert!(short.starts_with("~/"));
+            assert!(short.contains(".cc-rust"));
+        }
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,6 @@
 #[allow(dead_code)]
 pub mod app;
+pub mod browser;
 #[allow(dead_code)]
 pub mod diff;
 #[allow(dead_code)]


### PR DESCRIPTION
## Summary

Closes #40, #34, #39, #54, and realigns #42. Ships a shared read-only "list + drill-down" primitive and layers four new slash commands on top, plus realigns `/keybindings` around the Bun reference's editor-first flow.

The five commands all share the same tree-view + editor-jump plumbing (`src/ui/browser.rs`), so adding more browsers later is mostly a matter of writing a data collector and plugging it into the renderer.

## What changed

### Shared infrastructure — `src/ui/browser.rs`
- `TreeNode` + `render_tree` / `render_with_footer` — ASCII tree layout with source badges, secondary details, and stable child ordering.
- `ensure_and_open` + `format_open_outcome` — editor-jump helper that creates a file from a template only when missing, then hands it to `\$VISUAL`/`\$EDITOR` without clobbering existing contents.
- `shorten_path` — `~`-relative display for user-facing paths.

### New commands

- **/hooks (#40)** — `src/commands/hooks_cmd.rs`. Merged tree of every hook declared across managed/user/project/local settings layers, grouped by event → matcher → hook with source badges. `path`/`open <layer>` subcommands jump to the owning settings file.
- **/agents (#34)** — `src/commands/agents_cmd.rs`. Browser over built-in subagent types, fork-executing skills, and active team members with source + override/shadow visibility. `show <name>` prints full details.
- **/doctor (#39)** — `src/commands/doctor.rs`. Aggregated install/auth/settings/MCP/keybindings/sandbox/terminal diagnostics with ok/warn/fail/info statuses, summary counts, and `/doctor raw` JSON output for scripting.
- **/tasks (#54)** — `src/commands/tasks_cmd.rs`. Background task list spanning tool tasks (`TaskStore`) and in-process teammate tasks; `show <id>` drills into a task, `stop <id>` marks tool tasks stopped.

### Realignment

- **/keybindings (#42)** — default action is now create-template-if-missing + open in \`\$EDITOR\`, matching the Bun reference. Status readout moved to `/keybindings status`. `list`/`reload`/`path` preserved.

### Supporting API changes

- `tools::tasks::global_store()` — public accessor exposing the global `TaskStore` to command surfaces.
- `teams::in_process::InProcessBackend::task_snapshots()` + new `TeammateTaskSnapshot` projection type — lets browsers read registry state without holding non-`Clone` handles.

## Why

The five issues share a common shape (enumerate registered things from multiple sources, show overrides, link back to the config file that owns each entry). Building a single shared primitive and layering the commands on top keeps the surfaces consistent and makes future read-only browsers cheap. The acceptance criteria on each issue all ask for the read-only slice first, explicitly deferring CRUD — which is what this PR ships.

## Test plan

- [x] `cargo build` — zero new warnings (5 pre-existing warnings in `src/web`/`src/observability` untouched).
- [x] 37 new unit tests pass under `--test-threads=1` and in parallel:
  - `ui::browser` — 5 tests (renderer + editor-jump)
  - `commands::hooks_cmd` — 7 tests
  - `commands::agents_cmd` — 7 tests
  - `commands::doctor` — 6 tests
  - `commands::tasks_cmd` — 7 tests (including shared-store round-trips)
  - `commands::keybindings_cmd` — 5 tests (existing tests retargeted to the new default, plus a regression check that the default no longer shows the status readout)
- [x] `commands::tests::test_all_commands_registered` extended to assert the four new names are registered.
- [x] Existing test suite unaffected — the only failures on `rust-lite` are pre-existing flakes in `teams::mailbox`, `teams::helpers`, `tools::worktree`, and `commands::config_cmd`.

## Reviewer notes

- The tree renderer is deliberately text-only. The UX seam we actually have is `CommandResult::Output(String)`, so a rendered tree plus editor-jump subcommands covers what the Bun-side TUI menus do without dragging in a second UI layer.
- `/doctor raw` returns JSON — handy for CI/scripts that want to scan for fail rows.
- For `/agents`, the "agent" concept in cc-rust today is a union (built-in subagent types + fork-executing skills + team members). The data model carries enough metadata (source, path, active, execution kind) that a future CRUD pass can layer on top without a rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)