### PR TITLE
Issue 05: Operational panels slice

### DIFF
--- a/ui/docs/ui-panels-deferred.md
+++ b/ui/docs/ui-panels-deferred.md
@@ -1,0 +1,119 @@
+# Deferred operational panels
+
+This file tracks upstream sample-tree panels that were reviewed during
+Issue 05 (`Operational Panels For MCP, LSP, Team, And Shell`) but not
+brought into the active frontend. Each entry names the upstream source,
+the specific protocol gap that blocks the port, and a short note on
+what it would take to unblock it later.
+
+Keep this document honest: when a blocker is resolved — either by a
+protocol addition or a deliberate scope decision — move the upgraded
+panel into `ui/src/components/panels/` and remove its row from here.
+
+## MCP
+
+### `ui/examples/upstream-patterns/src/components/mcp/MCPListPanel.tsx`
+
+Full editor panel with scope grouping (project / user / local /
+enterprise) and per-server drill-down.
+
+- **Blocker**: the Lite `McpServerStatusInfo` does not carry a
+  `scope` — the upstream view groups servers under the file they were
+  loaded from. `McpServerConfigEntry` (protocol.ts, added for the
+  `/mcp` editor) *does* carry scope but is a different surface.
+- **Unblock path**: merge `scope` into `McpServerStatusInfo` or wire
+  the `/mcp` editor commands so the status panel can cross-reference
+  config entries by name.
+
+### `ui/examples/upstream-patterns/src/components/mcp/ElicitationDialog.tsx`
+
+Interactive dialog driven by MCP server `elicitation/*` JSON-RPC events.
+
+- **Blocker**: the Rust `mcp_event` protocol only emits
+  `server_state_changed` today — there is no inbound elicitation event
+  to dispatch on.
+- **Unblock path**: add an `mcp_event::elicitation_request` shape in
+  `src/mcp/` and forward it through the daemon.
+
+### `ui/examples/upstream-patterns/src/components/mcp/MCPReconnect.tsx`
+
+Per-server reconnect workflow with retry backoff visualization.
+
+- **Blocker**: the current backend reconnects automatically without
+  exposing retry counters or failure history over IPC.
+- **Unblock path**: surface `reconnect_attempt` / `next_retry_at` on
+  `server_state_changed` events.
+
+## LSP
+
+### `ui/examples/upstream-patterns/src/components/LspRecommendation/LspRecommendationMenu.tsx`
+
+"Install suggested LSPs" flow reached from a menu hint.
+
+- **Blocker**: `LspServerInfo` does not include a `recommended`
+  bucket or an install action channel.
+- **Unblock path**: teach the Rust LSP manager to publish a
+  `recommended_languages` snapshot alongside the active list, and add
+  an `lsp_install_request` IPC message.
+
+### `ui/examples/upstream-patterns/src/components/DiagnosticsDisplay.tsx`
+
+Inline diagnostics panel (file path, severity, source, message).
+
+- **Blocker**: the `LspDiagnostic` shape exists in `protocol.ts` but
+  the backend does not currently forward diagnostic batches to the
+  frontend. `LspServerInfo` only reports aggregate server state.
+- **Unblock path**: add an `lsp_event::diagnostics_updated` shape
+  carrying `LspDiagnostic[]` keyed by file path.
+
+## Teams
+
+### `ui/examples/upstream-patterns/src/components/teams/TeamsDialog.tsx`
+
+Dialog for browsing all teams + teammates with typing / selection
+affordances.
+
+- **Blocker**: routed through the upstream sample `AppState.teamContext`
+  tree + `browser.ink` dialog primitives. We already have a static
+  `TeamPanel`; a full dialog would need a keyboard-driven list widget
+  that the Lite frontend doesn't share yet.
+- **Unblock path**: either adopt a shared list widget (Issue 02 brought
+  in `OrderedList` but not a selection list) or defer until Issue 06+
+  adds a proper selector primitive.
+
+## Shell
+
+### `ui/examples/upstream-patterns/src/components/shell/ShellProgressMessage.tsx`
+
+Live shell progress line while a `Bash` tool runs (bytes streamed,
+elapsed).
+
+- **Blocker**: the Rust `Bash` tool reports status through the
+  generic `tool_activity` pipeline without emitting incremental
+  progress frames (no byte counts, no heartbeat).
+- **Unblock path**: add a tool-specific progress event (`bash_tick`?)
+  that forwards accumulated stdout size + elapsed ms. Without those
+  numbers there is nothing to animate.
+
+### `ui/examples/upstream-patterns/src/components/shell/ExpandShellOutputContext.tsx`
+
+"Expand truncated output" drawer for long Bash results.
+
+- **Blocker**: the current `tool_result` message carries a single
+  `output` string; the backend does not track a "full output" side
+  channel to expand into.
+- **Unblock path**: attach a content reference (path / handle) to
+  truncated tool results so the frontend can request the full blob on
+  demand.
+
+## Agent progress
+
+### `ui/examples/upstream-patterns/src/components/AgentProgressLine.tsx`
+
+Single-line compacted agent progress under the input bar.
+
+- **Blocker**: Lite already renders a richer `AgentTreePanel`.
+  Bringing in the upstream collapsed view would duplicate that without
+  the Lite tree's nested state.
+- **Unblock path**: consider unifying under a shared agent view-model
+  if we later want a collapsed status-bar view.

--- a/ui/src/components/SubsystemStatus.tsx
+++ b/ui/src/components/SubsystemStatus.tsx
@@ -1,103 +1,57 @@
 import React from 'react'
 import { useAppState } from '../store/app-store.js'
+import type {
+  LspServerInfo,
+  McpServerStatusInfo,
+  PluginInfo,
+  SkillInfo,
+} from '../ipc/protocol.js'
+import { LspServerCard, McpServerCard, PluginRow } from './panels/index.js'
 
-// ---------------------------------------------------------------------------
-// State color mapping
-// ---------------------------------------------------------------------------
+/**
+ * Overview of the currently-connected subsystems (MCP, LSP, plugins,
+ * skills). Each subsystem-specific card now lives under
+ * `./panels/`, and this component stays responsible for outer chrome
+ * and section headers.
+ */
 
-const stateColors: Record<string, string> = {
-  running: '#A6E3A1',
-  connected: '#A6E3A1',
-  installed: '#A6E3A1',
-  starting: '#F9E2AF',
-  connecting: '#F9E2AF',
-  stopped: '#6C7086',
-  disconnected: '#6C7086',
-  disabled: '#6C7086',
-  not_installed: '#6C7086',
-  error: '#F38BA8',
-}
-
-function stateColor(state: string): string {
-  return stateColors[state] ?? '#6C7086'
-}
-
-// ---------------------------------------------------------------------------
-// LSP section
-// ---------------------------------------------------------------------------
-
-function LspSection({ servers }: { servers: Array<{ language_id: string; state: string; open_files_count: number; error?: string }> }) {
+function LspSection({ servers }: { servers: LspServerInfo[] }) {
   if (servers.length === 0) return null
   return (
     <box flexDirection="column">
       <text><span fg="#89B4FA">LSP</span></text>
       {servers.map(s => (
-        <text key={s.language_id}>
-          {'  '}
-          <span fg={stateColor(s.state)}>{s.state}</span>
-          {' '}
-          <span fg="#CDD6F4">{s.language_id}</span>
-          <span fg="#6C7086"> ({s.open_files_count} files)</span>
-          {s.error && <span fg="#F38BA8"> {s.error}</span>}
-        </text>
+        <LspServerCard key={s.language_id} server={s} />
       ))}
     </box>
   )
 }
 
-// ---------------------------------------------------------------------------
-// MCP section
-// ---------------------------------------------------------------------------
-
-function McpSection({ servers }: { servers: Array<{ name: string; state: string; transport: string; tools_count: number; resources_count: number; error?: string }> }) {
+function McpSection({ servers }: { servers: McpServerStatusInfo[] }) {
   if (servers.length === 0) return null
   return (
     <box flexDirection="column">
       <text><span fg="#CBA6F7">MCP</span></text>
       {servers.map(s => (
-        <text key={s.name}>
-          {'  '}
-          <span fg={stateColor(s.state)}>{s.state}</span>
-          {' '}
-          <span fg="#CDD6F4">{s.name}</span>
-          <span fg="#6C7086"> [{s.transport}] {s.tools_count}T/{s.resources_count}R</span>
-          {s.error && <span fg="#F38BA8"> {s.error}</span>}
-        </text>
+        <McpServerCard key={s.name} server={s} />
       ))}
     </box>
   )
 }
 
-// ---------------------------------------------------------------------------
-// Plugin section
-// ---------------------------------------------------------------------------
-
-function PluginSection({ plugins }: { plugins: Array<{ id: string; name: string; status: string; contributed_tools: string[]; error?: string }> }) {
+function PluginSection({ plugins }: { plugins: PluginInfo[] }) {
   if (plugins.length === 0) return null
   return (
     <box flexDirection="column">
       <text><span fg="#FAB387">Plugins</span></text>
       {plugins.map(p => (
-        <text key={p.id}>
-          {'  '}
-          <span fg={stateColor(p.status)}>{p.status}</span>
-          {' '}
-          <span fg="#CDD6F4">{p.name}</span>
-          {p.contributed_tools.length > 0 && (
-            <span fg="#6C7086"> ({p.contributed_tools.length} tools)</span>
-          )}
-          {p.error && <span fg="#F38BA8"> {p.error}</span>}
-        </text>
+        <PluginRow key={p.id} plugin={p} />
       ))}
     </box>
   )
 }
 
-// ---------------------------------------------------------------------------
-// Skill section
-// ---------------------------------------------------------------------------
-
-function SkillSection({ skills }: { skills: Array<{ name: string; source: string; user_invocable: boolean }> }) {
+function SkillSection({ skills }: { skills: SkillInfo[] }) {
   if (skills.length === 0) return null
   const invocable = skills.filter(s => s.user_invocable)
   return (
@@ -109,10 +63,6 @@ function SkillSection({ skills }: { skills: Array<{ name: string; source: string
     </box>
   )
 }
-
-// ---------------------------------------------------------------------------
-// Combined panel
-// ---------------------------------------------------------------------------
 
 export function SubsystemStatus() {
   const { subsystems } = useAppState()

--- a/ui/src/components/TeamPanel.tsx
+++ b/ui/src/components/TeamPanel.tsx
@@ -1,59 +1,18 @@
 import React from 'react'
-import type { TeamMemberInfo } from '../ipc/protocol.js'
 import type { TeamState } from '../store/app-state.js'
 import { useAppState } from '../store/app-store.js'
+import { TeamMemberCard, summarizeTeam, summarizeTeams } from './panels/index.js'
 
-// ---------------------------------------------------------------------------
-// Color palette for teammate "color" tags coming from the backend.
-// Matches the logical names assigned by `src/teams/helpers.rs::assign_color`.
-// ---------------------------------------------------------------------------
+/**
+ * Active-team panel. Consumes `summarizeTeam` / `summarizeTeams` for
+ * aggregation (pure helpers under `./panels/`) so the header logic
+ * stays unit-testable, and delegates each member row to
+ * `TeamMemberCard`.
+ */
 
-const colorTags: Record<string, string> = {
-  red: '#F38BA8',
-  blue: '#89B4FA',
-  green: '#A6E3A1',
-  yellow: '#F9E2AF',
-  purple: '#CBA6F7',
-  orange: '#FAB387',
-  pink: '#F5C2E7',
-  cyan: '#94E2D5',
-}
+const MAX_RECENT_MESSAGES_SHOWN = 3
 
-function colorFor(tag: string | undefined): string {
-  if (!tag) return '#CDD6F4'
-  return colorTags[tag.toLowerCase()] ?? '#CDD6F4'
-}
-
-// ---------------------------------------------------------------------------
-// Single teammate row
-// ---------------------------------------------------------------------------
-
-function MemberRow({ member }: { member: TeamMemberInfo & { color?: string } }) {
-  const statusIcon = member.is_active ? '●' : '○'
-  const statusColor = member.is_active ? '#A6E3A1' : '#6C7086'
-  const unreadLabel =
-    member.unread_messages > 0 ? ` +${member.unread_messages}` : ''
-  const roleLabel = member.role ? ` [${member.role}]` : ''
-
-  return (
-    <text>
-      {'  '}
-      <span fg={statusColor}>{statusIcon}</span>
-      {' '}
-      <span fg={colorFor((member as { color?: string }).color)}>{member.agent_name}</span>
-      <span fg="#6C7086">{roleLabel}</span>
-      {member.unread_messages > 0 && (
-        <span fg="#F9E2AF">{unreadLabel}</span>
-      )}
-    </text>
-  )
-}
-
-// ---------------------------------------------------------------------------
-// Recent-message row
-// ---------------------------------------------------------------------------
-
-function RecentMessageRow({
+function TruncatedSummary({
   from,
   to,
   summary,
@@ -62,50 +21,55 @@ function RecentMessageRow({
   to: string
   summary: string
 }) {
-  const truncated = summary.length > 60 ? summary.slice(0, 57) + '...' : summary
+  const truncated = summary.length > 60 ? `${summary.slice(0, 57)}...` : summary
   return (
     <text>
       {'    '}
-      <span fg="#6C7086">{from} → {to}:</span>{' '}
+      <span fg="#6C7086">
+        {from} → {to}:
+      </span>{' '}
       <span fg="#CDD6F4">{truncated}</span>
     </text>
   )
 }
 
-// ---------------------------------------------------------------------------
-// Single team section
-// ---------------------------------------------------------------------------
-
 function TeamSection({ team }: { team: TeamState }) {
-  const memberCount = team.members.length
-  const unreadTotal = team.members.reduce(
-    (acc, m) => acc + (m.unread_messages ?? 0),
-    0,
-  )
-  const activeCount = team.members.filter(m => m.is_active).length
+  const s = summarizeTeam(team)
+  const headerSuffix = [
+    `${s.activeMembers}/${s.totalMembers} active`,
+    s.unreadTotal > 0 ? `${s.unreadTotal} unread` : null,
+    s.pendingMessages > 0 ? `${s.pendingMessages} pending` : null,
+  ]
+    .filter(Boolean)
+    .join(', ')
+
+  const recent = team.recentMessages.slice(-MAX_RECENT_MESSAGES_SHOWN)
+  const totalRecent = team.recentMessages.length
+  const hiddenRecent = Math.max(0, totalRecent - recent.length)
 
   return (
     <box flexDirection="column">
       <text>
         <span fg="#89B4FA">{team.name}</span>
-        <span fg="#6C7086">
-          {' '}({activeCount}/{memberCount} active
-          {unreadTotal > 0 ? `, ${unreadTotal} unread` : ''}
-          {team.pendingMessages > 0 ? `, ${team.pendingMessages} pending` : ''}
-          )
-        </span>
+        <span fg="#6C7086"> ({headerSuffix})</span>
       </text>
       {team.members.length === 0 && (
-        <text>{'  '}<span fg="#6C7086">(no members yet — use /team spawn or the TeamSpawn tool)</span></text>
+        <text>
+          {'  '}
+          <span fg="#6C7086">(no members yet — use /team spawn or the TeamSpawn tool)</span>
+        </text>
       )}
       {team.members.map(m => (
-        <MemberRow key={m.agent_id} member={m} />
+        <TeamMemberCard key={m.agent_id} member={m} />
       ))}
-      {team.recentMessages.length > 0 && (
+      {recent.length > 0 && (
         <>
-          <text>{'  '}<span fg="#6C7086">recent:</span></text>
-          {team.recentMessages.slice(-3).map((msg, idx) => (
-            <RecentMessageRow
+          <text>
+            {'  '}
+            <span fg="#6C7086">recent{hiddenRecent > 0 ? ` (latest ${recent.length} of ${totalRecent})` : ''}:</span>
+          </text>
+          {recent.map((msg, idx) => (
+            <TruncatedSummary
               key={`${team.name}-${msg.timestamp}-${idx}`}
               from={msg.from}
               to={msg.to}
@@ -118,20 +82,16 @@ function TeamSection({ team }: { team: TeamState }) {
   )
 }
 
-// ---------------------------------------------------------------------------
-// Panel
-// ---------------------------------------------------------------------------
-
 export function TeamPanel() {
   const { teams } = useAppState()
   const teamList = Object.values(teams)
   if (teamList.length === 0) return null
 
-  const totalMembers = teamList.reduce((acc, t) => acc + t.members.length, 0)
+  const rollup = summarizeTeams(teamList)
   const title =
-    teamList.length === 1
-      ? `Team · ${teamList[0]!.name} (${totalMembers} member${totalMembers === 1 ? '' : 's'})`
-      : `Teams (${teamList.length} teams, ${totalMembers} members)`
+    rollup.teamCount === 1
+      ? `Team · ${teamList[0]!.name} (${rollup.totalMembers} member${rollup.totalMembers === 1 ? '' : 's'})`
+      : `Teams (${rollup.teamCount} teams, ${rollup.totalMembers} members${rollup.unreadTotal > 0 ? `, ${rollup.unreadTotal} unread` : ''})`
 
   return (
     <box

--- a/ui/src/components/panels/LspServerCard.tsx
+++ b/ui/src/components/panels/LspServerCard.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import type { LspServerInfo } from '../../ipc/protocol.js'
+import { c } from '../../theme.js'
+import { stateColor } from './state-colors.js'
+
+/**
+ * Richer rendering for a single LSP server, shown inside
+ * `SubsystemStatus`.
+ *
+ * Lite-native counterpart of the sample tree's `DiagnosticsDisplay`
+ * (`ui/examples/upstream-patterns/src/components/DiagnosticsDisplay.tsx`)
+ * header row. Diagnostic payloads are not yet forwarded over IPC, so
+ * this card stays focused on the fields that *are* forwarded:
+ * `language_id`, `state`, `extensions`, `open_files_count`, `error`.
+ *
+ * Extension list is trimmed to the first four entries with an overflow
+ * marker so a language with dozens of registered extensions doesn't
+ * overflow the status box.
+ */
+
+const MAX_EXTENSIONS_SHOWN = 4
+
+type Props = {
+  server: LspServerInfo
+}
+
+function renderExtensions(extensions: string[]): string | null {
+  if (!extensions || extensions.length === 0) return null
+  const shown = extensions.slice(0, MAX_EXTENSIONS_SHOWN)
+  const suffix =
+    extensions.length > MAX_EXTENSIONS_SHOWN
+      ? ` +${extensions.length - MAX_EXTENSIONS_SHOWN}`
+      : ''
+  return shown.join(', ') + suffix
+}
+
+export function LspServerCard({ server }: Props) {
+  const color = stateColor(server.state)
+  const extensions = renderExtensions(server.extensions)
+
+  return (
+    <box flexDirection="column">
+      <text>
+        {'  '}
+        <span fg={color}>{server.state}</span>
+        {' '}
+        <strong><span fg="#CDD6F4">{server.language_id}</span></strong>
+        <span fg={c.dim}>
+          {' '}({server.open_files_count} file{server.open_files_count === 1 ? '' : 's'})
+        </span>
+        {extensions && (
+          <span fg={c.dim}> · {extensions}</span>
+        )}
+      </text>
+      {server.error && (
+        <text>
+          {'    '}
+          <span fg="#F38BA8">{server.error}</span>
+        </text>
+      )}
+    </box>
+  )
+}

--- a/ui/src/components/panels/McpServerCard.tsx
+++ b/ui/src/components/panels/McpServerCard.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import type { McpServerStatusInfo } from '../../ipc/protocol.js'
+import { c } from '../../theme.js'
+import { stateColor } from './state-colors.js'
+
+/**
+ * Richer rendering for a single MCP server, shown inside
+ * `SubsystemStatus`.
+ *
+ * Lite-native counterpart of the sample tree's `MCPListPanel`
+ * per-server row (`ui/examples/upstream-patterns/src/components/mcp/MCPListPanel.tsx`).
+ * The upstream version supports editing, scopes, and a full detail
+ * drill-down. We don't have scope information in the current protocol,
+ * so this card focuses on the fields we already forward:
+ *
+ * - `server_info.name` / `server_info.version` when the server
+ *   completes the MCP handshake — surfaced on a second line.
+ * - `instructions` — when provided, shown as a dimmed caption.
+ * - `transport` plus capability counts (`tools`, `resources`) on the
+ *   header line so operators can spot a silently-empty server.
+ * - `error` — highlighted on its own line so errors don't get lost in
+ *   a single-line run of text.
+ */
+
+type Props = {
+  server: McpServerStatusInfo
+}
+
+export function McpServerCard({ server }: Props) {
+  const color = stateColor(server.state)
+  const capabilities =
+    `${server.tools_count} tool${server.tools_count === 1 ? '' : 's'}` +
+    `, ${server.resources_count} resource${server.resources_count === 1 ? '' : 's'}`
+
+  return (
+    <box flexDirection="column" marginBottom={0}>
+      <text>
+        {'  '}
+        <span fg={color}>{server.state}</span>
+        {' '}
+        <strong><span fg="#CDD6F4">{server.name}</span></strong>
+        <span fg={c.dim}> [{server.transport}]</span>
+        <span fg={c.dim}> · {capabilities}</span>
+      </text>
+      {server.server_info && (
+        <text>
+          {'    '}
+          <span fg={c.dim}>
+            {server.server_info.name} v{server.server_info.version}
+          </span>
+        </text>
+      )}
+      {server.instructions && server.instructions.trim().length > 0 && (
+        <text>
+          {'    '}
+          <em>
+            <span fg={c.dim}>{firstLineOf(server.instructions)}</span>
+          </em>
+        </text>
+      )}
+      {server.error && (
+        <text>
+          {'    '}
+          <span fg="#F38BA8">{server.error}</span>
+        </text>
+      )}
+    </box>
+  )
+}
+
+function firstLineOf(text: string): string {
+  const trimmed = text.trim()
+  const newlineIdx = trimmed.indexOf('\n')
+  if (newlineIdx === -1) return trimmed
+  return trimmed.slice(0, newlineIdx)
+}

--- a/ui/src/components/panels/PluginRow.tsx
+++ b/ui/src/components/panels/PluginRow.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import type { PluginInfo } from '../../ipc/protocol.js'
+import { c } from '../../theme.js'
+import { stateColor } from './state-colors.js'
+
+/**
+ * Compact one-line rendering for a single plugin. Promotes the
+ * previously inline row in `SubsystemStatus` so every subsystem uses
+ * the same `panels/` card pattern. Version is surfaced inline so
+ * operators can confirm which build is active at a glance.
+ */
+
+type Props = {
+  plugin: PluginInfo
+}
+
+export function PluginRow({ plugin }: Props) {
+  const color = stateColor(plugin.status)
+  const toolsLabel =
+    plugin.contributed_tools.length > 0
+      ? ` · ${plugin.contributed_tools.length} tool${plugin.contributed_tools.length === 1 ? '' : 's'}`
+      : ''
+  const skillsLabel =
+    plugin.contributed_skills.length > 0
+      ? ` · ${plugin.contributed_skills.length} skill${plugin.contributed_skills.length === 1 ? '' : 's'}`
+      : ''
+  const version = plugin.version ? ` v${plugin.version}` : ''
+
+  return (
+    <box flexDirection="column">
+      <text>
+        {'  '}
+        <span fg={color}>{plugin.status}</span>
+        {' '}
+        <strong><span fg="#CDD6F4">{plugin.name}</span></strong>
+        <span fg={c.dim}>{version}{toolsLabel}{skillsLabel}</span>
+      </text>
+      {plugin.error && (
+        <text>
+          {'    '}
+          <span fg="#F38BA8">{plugin.error}</span>
+        </text>
+      )}
+    </box>
+  )
+}

--- a/ui/src/components/panels/TeamMemberCard.tsx
+++ b/ui/src/components/panels/TeamMemberCard.tsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import type { TeamMemberInfo } from '../../ipc/protocol.js'
+import { c } from '../../theme.js'
+
+/**
+ * Single-row rendering for a team member. Lite-native sibling of the
+ * sample tree's `TeamStatus`
+ * (`ui/examples/upstream-patterns/src/components/teams/TeamStatus.tsx`)
+ * — focused on the fields the Rust protocol already forwards. Role is
+ * surfaced with a tint so operators can scan at a glance which rows
+ * are leads vs workers.
+ */
+
+type AugmentedMember = TeamMemberInfo & { color?: string }
+
+type Props = {
+  member: AugmentedMember
+}
+
+const TEAMMATE_COLORS: Record<string, string> = {
+  red: '#F38BA8',
+  blue: '#89B4FA',
+  green: '#A6E3A1',
+  yellow: '#F9E2AF',
+  purple: '#CBA6F7',
+  orange: '#FAB387',
+  pink: '#F5C2E7',
+  cyan: '#94E2D5',
+}
+
+const DEFAULT_NAME_COLOR = '#CDD6F4'
+
+function resolveNameColor(tag: string | undefined): string {
+  if (!tag) return DEFAULT_NAME_COLOR
+  return TEAMMATE_COLORS[tag.toLowerCase()] ?? DEFAULT_NAME_COLOR
+}
+
+const ROLE_COLORS: Record<string, string> = {
+  lead: '#A6E3A1',
+  manager: '#A6E3A1',
+  worker: '#89B4FA',
+  reviewer: '#CBA6F7',
+}
+
+function roleColor(role: string | undefined): string {
+  if (!role) return c.dim
+  const lowered = role.toLowerCase()
+  for (const [key, value] of Object.entries(ROLE_COLORS)) {
+    if (lowered.includes(key)) return value
+  }
+  return c.dim
+}
+
+export function TeamMemberCard({ member }: Props) {
+  const nameColor = resolveNameColor(member.color)
+  const statusIcon = member.is_active ? '●' : '○'
+  const statusColor = member.is_active ? '#A6E3A1' : '#6C7086'
+  const unread = member.unread_messages ?? 0
+  const rolePrefix = member.role ? `[${member.role}]` : ''
+  const roleFg = roleColor(member.role)
+
+  return (
+    <text>
+      {'  '}
+      <span fg={statusColor}>{statusIcon}</span>
+      {' '}
+      <span fg={nameColor}>{member.agent_name}</span>
+      {rolePrefix && (
+        <>
+          {' '}
+          <span fg={roleFg}>{rolePrefix}</span>
+        </>
+      )}
+      {unread > 0 && (
+        <span fg="#F9E2AF"> +{unread}</span>
+      )}
+    </text>
+  )
+}

--- a/ui/src/components/panels/__tests__/state-colors.test.ts
+++ b/ui/src/components/panels/__tests__/state-colors.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test'
+import { isHealthyState, stateColor } from '../state-colors.js'
+
+describe('stateColor', () => {
+  test('maps healthy states to the green family', () => {
+    expect(stateColor('running')).toBe('#A6E3A1')
+    expect(stateColor('connected')).toBe('#A6E3A1')
+    expect(stateColor('installed')).toBe('#A6E3A1')
+    expect(stateColor('enabled')).toBe('#A6E3A1')
+  })
+
+  test('maps in-flight states to the amber family', () => {
+    expect(stateColor('starting')).toBe('#F9E2AF')
+    expect(stateColor('connecting')).toBe('#F9E2AF')
+    expect(stateColor('reconnecting')).toBe('#F9E2AF')
+  })
+
+  test('maps dormant states to grey', () => {
+    expect(stateColor('stopped')).toBe('#6C7086')
+    expect(stateColor('disabled')).toBe('#6C7086')
+    expect(stateColor('not_installed')).toBe('#6C7086')
+  })
+
+  test('maps failures to the red family', () => {
+    expect(stateColor('error')).toBe('#F38BA8')
+    expect(stateColor('failed')).toBe('#F38BA8')
+    expect(stateColor('crashed')).toBe('#F38BA8')
+  })
+
+  test('is case-insensitive', () => {
+    expect(stateColor('RUNNING')).toBe('#A6E3A1')
+    expect(stateColor('Error')).toBe('#F38BA8')
+  })
+
+  test('falls back to grey for unknown or missing states', () => {
+    expect(stateColor('pink')).toBe('#6C7086')
+    expect(stateColor(undefined)).toBe('#6C7086')
+    expect(stateColor(null)).toBe('#6C7086')
+    expect(stateColor('')).toBe('#6C7086')
+  })
+})
+
+describe('isHealthyState', () => {
+  test('returns true for the green-family states', () => {
+    expect(isHealthyState('running')).toBe(true)
+    expect(isHealthyState('connected')).toBe(true)
+    expect(isHealthyState('Ready')).toBe(true)
+  })
+
+  test('returns false for in-flight / dormant / error / missing states', () => {
+    expect(isHealthyState('starting')).toBe(false)
+    expect(isHealthyState('stopped')).toBe(false)
+    expect(isHealthyState('error')).toBe(false)
+    expect(isHealthyState(undefined)).toBe(false)
+  })
+})

--- a/ui/src/components/panels/__tests__/team-summary.test.ts
+++ b/ui/src/components/panels/__tests__/team-summary.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'bun:test'
+import type { TeamState } from '../../../store/app-state.js'
+import { summarizeTeam, summarizeTeams } from '../team-summary.js'
+
+function member(
+  agent_id: string,
+  opts: {
+    agent_name?: string
+    role?: string
+    is_active?: boolean
+    unread_messages?: number
+  } = {},
+) {
+  return {
+    agent_id,
+    agent_name: opts.agent_name ?? agent_id,
+    role: opts.role ?? 'worker',
+    is_active: opts.is_active ?? true,
+    unread_messages: opts.unread_messages ?? 0,
+  }
+}
+
+function team(name: string, overrides: Partial<TeamState> = {}): TeamState {
+  return {
+    name,
+    members: overrides.members ?? [],
+    pendingMessages: overrides.pendingMessages ?? 0,
+    recentMessages: overrides.recentMessages ?? [],
+  }
+}
+
+describe('summarizeTeam', () => {
+  test('aggregates active members and unread counts', () => {
+    const t = team('core', {
+      members: [
+        member('a', { is_active: true, unread_messages: 2 }),
+        member('b', { is_active: false, unread_messages: 3 }),
+        member('c', { is_active: true, unread_messages: 0 }),
+      ],
+      pendingMessages: 5,
+    })
+    const s = summarizeTeam(t)
+    expect(s.name).toBe('core')
+    expect(s.totalMembers).toBe(3)
+    expect(s.activeMembers).toBe(2)
+    expect(s.unreadTotal).toBe(5)
+    expect(s.pendingMessages).toBe(5)
+  })
+
+  test('marks a team as having a lead when any member role includes "lead"', () => {
+    const t = team('squad', {
+      members: [
+        member('a', { role: 'team-lead' }),
+        member('b', { role: 'worker' }),
+      ],
+    })
+    expect(summarizeTeam(t).hasLead).toBe(true)
+  })
+
+  test('hasLead is false when no member role mentions "lead"', () => {
+    const t = team('squad', {
+      members: [member('a', { role: 'worker' })],
+    })
+    expect(summarizeTeam(t).hasLead).toBe(false)
+  })
+
+  test('handles an empty team gracefully', () => {
+    const t = team('empty')
+    const s = summarizeTeam(t)
+    expect(s).toEqual({
+      name: 'empty',
+      totalMembers: 0,
+      activeMembers: 0,
+      unreadTotal: 0,
+      pendingMessages: 0,
+      hasLead: false,
+    })
+  })
+})
+
+describe('summarizeTeams', () => {
+  test('rolls the per-team summaries up into a single view', () => {
+    const a = team('alpha', {
+      members: [
+        member('a1', { is_active: true, unread_messages: 2 }),
+      ],
+      pendingMessages: 1,
+    })
+    const b = team('beta', {
+      members: [
+        member('b1', { is_active: false, unread_messages: 4 }),
+        member('b2', { is_active: true, unread_messages: 0 }),
+      ],
+      pendingMessages: 0,
+    })
+    const rollup = summarizeTeams([a, b])
+    expect(rollup).toEqual({
+      teamCount: 2,
+      totalMembers: 3,
+      activeMembers: 2,
+      unreadTotal: 6,
+      pendingTotal: 1,
+    })
+  })
+
+  test('empty list rolls up to zeros', () => {
+    expect(summarizeTeams([])).toEqual({
+      teamCount: 0,
+      totalMembers: 0,
+      activeMembers: 0,
+      unreadTotal: 0,
+      pendingTotal: 0,
+    })
+  })
+})

--- a/ui/src/components/panels/index.ts
+++ b/ui/src/components/panels/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Barrel for the operational-panel card primitives. Each card renders
+ * a single entry of the active protocol's subsystem snapshot using a
+ * shared `state-colors.ts` palette. Pure data helpers (`summarizeTeam`
+ * / `summarizeTeams`) are unit-tested under `__tests__/`.
+ *
+ * Upstream panels that cannot currently be supported by the Lite
+ * protocol are documented in `docs/ui-panels-deferred.md` rather than
+ * half-implemented here.
+ */
+export { LspServerCard } from './LspServerCard.js'
+export { McpServerCard } from './McpServerCard.js'
+export { PluginRow } from './PluginRow.js'
+export { TeamMemberCard } from './TeamMemberCard.js'
+export {
+  summarizeTeam,
+  summarizeTeams,
+  type TeamRollupSummary,
+  type TeamSummary,
+} from './team-summary.js'
+export { isHealthyState, stateColor } from './state-colors.js'

--- a/ui/src/components/panels/state-colors.ts
+++ b/ui/src/components/panels/state-colors.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared state-to-colour mapping for operational panels (MCP / LSP /
+ * plugins / teams). Lifted from the original `SubsystemStatus.tsx`
+ * module so every subsystem card reads from the same palette.
+ *
+ * Keep the mapping keyed on the raw protocol strings (`'running'`,
+ * `'connected'`, `'installed'`, etc.) — the Rust backend forwards
+ * these verbatim, and every card takes the state as-is.
+ */
+
+const STATE_COLORS: Record<string, string> = {
+  // Green family — healthy
+  running: '#A6E3A1',
+  connected: '#A6E3A1',
+  installed: '#A6E3A1',
+  enabled: '#A6E3A1',
+  ready: '#A6E3A1',
+  // Amber family — in-flight
+  starting: '#F9E2AF',
+  connecting: '#F9E2AF',
+  installing: '#F9E2AF',
+  reconnecting: '#F9E2AF',
+  // Grey family — dormant / explicit opt-out
+  stopped: '#6C7086',
+  disconnected: '#6C7086',
+  disabled: '#6C7086',
+  not_installed: '#6C7086',
+  idle: '#6C7086',
+  // Red family — failures
+  error: '#F38BA8',
+  failed: '#F38BA8',
+  crashed: '#F38BA8',
+}
+
+const DEFAULT_COLOR = '#6C7086'
+
+export function stateColor(state: string | undefined | null): string {
+  if (!state) return DEFAULT_COLOR
+  return STATE_COLORS[state.toLowerCase()] ?? DEFAULT_COLOR
+}
+
+export function isHealthyState(state: string | undefined | null): boolean {
+  if (!state) return false
+  const lowered = state.toLowerCase()
+  return (
+    lowered === 'running' ||
+    lowered === 'connected' ||
+    lowered === 'installed' ||
+    lowered === 'enabled' ||
+    lowered === 'ready'
+  )
+}

--- a/ui/src/components/panels/team-summary.ts
+++ b/ui/src/components/panels/team-summary.ts
@@ -1,0 +1,67 @@
+import type { TeamState } from '../../store/app-state.js'
+
+/**
+ * Pure data transforms for the team panel.
+ *
+ * `summarizeTeam` extracts the values that `TeamPanel.tsx` renders into
+ * its header line so we can unit-test the aggregation without mounting
+ * the component. `summarizeTeams` adds a cross-team roll-up used by the
+ * panel's title bar.
+ */
+
+export interface TeamSummary {
+  name: string
+  totalMembers: number
+  activeMembers: number
+  unreadTotal: number
+  pendingMessages: number
+  hasLead: boolean
+}
+
+export interface TeamRollupSummary {
+  teamCount: number
+  totalMembers: number
+  activeMembers: number
+  unreadTotal: number
+  pendingTotal: number
+}
+
+export function summarizeTeam(team: TeamState): TeamSummary {
+  let unreadTotal = 0
+  let activeMembers = 0
+  let hasLead = false
+  for (const member of team.members) {
+    unreadTotal += member.unread_messages ?? 0
+    if (member.is_active) activeMembers += 1
+    if ((member.role ?? '').toLowerCase().includes('lead')) hasLead = true
+  }
+  return {
+    name: team.name,
+    totalMembers: team.members.length,
+    activeMembers,
+    unreadTotal,
+    pendingMessages: team.pendingMessages,
+    hasLead,
+  }
+}
+
+export function summarizeTeams(teams: TeamState[]): TeamRollupSummary {
+  let totalMembers = 0
+  let activeMembers = 0
+  let unreadTotal = 0
+  let pendingTotal = 0
+  for (const team of teams) {
+    const s = summarizeTeam(team)
+    totalMembers += s.totalMembers
+    activeMembers += s.activeMembers
+    unreadTotal += s.unreadTotal
+    pendingTotal += s.pendingMessages
+  }
+  return {
+    teamCount: teams.length,
+    totalMembers,
+    activeMembers,
+    unreadTotal,
+    pendingTotal,
+  }
+}


### PR DESCRIPTION
## Summary

Fourth slice of the OpenTUI example-migration effort. Adopts per-subsystem card decomposition for the Lite MCP / LSP / plugin / team panels — focused on fields the current protocol already forwards. Upstream panels we can't yet support are documented rather than half-ported.

### New `ui/src/components/panels/`

- **`McpServerCard`** — adds a second row with `server_info.name` + version, first line of `instructions`, error on its own highlighted line. Transport + tools/resources counts on the header.
- **`LspServerCard`** — surfaces `extensions` (capped at 4 + overflow), open-files count, error.
- **`PluginRow`** — version + tools/skills counts inline.
- **`TeamMemberCard`** — role-tinted row (lead / manager / worker / reviewer), unread badge, colour-tag aware.
- **`state-colors.ts`** — shared `stateColor` palette + `isHealthyState`. Expanded to more protocol strings (\`enabled\`, \`ready\`, \`reconnecting\`, \`installing\`, \`failed\`, \`crashed\`).
- **`team-summary.ts`** — pure \`summarizeTeam\` / \`summarizeTeams\` helpers the panels consume for their header math.

### Refactored

- **`SubsystemStatus.tsx`** + **`TeamPanel.tsx`** delegate rows to the new cards; use pure summaries for the title line. Recent-message list now annotates \"latest N of M\".

### Deferred (documented in `ui/docs/ui-panels-deferred.md`)

Every upstream panel that needed unavailable protocol data:
- MCP: scope grouping (`MCPListPanel`), elicitation dialog, reconnect retry viz.
- LSP: recommendation menu, diagnostics display.
- Teams: full `TeamsDialog` (no selector list primitive yet).
- Shell: live progress line, expand-truncated-output drawer.
- Agent: collapsed progress line (already covered by \`AgentTreePanel\`).

## Test plan

- [x] \`bun test\` — 129 pass / 0 fail (14 new tests in \`panels/__tests__/\`).
- [x] \`bun run build\` in \`ui/\` — 103 modules bundled, succeeds.
- [ ] Manual smoke: any conversation with an active MCP server / LSP server / plugin / team shows the new cards.

Closes #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)