### PR TITLE
Issue 02: Render primitives from the sample tree

### DIFF
--- a/ui/src/components/FilePathLink.tsx
+++ b/ui/src/components/FilePathLink.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { pathToFileURL } from 'node:url'
+import { c } from '../theme.js'
+
+/**
+ * Render a file path so terminals that understand OSC 8 can open it in an
+ * editor. This is a Lite-native re-host of the sample tree's `FilePathLink`
+ * (`ui/examples/upstream-patterns/src/components/FilePathLink.tsx`) that
+ * avoids depending on `@anthropic/ink`'s `Link` component.
+ *
+ * Terminals that do not recognize OSC 8 simply render the label as styled
+ * text — the escape sequence is a no-op for them, so there is no harmful
+ * fallback path.
+ */
+
+/** Build a `file://` URL from an absolute path. */
+export function fileUrl(filePath: string): string {
+  return pathToFileURL(filePath).href
+}
+
+/**
+ * Wrap `text` in an OSC 8 hyperlink pointing at `url`. Terminals that do
+ * not support hyperlinks pass the inner text through unchanged.
+ */
+export function osc8Link(url: string, text: string): string {
+  return `\x1b]8;;${url}\x1b\\${text}\x1b]8;;\x1b\\`
+}
+
+type Props = {
+  /** The absolute file path the link should open. */
+  filePath: string
+  /** Optional display label. Defaults to `filePath`. */
+  label?: string
+  /** Foreground color override. Defaults to the Lite info accent. */
+  fg?: string
+}
+
+export function FilePathLink({ filePath, label, fg = c.info }: Props) {
+  const display = label ?? filePath
+  return <text fg={fg}>{osc8Link(fileUrl(filePath), display)}</text>
+}

--- a/ui/src/components/OrderedList.tsx
+++ b/ui/src/components/OrderedList.tsx
@@ -1,0 +1,78 @@
+import React, { createContext, isValidElement, type ReactNode, useContext } from 'react'
+import { c } from '../theme.js'
+
+/**
+ * Lite-native port of the sample tree's `OrderedList` / `OrderedListItem`
+ * (`ui/examples/upstream-patterns/src/components/ui/OrderedList.tsx`).
+ *
+ * Renders an ordered list where nested lists automatically produce
+ * multi-segment markers like `1.1.` / `1.2.1.`. Consumers compose it as:
+ *
+ *   <OrderedList>
+ *     <OrderedList.Item>first</OrderedList.Item>
+ *     <OrderedList.Item>
+ *       second
+ *       <OrderedList>
+ *         <OrderedList.Item>nested</OrderedList.Item>
+ *       </OrderedList>
+ *     </OrderedList.Item>
+ *   </OrderedList>
+ */
+
+const OrderedListContext = createContext<{ marker: string }>({ marker: '' })
+const OrderedListItemContext = createContext<{ marker: string }>({ marker: '' })
+
+function OrderedListItem({ children }: { children: ReactNode }) {
+  const { marker } = useContext(OrderedListItemContext)
+  return (
+    <box flexDirection="row" gap={1}>
+      <text fg={c.dim}>{marker}</text>
+      <box flexDirection="column">{children}</box>
+    </box>
+  )
+}
+
+type OrderedListProps = {
+  children: ReactNode
+}
+
+function OrderedListComponent({ children }: OrderedListProps) {
+  const { marker: parentMarker } = useContext(OrderedListContext)
+
+  let itemCount = 0
+  for (const child of React.Children.toArray(children)) {
+    if (isValidElement(child) && child.type === OrderedListItem) {
+      itemCount++
+    }
+  }
+
+  const maxMarkerWidth = String(itemCount).length
+
+  return (
+    <box flexDirection="column">
+      {React.Children.map(children, (child, index) => {
+        if (!isValidElement(child) || child.type !== OrderedListItem) {
+          return child
+        }
+        const paddedMarker = `${String(index + 1).padStart(maxMarkerWidth)}.`
+        const marker = `${parentMarker}${paddedMarker}`
+        return (
+          <OrderedListContext.Provider value={{ marker }}>
+            <OrderedListItemContext.Provider value={{ marker }}>
+              {child}
+            </OrderedListItemContext.Provider>
+          </OrderedListContext.Provider>
+        )
+      })}
+    </box>
+  )
+}
+
+type OrderedListType = typeof OrderedListComponent & {
+  Item: typeof OrderedListItem
+}
+
+const OrderedList = OrderedListComponent as OrderedListType
+OrderedList.Item = OrderedListItem
+
+export { OrderedList, OrderedListItem }

--- a/ui/src/components/PressEnterToContinue.tsx
+++ b/ui/src/components/PressEnterToContinue.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { c } from '../theme.js'
+
+/**
+ * Small prompt shown at the bottom of dialogs waiting on a user confirmation.
+ * Lite-native port of the sample tree's `PressEnterToContinue`
+ * (`ui/examples/upstream-patterns/src/components/PressEnterToContinue.tsx`).
+ */
+export function PressEnterToContinue({ label = 'continue' }: { label?: string }) {
+  return (
+    <text fg={c.warning}>
+      Press <strong>Enter</strong> to {label}…
+    </text>
+  )
+}

--- a/ui/src/components/TagTabs.tsx
+++ b/ui/src/components/TagTabs.tsx
@@ -1,0 +1,200 @@
+import React from 'react'
+import { c } from '../theme.js'
+import { stringWidth, truncateToWidth } from './string-width.js'
+
+/**
+ * Lite-native port of the sample tree's `TagTabs`
+ * (`ui/examples/upstream-patterns/src/components/TagTabs.tsx`).
+ *
+ * Renders a horizontally scrolling strip of tag-style tabs centered on
+ * `selectedIndex`. Tabs that do not fit the available width are collapsed
+ * into `← N` / `→N (tab to cycle)` hints at either edge. Pure layout:
+ * keyboard handling stays with the caller.
+ *
+ * Width math is exported via `planTagTabs` so callers can unit-test the
+ * window calculation without mounting the component.
+ */
+
+const ALL_TAB_LABEL = 'All'
+const TAB_PADDING = 2
+const HASH_PREFIX_LENGTH = 1
+const LEFT_ARROW_PREFIX = '← '
+const RIGHT_HINT_WITH_COUNT_PREFIX = '→'
+const RIGHT_HINT_SUFFIX = ' (tab to cycle)'
+const RIGHT_HINT_NO_COUNT = '(tab to cycle)'
+const MAX_OVERFLOW_DIGITS = 2
+
+const LEFT_ARROW_WIDTH = LEFT_ARROW_PREFIX.length + MAX_OVERFLOW_DIGITS + 1
+const RIGHT_HINT_WIDTH_WITH_COUNT =
+  RIGHT_HINT_WITH_COUNT_PREFIX.length +
+  MAX_OVERFLOW_DIGITS +
+  RIGHT_HINT_SUFFIX.length
+const RIGHT_HINT_WIDTH_NO_COUNT = RIGHT_HINT_NO_COUNT.length
+
+export type TagTabsPlan = {
+  /** Clamped selected index. */
+  selectedIndex: number
+  /** First visible tab index, inclusive. */
+  startIndex: number
+  /** Last visible tab index, exclusive. */
+  endIndex: number
+  /** Number of tabs hidden to the left of the window. */
+  hiddenLeft: number
+  /** Number of tabs hidden to the right of the window. */
+  hiddenRight: number
+  /** Max inline width for a single tab including padding. */
+  maxSingleTabWidth: number
+}
+
+type PlanInput = {
+  tabs: string[]
+  selectedIndex: number
+  availableWidth: number
+  resumeLabelWidth: number
+}
+
+function getTabWidth(tab: string, maxWidth?: number): number {
+  if (tab === ALL_TAB_LABEL) {
+    return ALL_TAB_LABEL.length + TAB_PADDING
+  }
+  const tagWidth = stringWidth(tab)
+  const effectiveTagWidth = maxWidth
+    ? Math.min(tagWidth, maxWidth - TAB_PADDING - HASH_PREFIX_LENGTH)
+    : tagWidth
+  return Math.max(0, effectiveTagWidth) + TAB_PADDING + HASH_PREFIX_LENGTH
+}
+
+function truncateTag(tag: string, maxWidth: number): string {
+  const availableForTag = maxWidth - TAB_PADDING - HASH_PREFIX_LENGTH
+  if (stringWidth(tag) <= availableForTag) return tag
+  if (availableForTag <= 1) return tag.charAt(0)
+  return truncateToWidth(tag, availableForTag)
+}
+
+export function planTagTabs({
+  tabs,
+  selectedIndex,
+  availableWidth,
+  resumeLabelWidth,
+}: PlanInput): TagTabsPlan {
+  const safeSelectedIndex = Math.max(0, Math.min(selectedIndex, tabs.length - 1))
+
+  const rightHintWidth = Math.max(RIGHT_HINT_WIDTH_WITH_COUNT, RIGHT_HINT_WIDTH_NO_COUNT)
+  const maxTabsWidth = availableWidth - resumeLabelWidth - rightHintWidth - 2
+
+  const maxSingleTabWidth = Math.max(20, Math.floor(maxTabsWidth / 2))
+  const tabWidths = tabs.map(tab => getTabWidth(tab, maxSingleTabWidth))
+
+  let startIndex = 0
+  let endIndex = tabs.length
+  const totalTabsWidth = tabWidths.reduce(
+    (sum, w, i) => sum + w + (i < tabWidths.length - 1 ? 1 : 0),
+    0,
+  )
+
+  if (totalTabsWidth > maxTabsWidth && tabs.length > 0) {
+    const effectiveMaxWidth = maxTabsWidth - LEFT_ARROW_WIDTH
+    let windowWidth = tabWidths[safeSelectedIndex] ?? 0
+    startIndex = safeSelectedIndex
+    endIndex = safeSelectedIndex + 1
+
+    while (startIndex > 0 || endIndex < tabs.length) {
+      const canExpandLeft = startIndex > 0
+      const canExpandRight = endIndex < tabs.length
+
+      if (canExpandLeft) {
+        const leftWidth = (tabWidths[startIndex - 1] ?? 0) + 1
+        if (windowWidth + leftWidth <= effectiveMaxWidth) {
+          startIndex--
+          windowWidth += leftWidth
+          continue
+        }
+      }
+
+      if (canExpandRight) {
+        const rightWidth = (tabWidths[endIndex] ?? 0) + 1
+        if (windowWidth + rightWidth <= effectiveMaxWidth) {
+          endIndex++
+          windowWidth += rightWidth
+          continue
+        }
+      }
+
+      break
+    }
+  }
+
+  return {
+    selectedIndex: safeSelectedIndex,
+    startIndex,
+    endIndex,
+    hiddenLeft: startIndex,
+    hiddenRight: Math.max(0, tabs.length - endIndex),
+    maxSingleTabWidth,
+  }
+}
+
+type Props = {
+  tabs: string[]
+  selectedIndex: number
+  availableWidth: number
+  showAllProjects?: boolean
+}
+
+export function TagTabs({
+  tabs,
+  selectedIndex,
+  availableWidth,
+  showAllProjects = false,
+}: Props) {
+  const resumeLabel = showAllProjects ? 'Resume (All Projects)' : 'Resume'
+  const resumeLabelWidth = resumeLabel.length + 1
+
+  const plan = planTagTabs({
+    tabs,
+    selectedIndex,
+    availableWidth,
+    resumeLabelWidth,
+  })
+  const visibleTabs = tabs.slice(plan.startIndex, plan.endIndex)
+
+  return (
+    <box flexDirection="row" gap={1}>
+      <text fg={c.accent}>{resumeLabel}</text>
+      {plan.hiddenLeft > 0 && (
+        <text fg={c.dim}>
+          {LEFT_ARROW_PREFIX}
+          {plan.hiddenLeft}
+        </text>
+      )}
+      {visibleTabs.map((tab, i) => {
+        const actualIndex = plan.startIndex + i
+        const isSelected = actualIndex === plan.selectedIndex
+        const displayText =
+          tab === ALL_TAB_LABEL
+            ? tab
+            : `#${truncateTag(tab, plan.maxSingleTabWidth - TAB_PADDING)}`
+        return (
+          <text
+            key={tab}
+            fg={isSelected ? c.bg : undefined}
+            bg={isSelected ? c.accent : undefined}
+          >
+            {' '}
+            {isSelected ? <strong>{displayText}</strong> : displayText}
+            {' '}
+          </text>
+        )
+      })}
+      {plan.hiddenRight > 0 ? (
+        <text fg={c.dim}>
+          {RIGHT_HINT_WITH_COUNT_PREFIX}
+          {plan.hiddenRight}
+          {RIGHT_HINT_SUFFIX}
+        </text>
+      ) : (
+        <text fg={c.dim}>{RIGHT_HINT_NO_COUNT}</text>
+      )}
+    </box>
+  )
+}

--- a/ui/src/components/ValidationErrorsList.tsx
+++ b/ui/src/components/ValidationErrorsList.tsx
@@ -1,0 +1,156 @@
+import React from 'react'
+import { c } from '../theme.js'
+
+/**
+ * Lite-native port of the sample tree's `ValidationErrorsList`
+ * (`ui/examples/upstream-patterns/src/components/ValidationErrorsList.tsx`).
+ *
+ * The upstream version pulls in `lodash-es`, a treeify helper, and the
+ * full Ink theme. This Lite variant keeps the visual shape — errors
+ * grouped by file, paths rendered hierarchically, optional suggestion /
+ * documentation link — but avoids those dependencies so it can live in
+ * the Lite UI bundle.
+ *
+ * The grouping helper `groupValidationErrors` is exported so tests can
+ * verify the ordering without mounting the component.
+ */
+
+export type ValidationError = {
+  /** File that triggered the error. `null` / missing → shown as
+   * `(file not specified)`. */
+  file?: string | null
+  /** Dot-notation path into the config (e.g. `mcp.servers.0.name`). */
+  path?: string | null
+  /** Human-readable error message. */
+  message: string
+  /** Optional invalid value for the path — shown verbatim when present. */
+  invalidValue?: unknown
+  /** Optional remediation hint shown below the grouped path list. */
+  suggestion?: string
+  /** Optional documentation link shown below the grouped path list. */
+  docLink?: string
+}
+
+export type GroupedValidationErrors = {
+  file: string
+  errors: ValidationError[]
+  suggestionPairs: Array<{ suggestion?: string; docLink?: string }>
+}
+
+const UNSPECIFIED_FILE = '(file not specified)'
+
+function formatInvalidValue(value: unknown): string {
+  if (value === null) return 'null'
+  if (value === undefined) return 'undefined'
+  if (typeof value === 'string') return `"${value}"`
+  return String(value)
+}
+
+function sortErrorsByPath(errors: ValidationError[]): ValidationError[] {
+  return [...errors].sort((a, b) => {
+    const ap = a.path ?? ''
+    const bp = b.path ?? ''
+    if (!ap && bp) return -1
+    if (ap && !bp) return 1
+    return ap.localeCompare(bp)
+  })
+}
+
+/**
+ * Groups errors by file, sorts files alphabetically, and deduplicates
+ * suggestion / docLink pairs within each group.
+ */
+export function groupValidationErrors(
+  errors: ValidationError[],
+): GroupedValidationErrors[] {
+  const byFile = new Map<string, ValidationError[]>()
+  for (const err of errors) {
+    const key = err.file ?? UNSPECIFIED_FILE
+    const list = byFile.get(key)
+    if (list) {
+      list.push(err)
+    } else {
+      byFile.set(key, [err])
+    }
+  }
+
+  const groups: GroupedValidationErrors[] = []
+  const sortedFiles = [...byFile.keys()].sort()
+  for (const file of sortedFiles) {
+    const fileErrors = sortErrorsByPath(byFile.get(file) ?? [])
+    const suggestions = new Map<string, { suggestion?: string; docLink?: string }>()
+    for (const err of fileErrors) {
+      if (!err.suggestion && !err.docLink) continue
+      const key = `${err.suggestion ?? ''}|${err.docLink ?? ''}`
+      if (!suggestions.has(key)) {
+        suggestions.set(key, { suggestion: err.suggestion, docLink: err.docLink })
+      }
+    }
+    groups.push({
+      file,
+      errors: fileErrors,
+      suggestionPairs: [...suggestions.values()],
+    })
+  }
+  return groups
+}
+
+type PathRowProps = {
+  error: ValidationError
+}
+
+function PathRow({ error }: PathRowProps) {
+  const rawPath = error.path ?? ''
+  const value =
+    error.invalidValue !== undefined
+      ? ` = ${formatInvalidValue(error.invalidValue)}`
+      : ''
+  const prefix = rawPath ? `${rawPath}${value}: ` : ''
+  return (
+    <text fg={c.dim} selectable>
+      {prefix}
+      <span fg={c.error}>{error.message}</span>
+    </text>
+  )
+}
+
+type Props = {
+  errors: ValidationError[]
+}
+
+export function ValidationErrorsList({ errors }: Props) {
+  if (errors.length === 0) return null
+
+  const groups = groupValidationErrors(errors)
+
+  return (
+    <box flexDirection="column">
+      {groups.map(group => (
+        <box key={group.file} flexDirection="column" marginBottom={1}>
+          <text>
+            <strong>{group.file}</strong>
+          </text>
+          <box flexDirection="column" marginLeft={1}>
+            {group.errors.map((err, i) => (
+              <PathRow key={`${err.path ?? ''}-${i}`} error={err} />
+            ))}
+          </box>
+          {group.suggestionPairs.length > 0 && (
+            <box flexDirection="column" marginTop={1}>
+              {group.suggestionPairs.map((pair, i) => (
+                <box key={i} flexDirection="column" marginBottom={1}>
+                  {pair.suggestion && (
+                    <text fg={c.dim}>{pair.suggestion}</text>
+                  )}
+                  {pair.docLink && (
+                    <text fg={c.dim}>Learn more: {pair.docLink}</text>
+                  )}
+                </box>
+              ))}
+            </box>
+          )}
+        </box>
+      ))}
+    </box>
+  )
+}

--- a/ui/src/components/WelcomeScreen.tsx
+++ b/ui/src/components/WelcomeScreen.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { c } from '../theme.js'
 import { useAppState } from '../store/app-store.js'
+import { FilePathLink } from './FilePathLink.js'
 import { Spinner } from './Spinner.js'
 
 const LOGO = `
@@ -23,10 +24,10 @@ export function WelcomeScreen() {
             <span fg={c.dim}>Model: </span>
             <strong>{model}</strong>
           </text>
-          <text>
-            <span fg={c.dim}>  cwd: </span>
-            {cwd}
-          </text>
+          <box flexDirection="row">
+            <text fg={c.dim}>  cwd: </text>
+            <FilePathLink filePath={cwd} />
+          </box>
           {sessionId && (
             <text>
               <span fg={c.dim}>  Session: </span>

--- a/ui/src/components/__tests__/file-path-link.test.ts
+++ b/ui/src/components/__tests__/file-path-link.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test'
+import { fileUrl, osc8Link } from '../FilePathLink.js'
+
+describe('fileUrl', () => {
+  test('returns a file:// href for an absolute path', () => {
+    const href = fileUrl('/tmp/example.txt')
+    expect(href.startsWith('file://')).toBe(true)
+    expect(href.endsWith('/example.txt')).toBe(true)
+  })
+
+  test('escapes spaces in the path', () => {
+    const href = fileUrl('/tmp/a b/c.txt')
+    expect(href).toContain('a%20b')
+  })
+})
+
+describe('osc8Link', () => {
+  test('wraps text in OSC 8 hyperlink escape sequences', () => {
+    const result = osc8Link('file:///tmp/example.txt', 'example.txt')
+    expect(result).toBe('\x1b]8;;file:///tmp/example.txt\x1b\\example.txt\x1b]8;;\x1b\\')
+  })
+
+  test('round-trips through plain text terminals (stripping escapes yields the label)', () => {
+    const result = osc8Link('file:///tmp/f.txt', 'label')
+    const plain = result.replace(/\x1b\]8;;[^\x1b]*\x1b\\/g, '')
+    expect(plain).toBe('label')
+  })
+})

--- a/ui/src/components/__tests__/string-width.test.ts
+++ b/ui/src/components/__tests__/string-width.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test'
+import { stringWidth, truncateToWidth } from '../string-width.js'
+
+describe('stringWidth', () => {
+  test('counts ASCII characters as width 1', () => {
+    expect(stringWidth('hello')).toBe(5)
+    expect(stringWidth('')).toBe(0)
+  })
+
+  test('counts CJK characters as width 2', () => {
+    expect(stringWidth('日本語')).toBe(6)
+    expect(stringWidth('한글')).toBe(4)
+  })
+
+  test('ignores C0 and C1 control characters', () => {
+    expect(stringWidth('a\x00b')).toBe(2)
+    expect(stringWidth('a\x1bb')).toBe(2) // ESC does not contribute width
+    expect(stringWidth('a\x7fb')).toBe(2) // DEL does not contribute width
+  })
+
+  test('handles astral plane CJK ideographs as width 2', () => {
+    // U+20000 CJK Extension B
+    expect(stringWidth('\u{20000}')).toBe(2)
+  })
+})
+
+describe('truncateToWidth', () => {
+  test('returns the original string when it already fits', () => {
+    expect(truncateToWidth('hello', 10)).toBe('hello')
+  })
+
+  test('truncates and appends an ellipsis', () => {
+    expect(truncateToWidth('hello world', 6)).toBe('hello\u2026')
+  })
+
+  test('returns an empty string for non-positive budgets', () => {
+    expect(truncateToWidth('hello', 0)).toBe('')
+    expect(truncateToWidth('hello', -1)).toBe('')
+  })
+
+  test('respects CJK widths when fitting', () => {
+    // "日本" (width 4) fits into width 5 budget — no truncation
+    expect(truncateToWidth('日本', 5)).toBe('日本')
+    // Force truncation: budget 3 => one wide char (width 2) + ellipsis (width 1)
+    expect(truncateToWidth('日本', 3)).toBe('日\u2026')
+  })
+})

--- a/ui/src/components/__tests__/tag-tabs.test.ts
+++ b/ui/src/components/__tests__/tag-tabs.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test'
+import { planTagTabs } from '../TagTabs.js'
+
+describe('planTagTabs', () => {
+  test('shows every tab when they fit in the available width', () => {
+    const plan = planTagTabs({
+      tabs: ['All', 'alpha', 'beta'],
+      selectedIndex: 1,
+      availableWidth: 200,
+      resumeLabelWidth: 7,
+    })
+    expect(plan.startIndex).toBe(0)
+    expect(plan.endIndex).toBe(3)
+    expect(plan.hiddenLeft).toBe(0)
+    expect(plan.hiddenRight).toBe(0)
+    expect(plan.selectedIndex).toBe(1)
+  })
+
+  test('collapses into a window centered on the selected tab when space is tight', () => {
+    const tabs = Array.from({ length: 20 }, (_, i) => `tag${i}`)
+    const plan = planTagTabs({
+      tabs,
+      selectedIndex: 10,
+      availableWidth: 50,
+      resumeLabelWidth: 7,
+    })
+    expect(plan.startIndex).toBeLessThanOrEqual(10)
+    expect(plan.endIndex).toBeGreaterThan(10)
+    // Either side should hide at least one tab in a 20-tab list at width 50.
+    expect(plan.hiddenLeft + plan.hiddenRight).toBeGreaterThan(0)
+    expect(plan.selectedIndex).toBe(10)
+  })
+
+  test('clamps the selected index to the last tab', () => {
+    const plan = planTagTabs({
+      tabs: ['All', 'alpha'],
+      selectedIndex: 99,
+      availableWidth: 200,
+      resumeLabelWidth: 7,
+    })
+    expect(plan.selectedIndex).toBe(1)
+  })
+
+  test('handles a single tab without error', () => {
+    const plan = planTagTabs({
+      tabs: ['All'],
+      selectedIndex: 0,
+      availableWidth: 200,
+      resumeLabelWidth: 7,
+    })
+    expect(plan.startIndex).toBe(0)
+    expect(plan.endIndex).toBe(1)
+    expect(plan.hiddenLeft).toBe(0)
+    expect(plan.hiddenRight).toBe(0)
+  })
+})

--- a/ui/src/components/__tests__/validation-errors-list.test.ts
+++ b/ui/src/components/__tests__/validation-errors-list.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test'
+import { groupValidationErrors, type ValidationError } from '../ValidationErrorsList.js'
+
+describe('groupValidationErrors', () => {
+  test('groups errors by file and sorts the group keys alphabetically', () => {
+    const errors: ValidationError[] = [
+      { file: 'b.json', path: 'x', message: 'nope' },
+      { file: 'a.json', path: 'y', message: 'bad' },
+      { file: 'a.json', path: 'x', message: 'wrong' },
+    ]
+    const groups = groupValidationErrors(errors)
+    expect(groups.map(g => g.file)).toEqual(['a.json', 'b.json'])
+    const first = groups[0]!
+    expect(first.errors.map(e => e.path)).toEqual(['x', 'y'])
+  })
+
+  test('falls back to the unspecified-file label when file is missing', () => {
+    const errors: ValidationError[] = [
+      { path: 'foo', message: 'oops' },
+      { file: null, path: 'bar', message: 'nope' },
+    ]
+    const groups = groupValidationErrors(errors)
+    expect(groups).toHaveLength(1)
+    expect(groups[0]!.file).toBe('(file not specified)')
+    expect(groups[0]!.errors).toHaveLength(2)
+  })
+
+  test('deduplicates suggestion / docLink pairs inside a group', () => {
+    const errors: ValidationError[] = [
+      { file: 'a.json', message: 'x', suggestion: 'retry', docLink: 'https://e/' },
+      { file: 'a.json', message: 'y', suggestion: 'retry', docLink: 'https://e/' },
+      { file: 'a.json', message: 'z', suggestion: 'check config' },
+    ]
+    const group = groupValidationErrors(errors)[0]!
+    expect(group.suggestionPairs).toHaveLength(2)
+    expect(group.suggestionPairs).toEqual(
+      expect.arrayContaining([
+        { suggestion: 'retry', docLink: 'https://e/' },
+        { suggestion: 'check config', docLink: undefined },
+      ]),
+    )
+  })
+
+  test('sorts path-less errors before keyed paths inside a group', () => {
+    const errors: ValidationError[] = [
+      { file: 'a.json', path: 'z', message: 'last' },
+      { file: 'a.json', message: 'root' },
+      { file: 'a.json', path: 'a', message: 'first' },
+    ]
+    const group = groupValidationErrors(errors)[0]!
+    expect(group.errors.map(e => e.message)).toEqual(['root', 'first', 'last'])
+  })
+})

--- a/ui/src/components/string-width.ts
+++ b/ui/src/components/string-width.ts
@@ -1,0 +1,67 @@
+/**
+ * Minimal terminal-width estimate for a string.
+ *
+ * Counts each code point as 1 column, with an extra column added for the
+ * common East Asian Wide / Fullwidth ranges. Good enough for layout math in
+ * the Lite frontend (tab labels, compact selectors) without pulling in the
+ * full `string-width` dependency used by the sample tree.
+ *
+ * The sample tree uses `stringWidth` from `@anthropic/ink` which delegates
+ * to `wcwidth`. This helper is intentionally simpler: it does not attempt
+ * to track zero-width joiners, variation selectors, or combining marks.
+ * If you need more accuracy, switch to the upstream library later.
+ */
+export function stringWidth(str: string): number {
+  let width = 0
+  for (const ch of str) {
+    const cp = ch.codePointAt(0)
+    if (cp === undefined) continue
+    // Skip control characters (C0 + DEL + C1) — they contribute no columns.
+    if (cp < 0x20 || (cp >= 0x7f && cp <= 0x9f)) continue
+    if (isWide(cp)) {
+      width += 2
+    } else {
+      width += 1
+    }
+  }
+  return width
+}
+
+function isWide(cp: number): boolean {
+  return (
+    (cp >= 0x1100 && cp <= 0x115f) || // Hangul Jamo
+    (cp >= 0x2e80 && cp <= 0x303e) || // CJK Radicals, Kangxi
+    (cp >= 0x3041 && cp <= 0x33ff) || // Hiragana/Katakana/CJK symbols
+    (cp >= 0x3400 && cp <= 0x4dbf) || // CJK Extension A
+    (cp >= 0x4e00 && cp <= 0x9fff) || // CJK Unified Ideographs
+    (cp >= 0xa000 && cp <= 0xa4cf) || // Yi Syllables
+    (cp >= 0xac00 && cp <= 0xd7a3) || // Hangul Syllables
+    (cp >= 0xf900 && cp <= 0xfaff) || // CJK Compatibility Ideographs
+    (cp >= 0xfe30 && cp <= 0xfe4f) || // CJK Compatibility Forms
+    (cp >= 0xff00 && cp <= 0xff60) || // Fullwidth forms
+    (cp >= 0xffe0 && cp <= 0xffe6) || // Fullwidth signs
+    (cp >= 0x20000 && cp <= 0x2fffd) || // CJK Extension B..F
+    (cp >= 0x30000 && cp <= 0x3fffd) // CJK Extension G..
+  )
+}
+
+/**
+ * Truncate `text` so that its display width does not exceed `maxWidth`.
+ * Returns the original string when it already fits. When truncation is
+ * needed, appends the ellipsis `…` (which has width 1) inside the budget.
+ */
+export function truncateToWidth(text: string, maxWidth: number): string {
+  if (maxWidth <= 0) return ''
+  if (stringWidth(text) <= maxWidth) return text
+  const ellipsis = '\u2026'
+  const budget = Math.max(0, maxWidth - stringWidth(ellipsis))
+  let width = 0
+  let out = ''
+  for (const ch of text) {
+    const w = stringWidth(ch)
+    if (width + w > budget) break
+    out += ch
+    width += w
+  }
+  return out + ellipsis
+}


### PR DESCRIPTION
## Summary

First wave of the OpenTUI sample-migration effort. Re-hosts the safest single-file primitives from the sample tree as Lite-native components, so later slices can build on stable helpers.

Primitives added under \`ui/src/components/\`:

- **\`FilePathLink\`** — OSC 8 hyperlink wrapper, with \`fileUrl\` / \`osc8Link\` exported as pure helpers.
- **\`PressEnterToContinue\`** — bottom-of-dialog continue hint.
- **\`OrderedList\`** — composition with \`<OrderedList.Item>\` that produces nested markers (\`1.\`, \`1.1.\`, \`1.1.1.\`).
- **\`TagTabs\`** — horizontally scrolling tag tab strip with a pure \`planTagTabs\` windowing calculator.
- **\`ValidationErrorsList\`** — errors grouped by file with a pure \`groupValidationErrors\` helper; avoids upstream lodash / treeify deps.
- **\`string-width.ts\`** — minimal CJK-aware \`stringWidth\` / \`truncateToWidth\` helpers.

\`FilePathLink\` is wired into \`WelcomeScreen\`'s \`cwd\` row as the live consumer for this slice.

No migrated primitive imports from the upstream sample runtime — they use OpenTUI JSX + the existing \`ui/src/theme.ts\` palette.

## Test plan

- [x] \`bun test\` — 20 new tests in \`src/components/__tests__/\` pass; full suite shows 102 pass / 1 pre-existing IPC integration failure (requires built Rust binary, unrelated).
- [x] \`bun run build\` in \`ui/\` — succeeds.
- [ ] Manual smoke: welcome screen renders \`cwd\` with the new hyperlink primitive.

Closes #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)