### PR TITLE
chore(deps): feature-gate heavyweight optional dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,24 +18,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aligned"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
-dependencies = [
- "as-slice",
-]
-
-[[package]]
-name = "aligned-vec"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
-dependencies = [
- "equator",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,36 +89,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-
-[[package]]
-name = "arg_enum_proc_macro"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "as-slice"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
-dependencies = [
- "stable_deref_trait",
-]
 
 [[package]]
 name = "assert_cmd"
@@ -334,49 +290,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "av-scenechange"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
-dependencies = [
- "aligned",
- "anyhow",
- "arg_enum_proc_macro",
- "arrayvec",
- "log",
- "num-rational",
- "num-traits",
- "pastey",
- "rayon",
- "thiserror 2.0.18",
- "v_frame",
- "y4m",
-]
-
-[[package]]
-name = "av1-grain"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
-dependencies = [
- "anyhow",
- "arrayvec",
- "log",
- "nom 8.0.0",
- "num-rational",
- "v_frame",
-]
-
-[[package]]
-name = "avif-serialize"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,10 +360,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit_field"
-version = "0.10.3"
+name = "bit-set"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -463,15 +385,6 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
-
-[[package]]
-name = "bitstream-io"
-version = "4.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
-dependencies = [
- "no_std_io2",
-]
 
 [[package]]
 name = "block-buffer"
@@ -514,12 +427,6 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
-
-[[package]]
-name = "built"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
 
 [[package]]
 name = "bumpalo"
@@ -714,12 +621,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,12 +741,6 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1023,26 +918,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
-name = "equator"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
-dependencies = [
- "equator-macro",
-]
-
-[[package]]
-name = "equator-macro"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,23 +961,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
 dependencies = [
  "futures-core",
- "nom 7.1.3",
+ "nom",
  "pin-project-lite",
 ]
 
 [[package]]
-name = "exr"
-version = "1.74.0"
+name = "fancy-regex"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
 dependencies = [
- "bit_field",
- "half",
- "lebe",
- "miniz_oxide",
- "rayon-core",
- "smallvec",
- "zune-inflate",
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1110,26 +981,6 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
-name = "fax"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
-dependencies = [
- "fax_derive",
-]
-
-[[package]]
-name = "fax_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "fdeflate"
@@ -1378,16 +1229,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gif"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
-dependencies = [
- "color_quant",
- "weezl",
-]
-
-[[package]]
 name = "git2"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,17 +1271,6 @@ dependencies = [
  "bitflags 2.11.1",
  "ignore",
  "walkdir",
-]
-
-[[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
 ]
 
 [[package]]
@@ -1755,37 +1585,12 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
- "color_quant",
- "exr",
- "gif",
- "image-webp",
  "moxcms",
  "num-traits",
  "png",
- "qoi",
- "ravif",
- "rayon",
- "rgb",
- "tiff",
  "zune-core",
  "zune-jpeg",
 ]
-
-[[package]]
-name = "image-webp"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
-dependencies = [
- "byteorder-lite",
- "quick-error",
-]
-
-[[package]]
-name = "imgref"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
 name = "indexmap"
@@ -1816,17 +1621,6 @@ checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
  "darling",
  "indoc",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "interpolate_name"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn",
@@ -1923,26 +1717,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
-name = "lebe"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
-
-[[package]]
 name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
-
-[[package]]
-name = "libfuzzer-sys"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
-dependencies = [
- "arbitrary",
- "cc",
-]
 
 [[package]]
 name = "libgit2-sys"
@@ -2018,15 +1796,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "loop9"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
-dependencies = [
- "imgref",
-]
-
-[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,16 +1843,6 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
-
-[[package]]
-name = "maybe-rayon"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
-dependencies = [
- "cfg-if",
- "rayon",
-]
 
 [[package]]
 name = "memchr"
@@ -2172,12 +1931,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
 name = "nix"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2190,15 +1943,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "no_std_io2"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2207,21 +1951,6 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
-
-[[package]]
-name = "nom"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "noop_proc_macro"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "normalize-line-endings"
@@ -2253,51 +1982,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
-
-[[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
-]
 
 [[package]]
 name = "num-traits"
@@ -2358,28 +2046,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "onig"
-version = "6.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
-dependencies = [
- "bitflags 2.11.1",
- "libc",
- "once_cell",
- "onig_sys",
-]
-
-[[package]]
-name = "onig_sys"
-version = "69.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
-dependencies = [
- "cc",
- "pkg-config",
-]
 
 [[package]]
 name = "openssl"
@@ -2570,12 +2236,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pastey"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "percent-encoding"
@@ -2770,25 +2430,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "profiling"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
-dependencies = [
- "profiling-procmacros",
-]
-
-[[package]]
-name = "profiling-procmacros"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2835,21 +2476,6 @@ name = "pxfm"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
-
-[[package]]
-name = "qoi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -2971,76 +2597,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rav1e"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
-dependencies = [
- "aligned-vec",
- "arbitrary",
- "arg_enum_proc_macro",
- "arrayvec",
- "av-scenechange",
- "av1-grain",
- "bitstream-io",
- "built",
- "cfg-if",
- "interpolate_name",
- "itertools 0.14.0",
- "libc",
- "libfuzzer-sys",
- "log",
- "maybe-rayon",
- "new_debug_unreachable",
- "noop_proc_macro",
- "num-derive",
- "num-traits",
- "paste",
- "profiling",
- "rand 0.9.4",
- "rand_chacha 0.9.0",
- "simd_helpers",
- "thiserror 2.0.18",
- "v_frame",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "ravif"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
-dependencies = [
- "avif-serialize",
- "imgref",
- "loop9",
- "quick-error",
- "rav1e",
- "rayon",
- "rgb",
-]
-
-[[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3128,12 +2684,6 @@ dependencies = [
  "wasm-streams",
  "web-sys",
 ]
-
-[[package]]
-name = "rgb"
-version = "0.8.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "ring"
@@ -3527,15 +3077,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
-name = "simd_helpers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
-dependencies = [
- "quote",
-]
-
-[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3668,10 +3209,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
 dependencies = [
  "bincode",
+ "fancy-regex",
  "flate2",
  "fnv",
  "once_cell",
- "onig",
  "plist",
  "regex-syntax",
  "serde",
@@ -3774,20 +3315,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiff"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
-dependencies = [
- "fax",
- "flate2",
- "half",
- "quick-error",
- "weezl",
- "zune-jpeg",
-]
-
-[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3837,7 +3364,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -4312,17 +3838,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "v_frame"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
-dependencies = [
- "aligned-vec",
- "num-traits",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4573,12 +4088,6 @@ checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
-
-[[package]]
-name = "weezl"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "which"
@@ -4999,12 +4508,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
-name = "y4m"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
-
-[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5188,15 +4691,6 @@ name = "zune-core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
-
-[[package]]
-name = "zune-inflate"
-version = "0.2.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
-dependencies = [
- "simd-adler32",
-]
 
 [[package]]
 name = "zune-jpeg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,51 @@ edition = "2021"
 description = "Claude Code CLI - Rust implementation (lite)"
 
 # ============================================================
+# Features
+# ============================================================
+#
+# default — minimal build: no telemetry, no embedded web assets,
+#           no image/syntect/tree-sitter pulls. Keeps `cargo build`
+#           fast and avoids heavy native deps (onig, tonic/prost).
+#
+# Opt-in:
+#   telemetry   — Langfuse + OpenTelemetry export (pulls tonic/prost).
+#   web-ui      — Embed the React SPA (rust-embed) into the binary.
+#   image       — Image decoding (png/jpeg only).
+#   syntect     — Syntax highlighting via fancy-regex (no onig C dep).
+#   tree-sitter — AST parsing.
+
+[features]
+default = []
+telemetry = [
+    "dep:tracing-opentelemetry",
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-langfuse",
+]
+web-ui = ["dep:rust-embed"]
+image = ["dep:image"]
+syntect = ["dep:syntect"]
+tree-sitter = ["dep:tree-sitter"]
+
+# ============================================================
 # 核心类型 + 状态机
 # ============================================================
 
 [dependencies]
-# 异步运行时
-tokio = { version = "1", features = ["full"] }
+# 异步运行时 — 按需选择 tokio 子模块，避免 `full` 带来的编译开销
+tokio = { version = "1", default-features = false, features = [
+    "rt-multi-thread",
+    "macros",
+    "io-util",
+    "io-std",
+    "net",
+    "fs",
+    "process",
+    "signal",
+    "sync",
+    "time",
+] }
 futures = "0.3"
 async-trait = "0.1"
 async-stream = "0.3"
@@ -41,10 +80,12 @@ lru = "0.12"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
-tracing-opentelemetry = "0.32.1"
-opentelemetry = { version = "0.31", features = ["trace"] }
-opentelemetry_sdk = { version = "0.31.0", features = ["trace", "rt-tokio", "experimental_trace_batch_span_processor_with_async_runtime"] }
-opentelemetry-langfuse = "0.6.1"
+# Telemetry stack (Langfuse + OpenTelemetry) — optional, enable via `telemetry` feature.
+# Pulls in tonic/prost et al., which is why it is off by default.
+tracing-opentelemetry = { version = "0.32.1", optional = true }
+opentelemetry = { version = "0.31", features = ["trace"], optional = true }
+opentelemetry_sdk = { version = "0.31.0", features = ["trace", "rt-tokio", "experimental_trace_batch_span_processor_with_async_runtime"], optional = true }
+opentelemetry-langfuse = { version = "0.6.1", optional = true }
 
 # LSP 协议类型
 lsp-types = "0.97"
@@ -78,8 +119,8 @@ shell-words = "1"
 ratatui = "0.29"
 crossterm = "0.28"
 
-# 语法高亮
-syntect = "5"
+# 语法高亮 — optional，启用 default-fancy 用 fancy-regex 代替 onig (避免 C 编译)
+syntect = { version = "5", default-features = false, features = ["default-fancy"], optional = true }
 
 # 文本处理
 textwrap = "0.16"
@@ -124,13 +165,13 @@ tower-http = { version = "0.6", features = ["cors", "trace"] }
 hmac = "0.12"
 notify-rust = "4"
 
-# Web UI: embed React SPA dist/ at compile time
-rust-embed = "8"
+# Web UI: embed React SPA dist/ at compile time — optional, enable via `web-ui` feature.
+rust-embed = { version = "8", optional = true }
 mime_guess = "2"
 
-# AST / 图像
-tree-sitter = "0.24"
-image = "0.25"
+# AST / 图像 — optional，默认不编译 (目前无使用点)
+tree-sitter = { version = "0.24", optional = true }
+image = { version = "0.25", default-features = false, features = ["png", "jpeg"], optional = true }
 
 # ============================================================
 # E2E 测试

--- a/src/services/langfuse/mod.rs
+++ b/src/services/langfuse/mod.rs
@@ -2,15 +2,34 @@
 //!
 //! This module keeps Langfuse-specific wiring out of the business logic and
 //! exposes a small set of helpers for lifecycle boundaries (submit/model/tool).
+//!
+//! The real telemetry path lives behind the `telemetry` feature. When that
+//! feature is disabled, `stub` provides drop-in no-op types and functions
+//! with identical signatures so call sites don't need `#[cfg]` guards.
 
-pub mod client;
 pub mod convert;
 pub mod sanitize;
+
+#[cfg(feature = "telemetry")]
+pub mod client;
+#[cfg(feature = "telemetry")]
 pub mod tracing;
 
+#[cfg(not(feature = "telemetry"))]
+mod stub;
+
+#[cfg(feature = "telemetry")]
 pub use client::{init_langfuse, shutdown_langfuse};
+#[cfg(feature = "telemetry")]
 pub use tracing::{
     create_generation_span, create_subagent_trace, create_tool_batch_span, create_tool_span,
     create_trace, end_span, end_trace, finish_generation_span, finish_tool_span, LangfuseSpan,
     LangfuseTrace, TraceStatus,
+};
+
+#[cfg(not(feature = "telemetry"))]
+pub use stub::{
+    create_generation_span, create_subagent_trace, create_tool_batch_span, create_tool_span,
+    create_trace, end_span, end_trace, finish_generation_span, finish_tool_span, shutdown_langfuse,
+    LangfuseSpan, LangfuseTrace, TraceStatus,
 };

--- a/src/services/langfuse/sanitize.rs
+++ b/src/services/langfuse/sanitize.rs
@@ -1,5 +1,8 @@
+#[cfg(feature = "telemetry")]
 use serde::Serialize;
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value};
+#[cfg(any(test, feature = "telemetry"))]
+use serde_json::json;
 
 const MAX_TEXT_LEN: usize = 40_000;
 const MAX_TOOL_OUTPUT_LEN: usize = 500;
@@ -18,6 +21,9 @@ const SENSITIVE_KEYWORDS: &[&str] = &[
     "authorization",
 ];
 
+/// Only consumed by the OpenTelemetry-backed tracing path; the compiler
+/// would otherwise flag it as dead code for default builds.
+#[cfg(feature = "telemetry")]
 pub fn sanitize_global<T: Serialize>(value: &T) -> Value {
     match serde_json::to_value(value) {
         Ok(value) => sanitize_global_value(&value),
@@ -45,6 +51,7 @@ pub fn sanitize_global_string(value: &str) -> String {
     truncate_string(&replace_home_dir(value), MAX_TEXT_LEN)
 }
 
+#[cfg(feature = "telemetry")]
 pub fn sanitize_tool_input(tool_name: &str, input: &Value) -> Value {
     let _ = tool_name;
     sanitize_global_value(input)
@@ -81,6 +88,7 @@ pub fn serialize_sanitized_value(value: &Value) -> String {
     }
 }
 
+#[cfg(feature = "telemetry")]
 pub fn metadata_json(entries: Vec<(&str, Value)>) -> String {
     let mut map = Map::new();
     for (key, value) in entries {

--- a/src/services/langfuse/stub.rs
+++ b/src/services/langfuse/stub.rs
@@ -1,0 +1,101 @@
+//! No-op Langfuse surface used when the `telemetry` feature is disabled.
+//!
+//! Keeps the public API that call sites in `engine::lifecycle`, `query::*`, and
+//! `main.rs` depend on, so gating telemetry does not require `#[cfg]` at every
+//! call site — the compiler simply folds these stubs away.
+
+use serde_json::Value;
+
+use crate::types::message::Usage;
+
+/// No-op trace handle. Holds a `session_id` string only because some call
+/// sites read it to stamp downstream context — the real impl exposes the
+/// same field.
+#[derive(Clone, Debug, Default)]
+pub struct LangfuseTrace {
+    pub session_id: String,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct LangfuseSpan;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TraceStatus {
+    Error,
+}
+
+pub fn shutdown_langfuse() {}
+
+pub fn create_trace(
+    _session_id: &str,
+    _model: &str,
+    _provider: &str,
+    _input: &str,
+    _query_source: Option<&str>,
+) -> Option<LangfuseTrace> {
+    None
+}
+
+pub fn create_subagent_trace(
+    _session_id: &str,
+    _agent_type: &str,
+    _agent_id: &str,
+    _model: &str,
+    _provider: &str,
+    _input: &str,
+) -> Option<LangfuseTrace> {
+    None
+}
+
+pub fn create_generation_span(
+    _root: &LangfuseTrace,
+    _model: &str,
+    _provider: &str,
+    _input: Value,
+) -> Option<LangfuseSpan> {
+    None
+}
+
+pub fn finish_generation_span(
+    _span: Option<LangfuseSpan>,
+    _output: Option<Value>,
+    _usage: Option<&Usage>,
+    _ttft_ms: Option<u64>,
+    _error: Option<&str>,
+) {
+}
+
+pub fn create_tool_span(
+    _root: &LangfuseTrace,
+    _tool_name: &str,
+    _tool_use_id: &str,
+    _input: &Value,
+    _parent_batch_span: Option<&LangfuseSpan>,
+) -> Option<LangfuseSpan> {
+    None
+}
+
+pub fn finish_tool_span(
+    _span: Option<LangfuseSpan>,
+    _tool_name: &str,
+    _output: &str,
+    _is_error: bool,
+) {
+}
+
+pub fn create_tool_batch_span(
+    _root: &LangfuseTrace,
+    _tool_names: &[String],
+    _batch_index: usize,
+) -> Option<LangfuseSpan> {
+    None
+}
+
+pub fn end_span(_span: Option<LangfuseSpan>) {}
+
+pub fn end_trace(
+    _trace: Option<LangfuseTrace>,
+    _output: Option<&str>,
+    _status: Option<TraceStatus>,
+) {
+}

--- a/src/startup/logging.rs
+++ b/src/startup/logging.rs
@@ -70,20 +70,26 @@ pub fn init_tracing(verbose: bool) -> WorkerGuard {
                 )),
         );
 
-    match crate::services::langfuse::init_langfuse() {
-        Ok(Some(tracer)) => {
-            let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
-            subscriber.with(telemetry).init();
-        }
-        Ok(None) => subscriber.init(),
-        Err(error) => {
-            eprintln!(
-                "warning: failed to initialize Langfuse tracing: {}. Continuing without Langfuse.",
-                error
-            );
-            subscriber.init();
+    #[cfg(feature = "telemetry")]
+    {
+        match crate::services::langfuse::init_langfuse() {
+            Ok(Some(tracer)) => {
+                let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+                subscriber.with(telemetry).init();
+            }
+            Ok(None) => subscriber.init(),
+            Err(error) => {
+                eprintln!(
+                    "warning: failed to initialize Langfuse tracing: {}. Continuing without Langfuse.",
+                    error
+                );
+                subscriber.init();
+            }
         }
     }
+
+    #[cfg(not(feature = "telemetry"))]
+    subscriber.init();
 
     guard
 }

--- a/src/web/static_files.rs
+++ b/src/web/static_files.rs
@@ -1,11 +1,19 @@
 //! Embedded static file serving for the React SPA.
+//!
+//! Only compiles the embedded-asset path when the `web-ui` feature is enabled
+//! (which pulls in `rust-embed`). Without the feature, the fallback responds
+//! with a message explaining how to build the UI or enable the feature — the
+//! Axum router stays valid either way.
 
 use axum::{
     http::{header, StatusCode, Uri},
     response::IntoResponse,
 };
+
+#[cfg(feature = "web-ui")]
 use rust_embed::Embed;
 
+#[cfg(feature = "web-ui")]
 #[derive(Embed)]
 #[folder = "web-ui/dist"]
 struct WebAssets;
@@ -18,7 +26,8 @@ pub async fn static_handler(uri: Uri) -> impl IntoResponse {
     serve_embedded_file(path)
 }
 
-fn serve_embedded_file(path: &str) -> impl IntoResponse {
+#[cfg(feature = "web-ui")]
+fn serve_embedded_file(path: &str) -> axum::response::Response {
     match WebAssets::get(path) {
         Some(file) => {
             let mime = mime_guess::from_path(path).first_or_octet_stream();
@@ -46,4 +55,14 @@ fn serve_embedded_file(path: &str) -> impl IntoResponse {
             }
         }
     }
+}
+
+#[cfg(not(feature = "web-ui"))]
+fn serve_embedded_file(_path: &str) -> axum::response::Response {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        [(header::CONTENT_TYPE, "text/plain".to_string())],
+        "Web UI assets are not bundled in this build. Rebuild with `--features web-ui` to embed the SPA.",
+    )
+        .into_response()
 }


### PR DESCRIPTION
## Summary

- Slim the default build by narrowing `tokio` features and moving heavy/unused crates behind opt-in features: `telemetry`, `web-ui`, `image`, `syntect`, `tree-sitter`.
- Default `cargo build` now avoids `opentelemetry` + `tonic` + `prost`, `onig` (via `syntect`), `rust-embed`, and the full `image` decoder stack — none of which have active call sites today.
- Langfuse call sites (~20 across `engine/`, `query/`, `main.rs`) stay unchanged; a new stub module provides no-op types/functions when `telemetry` is off, so gating did not require per-call `#[cfg]` guards.

## Changes

**Cargo.toml**
- New `[features]` block. `default = []`. Opt-in: `telemetry`, `web-ui`, `image`, `syntect`, `tree-sitter`.
- `tokio`: `default-features = false`, explicit feature list (`rt-multi-thread`, `macros`, `io-util`, `io-std`, `net`, `fs`, `process`, `signal`, `sync`, `time`). `io-std` is included because `ipc/runtime.rs` and `browser/{native_host,mcp_bridge}.rs` use `tokio::io::{stdin, stdout}`.
- `image`: `default-features = false`, `features = ["png", "jpeg"]`, `optional = true`.
- `syntect`: `default-features = false`, `features = ["default-fancy"]` (fancy-regex in place of C `onig`), `optional = true`.
- `tree-sitter`, `rust-embed`: `optional = true`.
- `opentelemetry`, `opentelemetry_sdk`, `opentelemetry-langfuse`, `tracing-opentelemetry`: all `optional = true`, gated by the `telemetry` feature.
- `git2` already had `default-features = false, features = ["https"]` — left as-is.

**Code**
- `src/services/langfuse/mod.rs` — routes the public API to the real client/tracing modules when `telemetry` is on, or to a new `stub` module otherwise.
- `src/services/langfuse/stub.rs` (new) — noop `LangfuseTrace` / `LangfuseSpan` / `TraceStatus` and matching-signature functions. `LangfuseTrace.session_id` is preserved because `engine/lifecycle/deps.rs` reads it.
- `src/services/langfuse/sanitize.rs` — gate the telemetry-only helpers (`sanitize_global`, `sanitize_tool_input`, `metadata_json`) and their imports so default builds don't flag them as dead code.
- `src/startup/logging.rs` — OpenTelemetry layer attachment gated; default path just initializes the stderr + rolling-file subscriber.
- `src/web/static_files.rs` — `rust_embed::Embed` derive + asset lookup gated behind `web-ui`; without the feature the fallback returns 503 with build instructions, keeping the Axum router valid.

## Verification

| Build | Result | Notes |
|---|---|---|
| `cargo check` (default) | ✅ | 0 new warnings; dep graph has no `opentelemetry`, `tonic`, `prost`, `onig`, `rust-embed`, `syntect`, `image`, `tree-sitter`. |
| `cargo check --features telemetry` | ✅ | Pulls `opentelemetry-otlp`, `prost`, `tonic` as expected. |
| `cargo check --features "telemetry web-ui image syntect tree-sitter"` | ✅ | `syntect` resolves to `fancy-regex` (no `onig`); `image` pulls `png` + `zune-jpeg` only. |
| `cargo check --tests` (default) | ✅ | Tests under `services/langfuse/sanitize.rs` continue to compile (the `json!` import is `#[cfg(any(test, feature = "telemetry"))]`). |

5 warnings remain in `src/web/handlers.rs` and `src/observability/{context,sink}.rs` — these pre-exist on `rust-lite` and are unrelated to this change (confirmed with `git stash`).

## Test plan

- [ ] `cargo check`
- [ ] `cargo check --features telemetry`
- [ ] `cargo check --features "telemetry web-ui image syntect tree-sitter"`
- [ ] `cargo test` (default) — run the langfuse sanitize tests.
- [ ] Manual: start the binary with `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` set and confirm telemetry remains a no-op on a default build, and that a `--features telemetry` build exports spans.
- [ ] Manual: `--web` mode on a default build returns the 503 hint from `web/static_files.rs`; a `--features web-ui` build serves the embedded SPA.

## Notes for reviewers

- `git2` → `gix` migration was mentioned in the brief as a "consider" item; left out of scope for this PR since `git2` is already `default-features = false`.
- The langfuse `convert_generation_input` / `convert_assistant_output` helpers still run on the hot path when `telemetry` is off (their return values are then discarded by the stubs). Happy to follow up with a second pass that gates the call sites if the wasted JSON conversion matters.