### PR TITLE
feat(session): /rename, /rewind, /insights + custom_title schema

### DIFF
--- a/src/commands/insights.rs
+++ b/src/commands/insights.rs
@@ -1,0 +1,248 @@
+//! /insights command -- session-history analytics and reporting.
+//!
+//! Usage:
+//! - `/insights`                -- all sessions, with usage stats
+//! - `/insights this`           -- only sessions in the current workspace
+//! - `/insights recent [days]`  -- filter to last `days` (default 30)
+//! - `/insights fast`           -- skip session-body scan for a quick metadata sweep
+//!
+//! Heavy lifting lives in `services::session_analytics`; this handler parses
+//! arguments, calls the service, and formats the textual report.
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use super::{CommandContext, CommandHandler, CommandResult};
+use crate::services::session_analytics::{self, InsightsFilter, Scope};
+
+/// Handler for the `/insights` slash command.
+pub struct InsightsHandler;
+
+#[async_trait]
+impl CommandHandler for InsightsHandler {
+    async fn execute(&self, args: &str, ctx: &mut CommandContext) -> Result<CommandResult> {
+        let parts: Vec<&str> = args.split_whitespace().collect();
+
+        let mut filter = InsightsFilter::default();
+        let mut label = String::from("Session insights (all workspaces)");
+
+        match parts.as_slice() {
+            [] => { /* defaults */ }
+            ["this"] | ["workspace"] | ["ws"] => {
+                filter.scope = Scope::Workspace(ctx.cwd.clone());
+                label = format!("Session insights ({})", ctx.cwd.display());
+            }
+            ["fast"] => {
+                filter.include_usage = false;
+                label = "Session insights (fast — metadata only)".into();
+            }
+            ["recent", days_arg] => {
+                let days = days_arg.parse::<i64>().map_err(|_| {
+                    anyhow::anyhow!("expected a positive integer for days, got: {}", days_arg)
+                })?;
+                if days <= 0 {
+                    return Ok(CommandResult::Output(
+                        "'days' must be a positive integer.".into(),
+                    ));
+                }
+                filter.since = Some(chrono::Utc::now().timestamp() - days * 86_400);
+                label = format!("Session insights (last {} days)", days);
+            }
+            ["recent"] => {
+                let days: i64 = 30;
+                filter.since = Some(chrono::Utc::now().timestamp() - days * 86_400);
+                label = format!("Session insights (last {} days)", days);
+            }
+            _ => {
+                return Ok(CommandResult::Output(format!(
+                    "Unknown /insights args: '{}'\n\n{}",
+                    args.trim(),
+                    USAGE_HELP
+                )));
+            }
+        }
+
+        let report = session_analytics::compute_insights(&filter)?;
+        if report.session_count == 0 {
+            return Ok(CommandResult::Output(
+                "No sessions match the current filter. Try /insights or /session list."
+                    .into(),
+            ));
+        }
+        Ok(CommandResult::Output(session_analytics::format_report(
+            &report, &label,
+        )))
+    }
+}
+
+const USAGE_HELP: &str = "Usage:\n  \
+   /insights                     -- all sessions\n  \
+   /insights this                -- current workspace only\n  \
+   /insights recent [days]       -- last N days (default 30)\n  \
+   /insights fast                -- metadata-only sweep (skips token/cost scan)";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bootstrap::SessionId;
+    use crate::session::storage::{self, SerializableMessage, SessionFile};
+    use crate::types::app_state::AppState;
+    use std::path::{Path, PathBuf};
+
+    struct HomeGuard {
+        previous: Option<String>,
+    }
+
+    impl HomeGuard {
+        fn set(path: &Path) -> Self {
+            let previous = std::env::var("CC_RUST_HOME").ok();
+            std::env::set_var("CC_RUST_HOME", path);
+            Self { previous }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(v) => std::env::set_var("CC_RUST_HOME", v),
+                None => std::env::remove_var("CC_RUST_HOME"),
+            }
+        }
+    }
+
+    fn test_ctx(cwd: PathBuf) -> CommandContext {
+        CommandContext {
+            messages: Vec::new(),
+            cwd,
+            app_state: AppState::default(),
+            session_id: SessionId::from_string("curr"),
+        }
+    }
+
+    fn write_session(id: &str, cwd: &str, last_modified: i64) {
+        let messages = vec![
+            SerializableMessage {
+                msg_type: "user".into(),
+                uuid: format!("{:0>8}-0000-0000-0000-000000000001", id),
+                timestamp: last_modified,
+                data: serde_json::json!({ "content": "hi", "is_meta": false }),
+            },
+            SerializableMessage {
+                msg_type: "assistant".into(),
+                uuid: format!("{:0>8}-0000-0000-0000-000000000002", id),
+                timestamp: last_modified,
+                data: serde_json::json!({
+                    "content": [],
+                    "usage": {
+                        "input_tokens": 10u64,
+                        "output_tokens": 5u64,
+                        "cache_read_input_tokens": 0u64,
+                        "cache_creation_input_tokens": 0u64,
+                    },
+                    "stop_reason": "end_turn",
+                    "cost_usd": 0.001,
+                }),
+            },
+        ];
+        let file = SessionFile {
+            session_id: id.into(),
+            created_at: last_modified,
+            last_modified,
+            cwd: cwd.into(),
+            custom_title: None,
+            messages,
+        };
+        std::fs::create_dir_all(storage::get_session_dir()).unwrap();
+        std::fs::write(
+            storage::get_session_file(id),
+            serde_json::to_string_pretty(&file).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_insights_no_sessions() {
+        let temp = tempfile::tempdir().unwrap();
+        let _g = HomeGuard::set(temp.path());
+
+        let mut ctx = test_ctx(temp.path().to_path_buf());
+        let result = InsightsHandler.execute("", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(t) => assert!(t.contains("No sessions")),
+            _ => panic!(),
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_insights_all_scope_counts_every_session() {
+        let temp = tempfile::tempdir().unwrap();
+        let _g = HomeGuard::set(temp.path());
+
+        write_session("aa", "/p1", 1_700_000_100);
+        write_session("bb", "/p2", 1_700_000_200);
+
+        let mut ctx = test_ctx(PathBuf::from("/some/where"));
+        let result = InsightsHandler.execute("", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(text) => {
+                assert!(text.contains("Session insights (all workspaces)"));
+                assert!(text.contains("Sessions included:   2"));
+                assert!(text.contains("Token usage"));
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_insights_recent_rejects_bad_days() {
+        let temp = tempfile::tempdir().unwrap();
+        let _g = HomeGuard::set(temp.path());
+
+        let mut ctx = test_ctx(temp.path().to_path_buf());
+        match InsightsHandler.execute("recent abc", &mut ctx).await {
+            Ok(_) => panic!("expected an error for non-numeric days"),
+            Err(e) => {
+                let msg = format!("{}", e);
+                assert!(msg.contains("days"), "got: {}", msg);
+            }
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_insights_fast_skips_usage() {
+        let temp = tempfile::tempdir().unwrap();
+        let _g = HomeGuard::set(temp.path());
+
+        write_session("fast1", "/p1", 1_700_000_100);
+
+        let mut ctx = test_ctx(temp.path().to_path_buf());
+        let result = InsightsHandler.execute("fast", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(text) => {
+                assert!(text.contains("fast"));
+                assert!(text.contains("Usage stats skipped"));
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_insights_unknown_subcommand_shows_help() {
+        let mut ctx = test_ctx(PathBuf::from("/x"));
+        let result = InsightsHandler
+            .execute("nonsense foo", &mut ctx)
+            .await
+            .unwrap();
+        match result {
+            CommandResult::Output(text) => {
+                assert!(text.contains("Unknown /insights args"));
+                assert!(text.contains("Usage:"));
+            }
+            _ => panic!(),
+        }
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -37,6 +37,9 @@ pub mod skills_cmd;
 // Session management
 pub mod copy;
 pub mod init;
+pub mod insights;
+pub mod rename;
+pub mod rewind;
 pub mod status;
 
 // Agent Teams
@@ -213,6 +216,24 @@ pub fn get_all_commands() -> Vec<Command> {
             aliases: vec![],
             description: "Resume a previous session".into(),
             handler: Box::new(resume::ResumeHandler),
+        },
+        Command {
+            name: "rename".into(),
+            aliases: vec![],
+            description: "Set or clear the custom title for the current session".into(),
+            handler: Box::new(rename::RenameHandler),
+        },
+        Command {
+            name: "rewind".into(),
+            aliases: vec![],
+            description: "Rewind the conversation to an earlier user turn".into(),
+            handler: Box::new(rewind::RewindHandler),
+        },
+        Command {
+            name: "insights".into(),
+            aliases: vec![],
+            description: "Session history analytics (cross-session statistics)".into(),
+            handler: Box::new(insights::InsightsHandler),
         },
         Command {
             name: "files".into(),

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -1,0 +1,323 @@
+//! /rename command -- set or clear the custom title on the current session.
+//!
+//! Usage:
+//! - `/rename`                -- show the current title
+//! - `/rename <title>`        -- set a custom title (persisted on the session file)
+//! - `/rename --auto`         -- adopt the auto-derived title as a pinned custom title
+//! - `/rename --clear`        -- remove the custom title (falling back to auto-derived)
+//!
+//! The title is stored on the `SessionFile` via
+//! [`crate::session::storage::set_session_title`]. If the session has not been
+//! persisted yet (no assistant turn has triggered an auto-save) we persist the
+//! current message buffer first so the rename has a file to land on.
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use super::{CommandContext, CommandHandler, CommandResult};
+use crate::session::storage;
+use crate::types::message::{Message, MessageContent};
+
+/// Handler for the `/rename` slash command.
+pub struct RenameHandler;
+
+#[async_trait]
+impl CommandHandler for RenameHandler {
+    async fn execute(&self, args: &str, ctx: &mut CommandContext) -> Result<CommandResult> {
+        let arg = args.trim();
+        let session_id = ctx.session_id.as_str();
+
+        // Ensure there is a session file on disk before we try to mutate it.
+        // In long-running REPLs auto-save has usually already produced one;
+        // new sessions that have not yet round-tripped through the engine
+        // need a first write here.
+        ensure_persisted(ctx)?;
+
+        match arg {
+            "" => show_current_title(session_id),
+            "--clear" | "-c" | "clear" => clear_title(session_id),
+            "--auto" | "-a" | "auto" => auto_rename(ctx, session_id),
+            other => set_title(session_id, other),
+        }
+    }
+}
+
+fn ensure_persisted(ctx: &CommandContext) -> Result<()> {
+    let path = storage::get_session_file(ctx.session_id.as_str());
+    if path.exists() {
+        return Ok(());
+    }
+    storage::save_session(
+        ctx.session_id.as_str(),
+        &ctx.messages,
+        &ctx.cwd.to_string_lossy(),
+    )
+}
+
+fn show_current_title(session_id: &str) -> Result<CommandResult> {
+    let info = storage::load_session_info(session_id)?;
+    let body = match info.custom_title.as_deref() {
+        Some(custom) => format!(
+            "Current title (custom): {}\n\n\
+             Use /rename <new title> to change it,\n\
+             or /rename --clear to fall back to the auto-derived title.",
+            custom
+        ),
+        None if info.title.is_empty() => "No title yet — run /rename <name> to set one.".into(),
+        None => format!(
+            "Current title (auto): {}\n\n\
+             Use /rename <new title> to pin a custom title,\n\
+             or /rename --auto to lock in the current auto-derived title.",
+            info.title
+        ),
+    };
+    Ok(CommandResult::Output(body))
+}
+
+fn set_title(session_id: &str, raw: &str) -> Result<CommandResult> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(CommandResult::Output(
+            "Title cannot be empty. Use /rename --clear to remove a custom title.".into(),
+        ));
+    }
+
+    match storage::set_session_title(session_id, Some(trimmed))? {
+        Some(stored) => Ok(CommandResult::Output(format!(
+            "Session title set to: {}",
+            stored
+        ))),
+        None => Ok(CommandResult::Output(
+            "Title was rejected (empty after trimming).".into(),
+        )),
+    }
+}
+
+fn clear_title(session_id: &str) -> Result<CommandResult> {
+    let before = storage::load_session_info(session_id)?;
+    if before.custom_title.is_none() {
+        return Ok(CommandResult::Output(
+            "No custom title to clear. The title is already auto-derived.".into(),
+        ));
+    }
+    storage::set_session_title(session_id, None)?;
+    let after = storage::load_session_info(session_id)?;
+    let fallback = if after.title.is_empty() {
+        "(no auto-derived title available yet)".into()
+    } else {
+        after.title
+    };
+    Ok(CommandResult::Output(format!(
+        "Custom title cleared. Falling back to: {}",
+        fallback
+    )))
+}
+
+fn auto_rename(ctx: &CommandContext, session_id: &str) -> Result<CommandResult> {
+    let candidate = derive_auto_title_from_messages(&ctx.messages);
+    let on_disk = storage::load_session_info(session_id)?.title;
+    let chosen = if !candidate.is_empty() {
+        candidate
+    } else if !on_disk.is_empty() {
+        on_disk
+    } else {
+        return Ok(CommandResult::Output(
+            "Cannot auto-generate a title — no user messages yet.".into(),
+        ));
+    };
+
+    let stored = storage::set_session_title(session_id, Some(&chosen))?;
+    Ok(CommandResult::Output(format!(
+        "Session title pinned to auto-derived value: {}",
+        stored.unwrap_or(chosen)
+    )))
+}
+
+/// Pull a reasonable title from the in-memory message list.
+///
+/// Mirrors the behavior of [`crate::session::storage`]'s derived title: first
+/// non-meta user message, first non-empty line, truncated to 80 chars.
+fn derive_auto_title_from_messages(messages: &[Message]) -> String {
+    const MAX: usize = 80;
+    for msg in messages {
+        let Message::User(u) = msg else { continue };
+        if u.is_meta {
+            continue;
+        }
+        let text = match &u.content {
+            MessageContent::Text(t) => t.clone(),
+            MessageContent::Blocks(blocks) => blocks
+                .iter()
+                .filter_map(|b| match b {
+                    crate::types::message::ContentBlock::Text { text } => Some(text.clone()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join("\n"),
+        };
+        let first_line = text.lines().find(|l| !l.trim().is_empty()).unwrap_or("").trim();
+        if first_line.is_empty() {
+            continue;
+        }
+        let out: String = first_line.chars().take(MAX).collect();
+        return if first_line.chars().count() > MAX {
+            format!("{}…", out)
+        } else {
+            out
+        };
+    }
+    String::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bootstrap::SessionId;
+    use crate::types::app_state::AppState;
+    use crate::types::message::{MessageContent, UserMessage};
+    use std::path::{Path, PathBuf};
+    use uuid::Uuid;
+
+    struct HomeGuard {
+        previous: Option<String>,
+    }
+
+    impl HomeGuard {
+        fn set(path: &Path) -> Self {
+            let previous = std::env::var("CC_RUST_HOME").ok();
+            std::env::set_var("CC_RUST_HOME", path);
+            Self { previous }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(v) => std::env::set_var("CC_RUST_HOME", v),
+                None => std::env::remove_var("CC_RUST_HOME"),
+            }
+        }
+    }
+
+    fn user(text: &str) -> Message {
+        Message::User(UserMessage {
+            uuid: Uuid::new_v4(),
+            timestamp: 0,
+            role: "user".into(),
+            content: MessageContent::Text(text.into()),
+            is_meta: false,
+            tool_use_result: None,
+            source_tool_assistant_uuid: None,
+        })
+    }
+
+    fn test_ctx(id: &str, messages: Vec<Message>) -> CommandContext {
+        CommandContext {
+            messages,
+            cwd: PathBuf::from("/proj"),
+            app_state: AppState::default(),
+            session_id: SessionId::from_string(id),
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_rename_without_args_shows_current_title() {
+        let temp = tempfile::tempdir().unwrap();
+        let _g = HomeGuard::set(temp.path());
+
+        let mut ctx = test_ctx("r1", vec![user("first prompt")]);
+        let result = RenameHandler.execute("", &mut ctx).await.unwrap();
+        let text = match result {
+            CommandResult::Output(t) => t,
+            _ => panic!("expected Output"),
+        };
+        assert!(text.contains("first prompt"), "got: {}", text);
+        assert!(text.contains("auto"), "got: {}", text);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_rename_sets_and_persists_custom_title() {
+        let temp = tempfile::tempdir().unwrap();
+        let _g = HomeGuard::set(temp.path());
+
+        let mut ctx = test_ctx("r2", vec![user("original prompt")]);
+        let result = RenameHandler
+            .execute("Feature Brainstorm", &mut ctx)
+            .await
+            .unwrap();
+        assert!(matches!(result, CommandResult::Output(_)));
+
+        let info = storage::load_session_info("r2").unwrap();
+        assert_eq!(info.custom_title.as_deref(), Some("Feature Brainstorm"));
+        assert_eq!(info.title, "Feature Brainstorm");
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_rename_clear_restores_auto_title() {
+        let temp = tempfile::tempdir().unwrap();
+        let _g = HomeGuard::set(temp.path());
+
+        let mut ctx = test_ctx("r3", vec![user("auto fallback")]);
+        RenameHandler.execute("pinned", &mut ctx).await.unwrap();
+        RenameHandler.execute("--clear", &mut ctx).await.unwrap();
+
+        let info = storage::load_session_info("r3").unwrap();
+        assert_eq!(info.custom_title, None);
+        assert_eq!(info.title, "auto fallback");
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_rename_auto_pins_derived_title() {
+        let temp = tempfile::tempdir().unwrap();
+        let _g = HomeGuard::set(temp.path());
+
+        let mut ctx = test_ctx("r4", vec![user("pin me\nsecond line")]);
+        RenameHandler.execute("--auto", &mut ctx).await.unwrap();
+
+        let info = storage::load_session_info("r4").unwrap();
+        assert_eq!(info.custom_title.as_deref(), Some("pin me"));
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_rename_clear_without_custom_title() {
+        let temp = tempfile::tempdir().unwrap();
+        let _g = HomeGuard::set(temp.path());
+
+        let mut ctx = test_ctx("r5", vec![user("hi")]);
+        let result = RenameHandler.execute("--clear", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(text) => {
+                assert!(text.to_lowercase().contains("no custom title"), "got: {}", text);
+            }
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[test]
+    fn test_derive_auto_title_truncates() {
+        let long = "x".repeat(200);
+        let title = derive_auto_title_from_messages(&[user(&long)]);
+        assert!(title.ends_with("…"));
+        assert!(title.chars().count() <= 81);
+    }
+
+    #[test]
+    fn test_derive_auto_title_skips_meta() {
+        let meta = Message::User(UserMessage {
+            uuid: Uuid::new_v4(),
+            timestamp: 0,
+            role: "user".into(),
+            content: MessageContent::Text("inject".into()),
+            is_meta: true,
+            tool_use_result: None,
+            source_tool_assistant_uuid: None,
+        });
+        let title = derive_auto_title_from_messages(&[meta, user("real question")]);
+        assert_eq!(title, "real question");
+    }
+}

--- a/src/commands/rewind.rs
+++ b/src/commands/rewind.rs
@@ -1,0 +1,494 @@
+//! /rewind command -- rewind the conversation to an earlier user turn.
+//!
+//! Usage:
+//! - `/rewind`                -- show a numbered list of user turns
+//! - `/rewind list`           -- same as bare invocation
+//! - `/rewind <n>`            -- rewind so the conversation keeps only the first `n` user turns
+//! - `/rewind --to <uuid>`    -- rewind to the turn identified by a (prefix of a) user UUID
+//!
+//! Rewinding does two things: it trims the in-memory message buffer (which the
+//! ingress layer mirrors back to the engine via `conversation_changed`), and
+//! it truncates the on-disk session file via
+//! [`crate::session::storage::truncate_session`], which writes a recoverable
+//! `*.rewind-<ts>.json` backup alongside the original.
+//!
+//! A "turn" here is anchored at a non-meta user message. Keeping `n` turns
+//! means keeping every message up to (but not including) the (n+1)th user
+//! anchor — i.e. we retain the assistant replies and tool traffic for the
+//! turns we keep.
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use super::{CommandContext, CommandHandler, CommandResult};
+use crate::session::storage;
+use crate::types::message::{Message, MessageContent};
+
+/// Handler for the `/rewind` slash command.
+pub struct RewindHandler;
+
+#[async_trait]
+impl CommandHandler for RewindHandler {
+    async fn execute(&self, args: &str, ctx: &mut CommandContext) -> Result<CommandResult> {
+        let arg = args.trim();
+
+        let anchors = collect_user_anchors(&ctx.messages);
+        if anchors.is_empty() {
+            return Ok(CommandResult::Output(
+                "No user turns to rewind — the conversation is empty.".into(),
+            ));
+        }
+
+        if arg.is_empty() || arg == "list" || arg == "--list" {
+            return Ok(CommandResult::Output(format_turn_list(&anchors)));
+        }
+
+        // `--to <uuid-prefix>` lookup.
+        if let Some(prefix) = arg.strip_prefix("--to").map(|s| s.trim()) {
+            if prefix.is_empty() {
+                return Ok(CommandResult::Output(
+                    "Usage: /rewind --to <user-message-uuid-prefix>".into(),
+                ));
+            }
+            let matches: Vec<&Anchor> = anchors
+                .iter()
+                .filter(|a| a.uuid.starts_with(prefix))
+                .collect();
+            return match matches.len() {
+                0 => Ok(CommandResult::Output(format!(
+                    "No user turn matches prefix '{}'. \
+                     Run /rewind to see the numbered list.",
+                    prefix
+                ))),
+                1 => rewind_to_turn(ctx, &anchors, matches[0].index),
+                _ => {
+                    let mut lines = vec![format!(
+                        "Prefix '{}' is ambiguous — {} turns match:",
+                        prefix,
+                        matches.len()
+                    )];
+                    for m in matches.iter().take(10) {
+                        lines.push(format!("  {}. {} — {}", m.index, short_uuid(&m.uuid), m.preview));
+                    }
+                    Ok(CommandResult::Output(lines.join("\n")))
+                }
+            };
+        }
+
+        // Numeric `<n>` form.
+        match arg.parse::<usize>() {
+            Ok(n) if n == 0 => {
+                ctx.messages.clear();
+                let _ = storage::truncate_session(ctx.session_id.as_str(), 0);
+                Ok(CommandResult::Output(
+                    "Conversation rewound to the start (0 messages). Use /clear next time for \
+                     a one-shot wipe."
+                        .into(),
+                ))
+            }
+            Ok(n) if n > anchors.len() => Ok(CommandResult::Output(format!(
+                "Turn {} is out of range — there are only {} turns. \
+                 Run /rewind to see the list.",
+                n,
+                anchors.len()
+            ))),
+            Ok(n) => rewind_to_turn(ctx, &anchors, n),
+            Err(_) => Ok(CommandResult::Output(format!(
+                "Unrecognized argument: '{}'.\n\n{}",
+                arg,
+                "Usage:\n  \
+                   /rewind              -- show turn list\n  \
+                   /rewind <n>          -- rewind to turn N\n  \
+                   /rewind --to <uuid>  -- rewind to a specific user UUID prefix"
+            ))),
+        }
+    }
+}
+
+/// Pointer to a single anchor user message in the history.
+#[derive(Debug, Clone)]
+struct Anchor {
+    /// 1-based turn number as shown to the user.
+    index: usize,
+    /// Position of the anchor inside the full `messages` slice.
+    message_index: usize,
+    uuid: String,
+    preview: String,
+    timestamp: i64,
+}
+
+fn collect_user_anchors(messages: &[Message]) -> Vec<Anchor> {
+    let mut anchors = Vec::new();
+    for (i, msg) in messages.iter().enumerate() {
+        let Message::User(u) = msg else { continue };
+        if u.is_meta {
+            continue;
+        }
+        // Skip synthetic user messages that wrap tool results — they are a
+        // continuation of the assistant's turn, not a user input.
+        if u.tool_use_result.is_some() || u.source_tool_assistant_uuid.is_some() {
+            continue;
+        }
+        let preview = message_preview(&u.content);
+        if preview.is_empty() {
+            continue;
+        }
+        anchors.push(Anchor {
+            index: anchors.len() + 1,
+            message_index: i,
+            uuid: u.uuid.to_string(),
+            preview,
+            timestamp: u.timestamp,
+        });
+    }
+    anchors
+}
+
+fn message_preview(content: &MessageContent) -> String {
+    let raw = match content {
+        MessageContent::Text(t) => t.clone(),
+        MessageContent::Blocks(blocks) => blocks
+            .iter()
+            .filter_map(|b| match b {
+                crate::types::message::ContentBlock::Text { text } => Some(text.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join(" "),
+    };
+    let first = raw.lines().find(|l| !l.trim().is_empty()).unwrap_or("").trim();
+    const MAX: usize = 72;
+    let trimmed: String = first.chars().take(MAX).collect();
+    if first.chars().count() > MAX {
+        format!("{}…", trimmed)
+    } else {
+        trimmed
+    }
+}
+
+fn short_uuid(uuid: &str) -> String {
+    uuid.chars().take(8).collect()
+}
+
+fn format_turn_list(anchors: &[Anchor]) -> String {
+    let mut lines = Vec::new();
+    lines.push(format!("Conversation turns ({}):", anchors.len()));
+    lines.push(String::new());
+    for a in anchors {
+        let when = if a.timestamp > 0 {
+            chrono::DateTime::from_timestamp(a.timestamp / 1000, 0)
+                .map(|dt| dt.format("%H:%M:%S").to_string())
+                .unwrap_or_else(|| "--:--:--".into())
+        } else {
+            "--:--:--".into()
+        };
+        lines.push(format!(
+            "  {:>3}. [{}] {} — {}",
+            a.index,
+            short_uuid(&a.uuid),
+            when,
+            a.preview,
+        ));
+    }
+    lines.push(String::new());
+    lines.push("Use /rewind <n> or /rewind --to <uuid-prefix> to rewind.".into());
+    lines.push(
+        "A backup of the pre-rewind session is written next to the session file."
+            .into(),
+    );
+    lines.join("\n")
+}
+
+fn rewind_to_turn(
+    ctx: &mut CommandContext,
+    anchors: &[Anchor],
+    turn: usize,
+) -> Result<CommandResult> {
+    // Keep everything strictly before the (turn+1)th anchor so the kept turns
+    // retain their full assistant/tool traffic.
+    let keep = if turn >= anchors.len() {
+        ctx.messages.len()
+    } else {
+        anchors[turn].message_index
+    };
+
+    let before = ctx.messages.len();
+    if keep >= before {
+        return Ok(CommandResult::Output(format!(
+            "Turn {} is already the last turn — nothing to rewind.",
+            turn
+        )));
+    }
+
+    ctx.messages.truncate(keep);
+
+    // Mirror the truncation on disk. Missing session file is fine — the next
+    // auto-save will create one from the truncated in-memory state.
+    let session_path = storage::get_session_file(ctx.session_id.as_str());
+    let backup_info = if session_path.exists() {
+        match storage::truncate_session(ctx.session_id.as_str(), keep) {
+            Ok(_) => " (disk session truncated, backup saved)",
+            Err(_) => " (disk session unchanged — see logs)",
+        }
+    } else {
+        " (in-memory only; session not yet persisted)"
+    };
+
+    Ok(CommandResult::Output(format!(
+        "Rewound to turn {} of {} — kept {} messages (was {}).{}",
+        turn,
+        anchors.len(),
+        keep,
+        before,
+        backup_info,
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bootstrap::SessionId;
+    use crate::types::app_state::AppState;
+    use crate::types::message::{AssistantMessage, UserMessage};
+    use std::path::{Path, PathBuf};
+    use uuid::Uuid;
+
+    struct HomeGuard {
+        previous: Option<String>,
+    }
+
+    impl HomeGuard {
+        fn set(path: &Path) -> Self {
+            let previous = std::env::var("CC_RUST_HOME").ok();
+            std::env::set_var("CC_RUST_HOME", path);
+            Self { previous }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(v) => std::env::set_var("CC_RUST_HOME", v),
+                None => std::env::remove_var("CC_RUST_HOME"),
+            }
+        }
+    }
+
+    fn user(text: &str) -> Message {
+        Message::User(UserMessage {
+            uuid: Uuid::new_v4(),
+            timestamp: 1_700_000_000_000,
+            role: "user".into(),
+            content: MessageContent::Text(text.into()),
+            is_meta: false,
+            tool_use_result: None,
+            source_tool_assistant_uuid: None,
+        })
+    }
+
+    fn assistant(text: &str) -> Message {
+        Message::Assistant(AssistantMessage {
+            uuid: Uuid::new_v4(),
+            timestamp: 1_700_000_000_000,
+            role: "assistant".into(),
+            content: vec![crate::types::message::ContentBlock::Text {
+                text: text.into(),
+            }],
+            usage: None,
+            stop_reason: Some("end_turn".into()),
+            is_api_error_message: false,
+            api_error: None,
+            cost_usd: 0.0,
+        })
+    }
+
+    fn tool_result_user(source_assistant: Uuid) -> Message {
+        Message::User(UserMessage {
+            uuid: Uuid::new_v4(),
+            timestamp: 1_700_000_000_000,
+            role: "user".into(),
+            content: MessageContent::Text("tool_result".into()),
+            is_meta: false,
+            tool_use_result: Some("ok".into()),
+            source_tool_assistant_uuid: Some(source_assistant),
+        })
+    }
+
+    fn test_ctx(id: &str, messages: Vec<Message>) -> CommandContext {
+        CommandContext {
+            messages,
+            cwd: PathBuf::from("/proj"),
+            app_state: AppState::default(),
+            session_id: SessionId::from_string(id),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rewind_empty_conversation() {
+        let mut ctx = test_ctx("empty", Vec::new());
+        let result = RewindHandler.execute("", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(t) => {
+                assert!(t.contains("No user turns"), "got: {}", t);
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rewind_list_numbers_turns() {
+        let msgs = vec![
+            user("first"),
+            assistant("answer 1"),
+            user("second"),
+            assistant("answer 2"),
+            user("third"),
+        ];
+        let mut ctx = test_ctx("list", msgs);
+        let result = RewindHandler.execute("list", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(t) => {
+                assert!(t.contains("Conversation turns (3)"));
+                assert!(t.contains("1.") && t.contains("first"));
+                assert!(t.contains("2.") && t.contains("second"));
+                assert!(t.contains("3.") && t.contains("third"));
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_rewind_to_turn_truncates_messages() {
+        let temp = tempfile::tempdir().unwrap();
+        let _g = HomeGuard::set(temp.path());
+
+        let msgs = vec![
+            user("first"),
+            assistant("answer 1"),
+            user("second"),
+            assistant("answer 2"),
+            user("third"),
+            assistant("answer 3"),
+        ];
+        let mut ctx = test_ctx("trunc", msgs);
+
+        let result = RewindHandler.execute("2", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(t) => {
+                assert!(t.contains("Rewound to turn 2"), "got: {}", t);
+            }
+            _ => panic!(),
+        }
+
+        // Kept: first user + answer 1 + second user + answer 2 == 4 messages.
+        assert_eq!(ctx.messages.len(), 4);
+        match &ctx.messages[2] {
+            Message::User(u) => match &u.content {
+                MessageContent::Text(s) => assert_eq!(s, "second"),
+                _ => panic!(),
+            },
+            _ => panic!(),
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_rewind_zero_clears_everything() {
+        let temp = tempfile::tempdir().unwrap();
+        let _g = HomeGuard::set(temp.path());
+
+        let mut ctx = test_ctx("zero", vec![user("first"), assistant("a")]);
+        let result = RewindHandler.execute("0", &mut ctx).await.unwrap();
+        assert!(matches!(result, CommandResult::Output(_)));
+        assert_eq!(ctx.messages.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_rewind_out_of_range() {
+        let mut ctx = test_ctx("oor", vec![user("only")]);
+        let result = RewindHandler.execute("99", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(t) => {
+                assert!(t.contains("out of range"), "got: {}", t);
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rewind_invalid_arg() {
+        let mut ctx = test_ctx("inv", vec![user("x")]);
+        let result = RewindHandler.execute("xyz", &mut ctx).await.unwrap();
+        match result {
+            CommandResult::Output(t) => {
+                assert!(t.contains("Unrecognized"), "got: {}", t);
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_rewind_to_by_uuid_prefix() {
+        let temp = tempfile::tempdir().unwrap();
+        let _g = HomeGuard::set(temp.path());
+
+        let msgs = vec![
+            user("first"),
+            assistant("a1"),
+            user("second"),
+            assistant("a2"),
+        ];
+        // Grab the uuid of the *second* anchor so we know the prefix exists.
+        let target_uuid = match &msgs[2] {
+            Message::User(u) => u.uuid.to_string(),
+            _ => unreachable!(),
+        };
+        let mut ctx = test_ctx("by_uuid", msgs);
+
+        let prefix = &target_uuid[..6];
+        let result = RewindHandler
+            .execute(&format!("--to {}", prefix), &mut ctx)
+            .await
+            .unwrap();
+        assert!(matches!(result, CommandResult::Output(_)));
+        // We keep up to (turn 2), which means we keep turn 1 + turn 2 = 4 messages.
+        assert_eq!(ctx.messages.len(), 4);
+    }
+
+    #[test]
+    fn test_collect_user_anchors_skips_tool_results() {
+        let assistant_msg = assistant("call tool");
+        let assistant_uuid = match &assistant_msg {
+            Message::Assistant(a) => a.uuid,
+            _ => unreachable!(),
+        };
+        let msgs = vec![
+            user("real"),
+            assistant_msg,
+            tool_result_user(assistant_uuid),
+            user("real again"),
+        ];
+        let anchors = collect_user_anchors(&msgs);
+        assert_eq!(anchors.len(), 2);
+        assert_eq!(anchors[0].preview, "real");
+        assert_eq!(anchors[1].preview, "real again");
+    }
+
+    #[test]
+    fn test_collect_user_anchors_skips_meta() {
+        let meta = Message::User(UserMessage {
+            uuid: Uuid::new_v4(),
+            timestamp: 0,
+            role: "user".into(),
+            content: MessageContent::Text("injected".into()),
+            is_meta: true,
+            tool_use_result: None,
+            source_tool_assistant_uuid: None,
+        });
+        let anchors = collect_user_anchors(&[meta, user("real")]);
+        assert_eq!(anchors.len(), 1);
+        assert_eq!(anchors[0].preview, "real");
+    }
+}

--- a/src/commands/session.rs
+++ b/src/commands/session.rs
@@ -55,11 +55,11 @@ fn format_session_table(
     lines.push(String::new());
     lines.push(format!(
         "  {:<38} {:>6}  {:<20}  {}",
-        "Session ID", "Msgs", "Last Modified", "Directory"
+        "Session ID", "Msgs", "Last Modified", "Title / Directory"
     ));
     lines.push(format!(
         "  {:<38} {:>6}  {:<20}  {}",
-        "----------", "----", "-------------", "---------"
+        "----------", "----", "-------------", "-----------------"
     ));
 
     for session in visible {
@@ -67,15 +67,24 @@ fn format_session_table(
             .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
             .unwrap_or_else(|| "unknown".into());
 
-        let dir = if session.cwd.len() > 40 {
-            format!("...{}", &session.cwd[session.cwd.len() - 37..])
+        let label = if !session.title.is_empty() {
+            let prefix = if session.custom_title.is_some() { "★ " } else { "" };
+            let max = 60;
+            let truncated: String = session.title.chars().take(max).collect();
+            if session.title.chars().count() > max {
+                format!("{}{}…", prefix, truncated)
+            } else {
+                format!("{}{}", prefix, truncated)
+            }
+        } else if session.cwd.len() > 60 {
+            format!("...{}", &session.cwd[session.cwd.len() - 57..])
         } else {
             session.cwd.clone()
         };
 
         lines.push(format!(
             "  {:<38} {:>6}  {:<20}  {}",
-            session.session_id, session.message_count, ts, dir
+            session.session_id, session.message_count, ts, label
         ));
     }
 
@@ -95,6 +104,17 @@ fn handle_show(ctx: &CommandContext) -> Result<CommandResult> {
     lines.push("Current session:".into());
     lines.push(String::new());
     lines.push(format!("  Session ID:        {}", ctx.session_id));
+    // Show the persisted title if we already have a session file — skip the
+    // disk read otherwise so freshly-started sessions don't pay for it.
+    if storage::get_session_file(ctx.session_id.as_str()).exists() {
+        if let Ok(info) = storage::load_session_info(ctx.session_id.as_str()) {
+            if let Some(custom) = info.custom_title.as_deref() {
+                lines.push(format!("  Title (custom):    {}", custom));
+            } else if !info.title.is_empty() {
+                lines.push(format!("  Title (auto):      {}", info.title));
+            }
+        }
+    }
     lines.push(format!("  Working directory: {}", cwd));
     lines.push(format!("  Messages:          {}", msg_count));
     lines.push(format!(

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -6,5 +6,6 @@
 pub mod langfuse;
 pub mod lsp_lifecycle;
 pub mod prompt_suggestion;
+pub mod session_analytics;
 pub mod session_memory;
 pub mod tool_use_summary;

--- a/src/services/session_analytics.rs
+++ b/src/services/session_analytics.rs
@@ -1,0 +1,625 @@
+//! Session analytics — cross-session statistics for the `/insights` command.
+//!
+//! This service walks the persisted session directory, optionally loads the
+//! bodies to tally token/cost usage, and produces a [`InsightsReport`] that
+//! the command wrapper renders as text. It is completely read-only: nothing
+//! here mutates sessions on disk.
+//!
+//! The analytics layer is intentionally thin. It does not batch API calls,
+//! generate model summaries, or write files — those are policy choices left
+//! to callers.
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+
+use crate::session::storage::{self, SessionInfo};
+use crate::types::message::Message;
+
+/// Filter + scoping controls for [`compute_insights`].
+#[derive(Debug, Clone)]
+pub struct InsightsFilter {
+    pub scope: Scope,
+    /// Inclusive lower bound (unix seconds) on `last_modified`.
+    pub since: Option<i64>,
+    /// Sessions with fewer than this many messages are skipped as "minimal".
+    pub min_messages: usize,
+    /// Number of largest sessions to surface in `largest_sessions`.
+    pub top_n: usize,
+    /// Whether to load each session to compute token / cost figures.
+    /// Disable for a faster metadata-only sweep.
+    pub include_usage: bool,
+}
+
+impl Default for InsightsFilter {
+    fn default() -> Self {
+        Self {
+            scope: Scope::All,
+            since: None,
+            min_messages: 2,
+            top_n: 5,
+            include_usage: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Scope {
+    /// All sessions on disk.
+    All,
+    /// Only sessions that belong to the same workspace as the supplied cwd.
+    Workspace(std::path::PathBuf),
+}
+
+/// Lightweight descriptor for the top-N session list in a report.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SessionSummary {
+    pub session_id: String,
+    pub title: String,
+    pub workspace_name: String,
+    pub message_count: usize,
+    pub last_modified: i64,
+}
+
+/// Aggregated statistics across the selected sessions.
+#[derive(Debug, Clone, Default)]
+pub struct InsightsReport {
+    pub session_count: usize,
+    /// How many sessions on disk were filtered out (scope/since/min_messages).
+    pub filtered_out: usize,
+    pub total_messages: u64,
+    pub total_user_messages: u64,
+    pub total_assistant_messages: u64,
+    pub total_input_tokens: u64,
+    pub total_output_tokens: u64,
+    pub total_cache_read_tokens: u64,
+    pub total_cache_creation_tokens: u64,
+    pub total_cost_usd: f64,
+    /// Oldest `last_modified` among included sessions.
+    pub oldest: Option<i64>,
+    /// Newest `last_modified` among included sessions.
+    pub newest: Option<i64>,
+    /// Sorted by session count descending.
+    pub workspace_breakdown: Vec<(String, usize)>,
+    /// Sorted by message_count descending.
+    pub largest_sessions: Vec<SessionSummary>,
+    /// True when `filter.include_usage` was honored — false when we skipped
+    /// the body scan.
+    pub usage_included: bool,
+}
+
+/// Compute aggregated analytics for every session that matches `filter`.
+pub fn compute_insights(filter: &InsightsFilter) -> Result<InsightsReport> {
+    let raw = match &filter.scope {
+        Scope::All => storage::list_sessions()?,
+        Scope::Workspace(cwd) => storage::list_workspace_sessions(cwd)?,
+    };
+
+    let total_scanned = raw.len();
+    let included: Vec<SessionInfo> = raw
+        .into_iter()
+        .filter(|s| passes(s, filter))
+        .collect();
+
+    let mut report = InsightsReport {
+        usage_included: filter.include_usage,
+        ..Default::default()
+    };
+    report.session_count = included.len();
+    report.filtered_out = total_scanned.saturating_sub(included.len());
+
+    // Workspace bucketing.
+    let mut buckets: HashMap<String, usize> = HashMap::new();
+    for s in &included {
+        let label = if s.workspace_name.is_empty() {
+            s.cwd.clone()
+        } else {
+            s.workspace_name.clone()
+        };
+        *buckets.entry(label).or_insert(0) += 1;
+    }
+    let mut breakdown: Vec<(String, usize)> = buckets.into_iter().collect();
+    breakdown.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    report.workspace_breakdown = breakdown;
+
+    for s in &included {
+        report.total_messages += s.message_count as u64;
+        report.oldest = Some(match report.oldest {
+            Some(prev) => prev.min(s.last_modified),
+            None => s.last_modified,
+        });
+        report.newest = Some(match report.newest {
+            Some(prev) => prev.max(s.last_modified),
+            None => s.last_modified,
+        });
+    }
+
+    if filter.include_usage {
+        for s in &included {
+            if let Ok(messages) = storage::load_session(&s.session_id) {
+                accumulate_usage(&messages, &mut report);
+            }
+        }
+    }
+
+    // Largest sessions (by message_count then last_modified).
+    let mut sorted = included;
+    sorted.sort_by(|a, b| {
+        b.message_count
+            .cmp(&a.message_count)
+            .then_with(|| b.last_modified.cmp(&a.last_modified))
+    });
+    report.largest_sessions = sorted
+        .into_iter()
+        .take(filter.top_n)
+        .map(|s| SessionSummary {
+            session_id: s.session_id,
+            title: if s.title.is_empty() {
+                "(untitled)".into()
+            } else {
+                s.title
+            },
+            workspace_name: s.workspace_name,
+            message_count: s.message_count,
+            last_modified: s.last_modified,
+        })
+        .collect();
+
+    Ok(report)
+}
+
+fn passes(s: &SessionInfo, filter: &InsightsFilter) -> bool {
+    if s.message_count < filter.min_messages {
+        return false;
+    }
+    if let Some(since) = filter.since {
+        if s.last_modified < since {
+            return false;
+        }
+    }
+    true
+}
+
+fn accumulate_usage(messages: &[Message], report: &mut InsightsReport) {
+    for msg in messages {
+        match msg {
+            Message::User(u) => {
+                // Don't count synthesized continuation messages (tool results).
+                if u.is_meta || u.tool_use_result.is_some() {
+                    continue;
+                }
+                report.total_user_messages += 1;
+            }
+            Message::Assistant(a) => {
+                report.total_assistant_messages += 1;
+                report.total_cost_usd += a.cost_usd;
+                if let Some(usage) = &a.usage {
+                    report.total_input_tokens += usage.input_tokens;
+                    report.total_output_tokens += usage.output_tokens;
+                    report.total_cache_read_tokens += usage.cache_read_input_tokens;
+                    report.total_cache_creation_tokens += usage.cache_creation_input_tokens;
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Render an [`InsightsReport`] as a terminal-friendly text block.
+///
+/// The caller decides whether to send the text to the user, stash it in a
+/// report artifact, etc.; this function deliberately has no side effects.
+pub fn format_report(report: &InsightsReport, label: &str) -> String {
+    let mut lines = Vec::new();
+    lines.push(format!("{}", label));
+    lines.push(String::new());
+    lines.push(format!("  Sessions included:   {}", report.session_count));
+    lines.push(format!("  Sessions filtered:   {}", report.filtered_out));
+    lines.push(format!("  Total messages:      {}", report.total_messages));
+    lines.push(format!(
+        "  User turns:          {}",
+        report.total_user_messages
+    ));
+    lines.push(format!(
+        "  Assistant turns:     {}",
+        report.total_assistant_messages
+    ));
+
+    if let (Some(oldest), Some(newest)) = (report.oldest, report.newest) {
+        lines.push(format!(
+            "  Activity span:       {} → {}",
+            fmt_ts(oldest),
+            fmt_ts(newest)
+        ));
+    }
+
+    if report.usage_included {
+        lines.push(String::new());
+        lines.push("  Token usage:".into());
+        lines.push(format!(
+            "    Input:             {}",
+            thousands(report.total_input_tokens)
+        ));
+        lines.push(format!(
+            "    Output:            {}",
+            thousands(report.total_output_tokens)
+        ));
+        lines.push(format!(
+            "    Cache read:        {}",
+            thousands(report.total_cache_read_tokens)
+        ));
+        lines.push(format!(
+            "    Cache creation:    {}",
+            thousands(report.total_cache_creation_tokens)
+        ));
+        lines.push(format!(
+            "  Estimated cost:      {}",
+            fmt_cost(report.total_cost_usd)
+        ));
+    } else {
+        lines.push(String::new());
+        lines.push("  (Usage stats skipped — rerun without --fast to load session bodies.)".into());
+    }
+
+    if !report.workspace_breakdown.is_empty() {
+        lines.push(String::new());
+        lines.push("  Sessions by workspace:".into());
+        for (name, count) in report.workspace_breakdown.iter().take(8) {
+            lines.push(format!("    {:<30} {}", truncate_inline(name, 30), count));
+        }
+        if report.workspace_breakdown.len() > 8 {
+            lines.push(format!(
+                "    ... and {} more",
+                report.workspace_breakdown.len() - 8
+            ));
+        }
+    }
+
+    if !report.largest_sessions.is_empty() {
+        lines.push(String::new());
+        lines.push("  Largest sessions:".into());
+        for s in &report.largest_sessions {
+            let ts = chrono::DateTime::from_timestamp(s.last_modified, 0)
+                .map(|dt| dt.format("%Y-%m-%d").to_string())
+                .unwrap_or_else(|| "unknown".into());
+            lines.push(format!(
+                "    [{}] {:>4} msgs  {}  {}",
+                &s.session_id.chars().take(8).collect::<String>(),
+                s.message_count,
+                ts,
+                truncate_inline(&s.title, 50),
+            ));
+        }
+    }
+
+    lines.join("\n")
+}
+
+fn fmt_ts(ts: i64) -> String {
+    chrono::DateTime::from_timestamp(ts, 0)
+        .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
+        .unwrap_or_else(|| format!("{}s", ts))
+}
+
+fn fmt_cost(usd: f64) -> String {
+    if usd < 0.01 {
+        format!("${:.4}", usd)
+    } else {
+        format!("${:.2}", usd)
+    }
+}
+
+fn thousands(n: u64) -> String {
+    if n == 0 {
+        return "0".into();
+    }
+    let s = n.to_string();
+    let mut out = String::new();
+    for (i, ch) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            out.push(',');
+        }
+        out.push(ch);
+    }
+    out.chars().rev().collect()
+}
+
+fn truncate_inline(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let shortened: String = s.chars().take(max.saturating_sub(1)).collect();
+    format!("{}…", shortened)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::storage::{SerializableMessage, SessionFile};
+    use std::path::{Path, PathBuf};
+
+    struct HomeGuard {
+        previous: Option<String>,
+    }
+
+    impl HomeGuard {
+        fn set(path: &Path) -> Self {
+            let previous = std::env::var("CC_RUST_HOME").ok();
+            std::env::set_var("CC_RUST_HOME", path);
+            Self { previous }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(v) => std::env::set_var("CC_RUST_HOME", v),
+                None => std::env::remove_var("CC_RUST_HOME"),
+            }
+        }
+    }
+
+    fn user_sm(uuid: &str) -> SerializableMessage {
+        SerializableMessage {
+            msg_type: "user".into(),
+            uuid: uuid.into(),
+            timestamp: 1_700_000_000,
+            data: serde_json::json!({ "content": "hi", "is_meta": false }),
+        }
+    }
+
+    fn assistant_sm(
+        uuid: &str,
+        input_tokens: u64,
+        output_tokens: u64,
+        cost: f64,
+    ) -> SerializableMessage {
+        SerializableMessage {
+            msg_type: "assistant".into(),
+            uuid: uuid.into(),
+            timestamp: 1_700_000_000,
+            data: serde_json::json!({
+                "content": [],
+                "usage": {
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "cache_read_input_tokens": 0u64,
+                    "cache_creation_input_tokens": 0u64,
+                },
+                "stop_reason": "end_turn",
+                "cost_usd": cost,
+            }),
+        }
+    }
+
+    fn write_session(
+        id: &str,
+        cwd: &str,
+        last_modified: i64,
+        messages: Vec<SerializableMessage>,
+    ) {
+        let file = SessionFile {
+            session_id: id.into(),
+            created_at: last_modified,
+            last_modified,
+            cwd: cwd.into(),
+            custom_title: None,
+            messages,
+        };
+        std::fs::create_dir_all(storage::get_session_dir()).unwrap();
+        let json = serde_json::to_string_pretty(&file).unwrap();
+        std::fs::write(storage::get_session_file(id), json).unwrap();
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn compute_insights_aggregates_across_sessions() {
+        let temp = tempfile::tempdir().unwrap();
+        let _g = HomeGuard::set(temp.path());
+
+        write_session(
+            "big",
+            "/proj-a",
+            1_700_000_100,
+            vec![
+                user_sm("11111111-0000-0000-0000-000000000001"),
+                assistant_sm("11111111-0000-0000-0000-000000000002", 100, 50, 0.01),
+                user_sm("11111111-0000-0000-0000-000000000003"),
+                assistant_sm("11111111-0000-0000-0000-000000000004", 200, 80, 0.02),
+            ],
+        );
+        write_session(
+            "small",
+            "/proj-b",
+            1_700_000_200,
+            vec![
+                user_sm("22222222-0000-0000-0000-000000000001"),
+                assistant_sm("22222222-0000-0000-0000-000000000002", 10, 5, 0.001),
+            ],
+        );
+        // Below min_messages — should be filtered out.
+        write_session(
+            "tiny",
+            "/proj-a",
+            1_700_000_050,
+            vec![user_sm("33333333-0000-0000-0000-000000000001")],
+        );
+
+        let report = compute_insights(&InsightsFilter::default()).unwrap();
+        assert_eq!(report.session_count, 2);
+        assert_eq!(report.filtered_out, 1);
+        assert_eq!(report.total_messages, 6);
+        assert_eq!(report.total_input_tokens, 310);
+        assert_eq!(report.total_output_tokens, 135);
+        assert!((report.total_cost_usd - 0.031).abs() < 1e-9);
+        assert_eq!(report.total_user_messages, 3);
+        assert_eq!(report.total_assistant_messages, 3);
+        assert_eq!(report.oldest, Some(1_700_000_100));
+        assert_eq!(report.newest, Some(1_700_000_200));
+        assert_eq!(report.largest_sessions.len(), 2);
+        assert_eq!(report.largest_sessions[0].session_id, "big");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn compute_insights_workspace_scope_filters_sessions() {
+        let temp = tempfile::tempdir().unwrap();
+        let _g = HomeGuard::set(temp.path());
+
+        let repo = temp.path().join("repo-x");
+        std::fs::create_dir_all(&repo).unwrap();
+        git2::Repository::init(&repo).unwrap();
+
+        write_session(
+            "in-repo",
+            repo.to_string_lossy().as_ref(),
+            1_700_000_100,
+            vec![
+                user_sm("44444444-0000-0000-0000-000000000001"),
+                assistant_sm("44444444-0000-0000-0000-000000000002", 1, 1, 0.0),
+            ],
+        );
+        write_session(
+            "elsewhere",
+            "/proj-c",
+            1_700_000_200,
+            vec![
+                user_sm("55555555-0000-0000-0000-000000000001"),
+                assistant_sm("55555555-0000-0000-0000-000000000002", 1, 1, 0.0),
+            ],
+        );
+
+        let filter = InsightsFilter {
+            scope: Scope::Workspace(repo.clone()),
+            ..Default::default()
+        };
+        let report = compute_insights(&filter).unwrap();
+        assert_eq!(report.session_count, 1);
+        assert_eq!(report.largest_sessions[0].session_id, "in-repo");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn compute_insights_since_filter_drops_old_sessions() {
+        let temp = tempfile::tempdir().unwrap();
+        let _g = HomeGuard::set(temp.path());
+
+        write_session(
+            "old",
+            "/p",
+            1_000,
+            vec![
+                user_sm("66666666-0000-0000-0000-000000000001"),
+                assistant_sm("66666666-0000-0000-0000-000000000002", 1, 1, 0.0),
+            ],
+        );
+        write_session(
+            "recent",
+            "/p",
+            2_000,
+            vec![
+                user_sm("77777777-0000-0000-0000-000000000001"),
+                assistant_sm("77777777-0000-0000-0000-000000000002", 1, 1, 0.0),
+            ],
+        );
+
+        let filter = InsightsFilter {
+            since: Some(1_500),
+            ..Default::default()
+        };
+        let report = compute_insights(&filter).unwrap();
+        assert_eq!(report.session_count, 1);
+        assert_eq!(report.largest_sessions[0].session_id, "recent");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn compute_insights_fast_mode_skips_usage() {
+        let temp = tempfile::tempdir().unwrap();
+        let _g = HomeGuard::set(temp.path());
+
+        write_session(
+            "any",
+            "/p",
+            1_000,
+            vec![
+                user_sm("88888888-0000-0000-0000-000000000001"),
+                assistant_sm("88888888-0000-0000-0000-000000000002", 99, 99, 1.0),
+            ],
+        );
+
+        let filter = InsightsFilter {
+            include_usage: false,
+            ..Default::default()
+        };
+        let report = compute_insights(&filter).unwrap();
+        assert_eq!(report.session_count, 1);
+        assert_eq!(report.total_input_tokens, 0);
+        assert_eq!(report.total_cost_usd, 0.0);
+        assert!(!report.usage_included);
+    }
+
+    #[test]
+    fn format_report_contains_expected_sections() {
+        let report = InsightsReport {
+            session_count: 2,
+            filtered_out: 3,
+            total_messages: 10,
+            total_user_messages: 4,
+            total_assistant_messages: 4,
+            total_input_tokens: 1_234,
+            total_output_tokens: 5_678,
+            total_cache_read_tokens: 0,
+            total_cache_creation_tokens: 0,
+            total_cost_usd: 0.12,
+            oldest: Some(1_700_000_000),
+            newest: Some(1_700_100_000),
+            workspace_breakdown: vec![("proj".into(), 2)],
+            largest_sessions: vec![SessionSummary {
+                session_id: "abcdef1234".into(),
+                title: "hello".into(),
+                workspace_name: "proj".into(),
+                message_count: 10,
+                last_modified: 1_700_100_000,
+            }],
+            usage_included: true,
+        };
+        let text = format_report(&report, "Session insights (all workspaces)");
+        assert!(text.contains("Session insights"));
+        assert!(text.contains("Sessions included:   2"));
+        assert!(text.contains("Token usage"));
+        assert!(text.contains("Input:"));
+        assert!(text.contains("Largest sessions"));
+        assert!(text.contains("hello"));
+    }
+
+    #[test]
+    fn thousands_formats_expected() {
+        assert_eq!(thousands(0), "0");
+        assert_eq!(thousands(999), "999");
+        assert_eq!(thousands(1_000), "1,000");
+        assert_eq!(thousands(1_234_567), "1,234,567");
+    }
+
+    #[test]
+    fn truncate_inline_uses_ellipsis() {
+        assert_eq!(truncate_inline("short", 10), "short");
+        let out = truncate_inline(&"x".repeat(100), 5);
+        assert_eq!(out.chars().count(), 5);
+        assert!(out.ends_with("…"));
+    }
+
+    #[test]
+    fn insights_filter_default_is_reasonable() {
+        let f = InsightsFilter::default();
+        assert!(matches!(f.scope, Scope::All));
+        assert_eq!(f.min_messages, 2);
+        assert!(f.include_usage);
+        // Cover the path-helper to keep it from going dead.
+        let _ = PathBuf::from(".");
+    }
+}

--- a/src/session/migrations.rs
+++ b/src/session/migrations.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 // ---------------------------------------------------------------------------
 
 /// Current session format version.
-pub const CURRENT_VERSION: u32 = 3;
+pub const CURRENT_VERSION: u32 = 4;
 
 /// Minimum version we can migrate from.
 pub const MIN_SUPPORTED_VERSION: u32 = 1;
@@ -43,6 +43,11 @@ fn all_migrations() -> Vec<Migration> {
             from_version: 2,
             description: "Normalize message content blocks",
             migrate: migrate_v2_to_v3,
+        },
+        Migration {
+            from_version: 3,
+            description: "Add optional custom_title field",
+            migrate: migrate_v3_to_v4,
         },
     ]
 }
@@ -197,6 +202,21 @@ fn normalize_message_content(msg: &mut Value) {
     }
 }
 
+/// V3 → V4: Introduce optional `custom_title` field for user-renamed sessions.
+///
+/// Sessions written before `/rename` existed did not carry the field; since
+/// serde marks it `#[serde(default)]` on load, the on-disk file is already
+/// forward-compatible. This migration simply stamps the format version so any
+/// consumer inspecting the `version` field knows the file has been surveyed.
+fn migrate_v3_to_v4(mut data: Value) -> Result<Value> {
+    if let Some(obj) = data.as_object_mut() {
+        obj.entry("custom_title".to_string())
+            .or_insert(Value::Null);
+        obj.insert("version".to_string(), Value::from(4u32));
+    }
+    Ok(data)
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -277,8 +297,33 @@ mod tests {
 
         let (result, log) = migrate_to_current(v1).unwrap();
         assert_eq!(result["version"], CURRENT_VERSION);
-        assert_eq!(log.len(), 2); // v1→v2, v2→v3
+        assert_eq!(log.len(), 3); // v1→v2, v2→v3, v3→v4
         assert!(result["messages"][0]["content"].is_array());
+        assert!(result.get("custom_title").is_some());
+    }
+
+    #[test]
+    fn test_migrate_v3_to_v4_adds_custom_title() {
+        let v3 = json!({
+            "version": 3,
+            "session_id": "xyz",
+            "messages": []
+        });
+        let v4 = migrate_v3_to_v4(v3).unwrap();
+        assert_eq!(v4["version"], 4);
+        assert!(v4.get("custom_title").is_some());
+        assert!(v4["custom_title"].is_null());
+    }
+
+    #[test]
+    fn test_migrate_v3_to_v4_preserves_existing_custom_title() {
+        let v3 = json!({
+            "version": 3,
+            "messages": [],
+            "custom_title": "My cool session"
+        });
+        let v4 = migrate_v3_to_v4(v3).unwrap();
+        assert_eq!(v4["custom_title"], "My cool session");
     }
 
     #[test]

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -31,9 +31,15 @@ pub struct SessionInfo {
     pub message_count: usize,
     /// Working directory at the time the session was created.
     pub cwd: String,
-    /// Derived title — first user message text, truncated. Empty if not computable.
+    /// Display title — prefers `custom_title` (set via `/rename`), falls back to
+    /// the derived title (first user message text, truncated). Empty when
+    /// neither is available.
     #[serde(default)]
     pub title: String,
+    /// Explicit user-assigned title, or `None` to fall back to the derived
+    /// title. Populated by `/rename` and persisted on the `SessionFile`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub custom_title: Option<String>,
     /// Stable grouping key for the workspace. Sessions sharing the same git
     /// common-dir (or canonical path for non-git dirs) get the same key.
     #[serde(default)]
@@ -53,6 +59,10 @@ pub struct SessionFile {
     pub created_at: i64,
     pub last_modified: i64,
     pub cwd: String,
+    /// Custom user-assigned title (via `/rename`). `None` means use the
+    /// auto-derived title from the first user message.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub custom_title: Option<String>,
     pub messages: Vec<SerializableMessage>,
 }
 
@@ -231,7 +241,13 @@ fn build_session_info(file: SessionFile) -> SessionInfo {
     let ws_root = workspace_root(cwd_path);
     let ws_key = workspace_key(cwd_path);
     let ws_name = workspace_name(&ws_root);
-    let title = derive_title(&file.messages);
+    let derived = derive_title(&file.messages);
+    let title = file
+        .custom_title
+        .as_ref()
+        .filter(|t| !t.is_empty())
+        .cloned()
+        .unwrap_or(derived);
     SessionInfo {
         session_id: file.session_id,
         created_at: file.created_at,
@@ -239,6 +255,7 @@ fn build_session_info(file: SessionFile) -> SessionInfo {
         message_count: file.messages.len(),
         cwd: file.cwd,
         title,
+        custom_title: file.custom_title,
         workspace_key: ws_key,
         workspace_root: ws_root.to_string_lossy().to_string(),
         workspace_name: ws_name,
@@ -276,13 +293,14 @@ pub fn save_session(session_id: &str, messages: &[Message], cwd: &str) -> Result
 
     let now = Utc::now().timestamp();
 
-    // Try to preserve the original created_at if we are updating.
-    let created_at = if path.exists() {
-        load_session_file(session_id)
-            .map(|f| f.created_at)
-            .unwrap_or(now)
+    // Preserve the original created_at and custom_title when updating.
+    let (created_at, custom_title) = if path.exists() {
+        match load_session_file(session_id) {
+            Ok(f) => (f.created_at, f.custom_title),
+            Err(_) => (now, None),
+        }
     } else {
-        now
+        (now, None)
     };
 
     let serializable_messages = messages_to_serializable(messages);
@@ -295,6 +313,7 @@ pub fn save_session(session_id: &str, messages: &[Message], cwd: &str) -> Result
         created_at,
         last_modified: now,
         cwd: stable_cwd,
+        custom_title,
         messages: serializable_messages,
     };
 
@@ -311,6 +330,105 @@ pub fn save_session(session_id: &str, messages: &[Message], cwd: &str) -> Result
     );
 
     Ok(())
+}
+
+/// Maximum length (in chars) for a custom session title.
+pub const MAX_CUSTOM_TITLE_LEN: usize = 200;
+
+/// Set or clear the user-assigned title for a session.
+///
+/// `title = None` clears the custom title (falling back to the auto-derived
+/// one). A non-empty title is trimmed and truncated to [`MAX_CUSTOM_TITLE_LEN`]
+/// characters before persistence.
+///
+/// Updates `last_modified` to the current time. Returns the final stored title
+/// (after trimming/truncation) or `None` if cleared.
+pub fn set_session_title(session_id: &str, title: Option<&str>) -> Result<Option<String>> {
+    let mut file = load_session_file(session_id)?;
+
+    let new_title = title.and_then(|raw| {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        let truncated: String = trimmed.chars().take(MAX_CUSTOM_TITLE_LEN).collect();
+        Some(truncated)
+    });
+
+    file.custom_title = new_title.clone();
+    file.last_modified = Utc::now().timestamp();
+
+    let path = get_session_file(session_id);
+    let json = serde_json::to_string_pretty(&file).context("Failed to serialize session")?;
+    std::fs::write(&path, json)
+        .with_context(|| format!("Failed to write session file {}", path.display()))?;
+
+    debug!(
+        session_id = session_id,
+        title = ?new_title,
+        "session title updated"
+    );
+
+    Ok(new_title)
+}
+
+/// Truncate the stored session to its first `keep` messages, producing a
+/// backup copy of the pre-truncation file for recovery.
+///
+/// Returns the new length after truncation. The backup is written next to the
+/// session file as `{session_id}.rewind-{epoch_seconds}.json`. When `keep`
+/// exceeds the current message count, this is a no-op and no backup is
+/// produced.
+///
+/// Use [`load_session`] afterwards to fetch the truncated messages.
+pub fn truncate_session(session_id: &str, keep: usize) -> Result<usize> {
+    let mut file = load_session_file(session_id)?;
+
+    if keep >= file.messages.len() {
+        return Ok(file.messages.len());
+    }
+
+    let backup_path = rewind_backup_path(session_id);
+    let original = serde_json::to_string_pretty(&file)
+        .context("Failed to serialize session for backup")?;
+    std::fs::write(&backup_path, original).with_context(|| {
+        format!(
+            "Failed to write rewind backup {}",
+            backup_path.display()
+        )
+    })?;
+
+    file.messages.truncate(keep);
+    file.last_modified = Utc::now().timestamp();
+    let new_len = file.messages.len();
+
+    let path = get_session_file(session_id);
+    let json = serde_json::to_string_pretty(&file).context("Failed to serialize session")?;
+    std::fs::write(&path, json)
+        .with_context(|| format!("Failed to write session file {}", path.display()))?;
+
+    debug!(
+        session_id = session_id,
+        kept = new_len,
+        backup = %backup_path.display(),
+        "session truncated"
+    );
+
+    Ok(new_len)
+}
+
+fn rewind_backup_path(session_id: &str) -> PathBuf {
+    let ts = Utc::now().timestamp();
+    get_session_dir().join(format!("{}.rewind-{}.json", session_id, ts))
+}
+
+/// Return the raw on-disk view of a single session file.
+///
+/// Useful for analytics and tooling that need the canonical view before
+/// rebuilding the derived [`SessionInfo`].
+pub fn load_session_info(session_id: &str) -> Result<SessionInfo> {
+    let file = load_session_file(session_id)?;
+    Ok(build_session_info(file))
 }
 
 /// Load a session from disk and return the messages.
@@ -592,6 +710,7 @@ mod tests {
                 message_count: messages,
                 cwd: normalize_display_path(cwd),
                 title: String::new(),
+                custom_title: None,
                 workspace_key: workspace_key(cwd),
                 workspace_root: workspace_root(cwd).to_string_lossy().to_string(),
                 workspace_name: workspace_name(&workspace_root(cwd)),
@@ -607,6 +726,184 @@ mod tests {
         let filtered = filter_sessions_for_workspace(sessions, &nested_dir);
         let ids: Vec<_> = filtered.into_iter().map(|s| s.session_id).collect();
         assert_eq!(ids, vec!["repo-root", "repo-nested"]);
+    }
+
+    // ------------------------------------------------------------------
+    // Round-trip tests for the new title / truncate / info APIs. These
+    // all pin CC_RUST_HOME to a tempdir and run serially so they cannot
+    // stomp on each other or on the user's real session directory.
+    // ------------------------------------------------------------------
+
+    struct HomeGuard {
+        previous: Option<String>,
+    }
+
+    impl HomeGuard {
+        fn set(path: &Path) -> Self {
+            let previous = std::env::var("CC_RUST_HOME").ok();
+            std::env::set_var("CC_RUST_HOME", path);
+            Self { previous }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(v) => std::env::set_var("CC_RUST_HOME", v),
+                None => std::env::remove_var("CC_RUST_HOME"),
+            }
+        }
+    }
+
+    fn write_fixture_session(
+        id: &str,
+        messages: Vec<SerializableMessage>,
+        cwd: &str,
+    ) -> Result<()> {
+        let file = SessionFile {
+            session_id: id.into(),
+            created_at: 1_700_000_000,
+            last_modified: 1_700_000_000,
+            cwd: cwd.into(),
+            custom_title: None,
+            messages,
+        };
+        std::fs::create_dir_all(get_session_dir())?;
+        let json = serde_json::to_string_pretty(&file)?;
+        std::fs::write(get_session_file(id), json)?;
+        Ok(())
+    }
+
+    fn user_sm(text: &str, uuid: &str) -> SerializableMessage {
+        SerializableMessage {
+            msg_type: "user".into(),
+            uuid: uuid.into(),
+            timestamp: 0,
+            data: serde_json::json!({ "content": text, "is_meta": false }),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_set_session_title_roundtrip() {
+        let temp = tempdir().unwrap();
+        let _g = HomeGuard::set(temp.path());
+
+        write_fixture_session(
+            "s1",
+            vec![user_sm("hello world", "00000000-0000-0000-0000-000000000001")],
+            "/proj",
+        )
+        .unwrap();
+
+        // Initially empty, derived title used.
+        let info = load_session_info("s1").unwrap();
+        assert_eq!(info.custom_title, None);
+        assert_eq!(info.title, "hello world");
+
+        // Set a custom title — preferred over derived.
+        let stored = set_session_title("s1", Some("  Renamed  ")).unwrap();
+        assert_eq!(stored.as_deref(), Some("Renamed"));
+        let info = load_session_info("s1").unwrap();
+        assert_eq!(info.custom_title.as_deref(), Some("Renamed"));
+        assert_eq!(info.title, "Renamed");
+
+        // save_session preserves custom_title even though the saver does not
+        // know about it.
+        save_session("s1", &[], "/proj").unwrap();
+        let info = load_session_info("s1").unwrap();
+        assert_eq!(info.custom_title.as_deref(), Some("Renamed"));
+
+        // Clear via explicit None.
+        let stored = set_session_title("s1", None).unwrap();
+        assert_eq!(stored, None);
+        let info = load_session_info("s1").unwrap();
+        assert_eq!(info.custom_title, None);
+
+        // Empty / whitespace also clears.
+        set_session_title("s1", Some("x")).unwrap();
+        let stored = set_session_title("s1", Some("   ")).unwrap();
+        assert_eq!(stored, None);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_set_session_title_truncates_long_input() {
+        let temp = tempdir().unwrap();
+        let _g = HomeGuard::set(temp.path());
+
+        write_fixture_session(
+            "s2",
+            vec![user_sm("x", "00000000-0000-0000-0000-000000000002")],
+            "/proj",
+        )
+        .unwrap();
+
+        let long = "a".repeat(MAX_CUSTOM_TITLE_LEN + 50);
+        let stored = set_session_title("s2", Some(&long)).unwrap().unwrap();
+        assert_eq!(stored.chars().count(), MAX_CUSTOM_TITLE_LEN);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_truncate_session_keeps_prefix_and_writes_backup() {
+        let temp = tempdir().unwrap();
+        let _g = HomeGuard::set(temp.path());
+
+        let messages = (0..5)
+            .map(|i| {
+                user_sm(
+                    &format!("msg {}", i),
+                    &format!("00000000-0000-0000-0000-00000000000{}", i),
+                )
+            })
+            .collect();
+        write_fixture_session("s3", messages, "/proj").unwrap();
+
+        let new_len = truncate_session("s3", 2).unwrap();
+        assert_eq!(new_len, 2);
+
+        let info = load_session_info("s3").unwrap();
+        assert_eq!(info.message_count, 2);
+
+        // Backup file must exist alongside the session.
+        let backup_count = std::fs::read_dir(get_session_dir())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with("s3.rewind-")
+            })
+            .count();
+        assert_eq!(backup_count, 1);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_truncate_session_noop_when_keep_exceeds_len() {
+        let temp = tempdir().unwrap();
+        let _g = HomeGuard::set(temp.path());
+
+        write_fixture_session(
+            "s4",
+            vec![user_sm("only", "00000000-0000-0000-0000-000000000010")],
+            "/proj",
+        )
+        .unwrap();
+
+        let new_len = truncate_session("s4", 99).unwrap();
+        assert_eq!(new_len, 1);
+        let backups: Vec<_> = std::fs::read_dir(get_session_dir())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with("s4.rewind-")
+            })
+            .collect();
+        assert!(backups.is_empty(), "expected no backup when no truncation");
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
## Summary

Extends session persistence with an optional `custom_title` field and adds three new slash commands that all share the same schema change, so the on-disk format only moves once.

Closes #52, #53, #57.

## What's new

### Schema (single schema bump, v3 → v4)

- `SessionFile` and `SessionInfo` gain `custom_title: Option<String>` (`#[serde(default, skip_serializing_if)]`, so older files still load and newer files stay compact when the title is unset).
- `save_session` preserves an existing `custom_title` on update.
- New storage APIs:
  - `set_session_title(session_id, Option<&str>) -> Result<Option<String>>` — trims, truncates to `MAX_CUSTOM_TITLE_LEN` (200), clears on `None`/empty.
  - `truncate_session(session_id, keep) -> Result<usize>` — keeps the first `keep` messages and writes a `{session_id}.rewind-<ts>.json` backup alongside the session file. No-op when `keep >= len`.
  - `load_session_info(session_id)` — canonical per-session view used by the analytics service and commands.
- `migrations.rs` gets a `v3_to_v4` step that stamps the format version (loading is already backward-compatible via serde).

### `/rename` (#52)

- `/rename` — show current title (custom ★ vs auto) with a usage hint.
- `/rename <title>` — pin a custom title.
- `/rename --auto` — pin the currently-derived auto title.
- `/rename --clear` — drop the custom title, fall back to auto-derived.
- Ensures the session file exists before mutating it (first-save for brand-new sessions).

### `/rewind` (#53)

- `/rewind` / `/rewind list` — numbered list of user turns with a UUID prefix, timestamp, and preview.
- `/rewind <n>` — truncate the conversation in-memory (which the ingress layer mirrors to the engine via `conversation_changed`) **and** on disk.
- `/rewind --to <uuid-prefix>` — rewind by user-message UUID prefix, with ambiguous-prefix and not-found feedback.
- `/rewind 0` — rewind to empty.
- Anchors skip `is_meta` and synthetic tool-result user messages, so only real user turns count.
- The on-disk backup (`*.rewind-<ts>.json`) satisfies the "preserving recoverable metadata" acceptance.

### `/insights` (#57)

New `services::session_analytics` module (the shared analytics service the issue asks for):

- `compute_insights(&InsightsFilter)` — scope: All or Workspace(cwd); filters: `since`, `min_messages`, `top_n`, `include_usage`.
- Aggregates: total messages (with user/assistant split), token usage (input/output/cache read/creation), cost, activity span, top-N largest sessions, sessions-per-workspace.
- `format_report(&report, label)` — terminal-friendly text renderer (pure, no side effects).

`/insights` command wraps it with:

- `/insights` — all sessions with usage stats.
- `/insights this` — current workspace only.
- `/insights recent [days]` — last N days (default 30).
- `/insights fast` — metadata-only sweep (no body scan).

### Misc UX

`/session` now surfaces the resolved title (custom/auto) for the current session and shows a `★` marker next to renamed sessions in the listings.

## Testing

- New/extended tests: **49** total
  - `commands::rename` — 7
  - `commands::rewind` — 9
  - `commands::insights` — 5
  - `services::session_analytics` — 8
  - `session::storage` — 4 new (round-trip title, long-title truncation, rewind backup, rewind no-op)
  - `session::migrations` — 2 new (v3→v4 add, preserve existing)
  - Updated `test_migrate_to_current_from_v1` for the new migration count.
- All env-var tests gate on `#[serial_test::serial]` with a local `HomeGuard` and a `tempdir` CC_RUST_HOME.
- Full suites single-threaded: commands 227, session 98, services 55 — all green.
- No new compiler warnings from the new/edited files.

## Test plan

- [ ] `cargo test --bin claude-code-rs commands::rename`
- [ ] `cargo test --bin claude-code-rs commands::rewind`
- [ ] `cargo test --bin claude-code-rs commands::insights`
- [ ] `cargo test --bin claude-code-rs services::session_analytics`
- [ ] `cargo test --bin claude-code-rs session::storage`
- [ ] `cargo test --bin claude-code-rs session::migrations`
- [ ] Manually: `/rename Foo`, `/session`, `/rewind`, `/rewind 2`, `/insights this`, `/insights recent 7`.
- [ ] Verify `*.rewind-<ts>.json` backup appears next to the truncated session file.

## Notes for reviewers

- Because the original issue #48 (`/recap` long form) is already closed, it's out of scope here.
- The web-ui build emits a harmless pre-existing warning locally when `web-ui/dist/` is missing; I didn't touch that path.
- Two unrelated tests (`commands::config_cmd::test_config_set_model_in_memory`, `commands::model_add::test_model_add_unknown_model_no_price_errors`) are flaky under parallel execution because they mutate `CC_RUST_HOME` without `serial_test`. Confirmed pre-existing via stash — not introduced by this PR. Worth tagging them `#[serial_test::serial]` in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)