### PR TITLE
Issue 06: Composer + prompt input decomposition

### DIFF
--- a/ui/src/components/InputPrompt.tsx
+++ b/ui/src/components/InputPrompt.tsx
@@ -3,7 +3,6 @@ import { useKeyboard, useRenderer } from '@opentui/react'
 import type { KeyEvent } from '@opentui/core'
 import {
   matchesShortcut,
-  shortcutLabel,
   type ViewMode,
 } from '../keybindings.js'
 import { c } from '../theme.js'
@@ -11,25 +10,21 @@ import { useBackend } from '../ipc/context.js'
 import { useAppDispatch, useAppState } from '../store/app-store.js'
 import { matchCommands, type CommandDef } from '../commands.js'
 import { VimState } from '../vim/index.js'
-import { CommandHint } from './CommandHint.js'
 import {
-  formatPasteSize,
-  promptPlaceholder,
-  summarizeQueuedSubmissions,
-} from './input-prompt-utils.js'
-import {
+  ComposerBuffer,
+  ModeIndicator,
+  QueuedSubmissions,
+  SlashCommandHints,
+  buildBusyStatus,
+  deriveExternalStatus,
   extractInput,
-  formatWorkedDuration,
   toShortcutKey,
-} from './input-prompt-keys.js'
-import {
   useBusyTimer,
   useComposerState,
+  useComposerSubmit,
   useInputHistoryNav,
   usePasteHandler,
-} from './input-prompt-hooks.js'
-
-const PASTE_COMPACT_CHARS = 200
+} from './PromptInput/index.js'
 
 interface InputPromptProps {
   isActive?: boolean
@@ -59,7 +54,6 @@ export function InputPrompt({
     keybindingConfig,
     vimEnabled,
     queuedSubmissions,
-    pendingQuestion,
   } = useAppState()
   const dispatch = useAppDispatch()
   const renderer = useRenderer()
@@ -107,6 +101,25 @@ export function InputPrompt({
     resetBuffer()
     clearSubMode()
   }, [clearSubMode, resetBuffer])
+
+  const prefillInput = useCallback((nextText: string) => {
+    setText(nextText)
+    setCursorPos(nextText.length)
+  }, [setCursorPos, setText])
+
+  const openSubMode = useCallback(
+    (cmd: CommandDef, options: string[]) => {
+      setSubMode({ cmd, options })
+      setSubIndex(0)
+    },
+    [],
+  )
+
+  const { submit, sendCommand, activateCommand } = useComposerSubmit({
+    reset: resetComposer,
+    openSubMode,
+    prefillInput,
+  })
 
   const slashPrefix = viewMode === 'prompt' && text.startsWith('/') && !text.includes(' ') && !subMode
   const cmdPartial = slashPrefix ? text.slice(1) : ''
@@ -160,89 +173,6 @@ export function InputPrompt({
     text.length,
     viewMode,
   ])
-
-  const sendCommand = useCallback((raw: string) => {
-    if (isBusyRef.current) {
-      return
-    }
-    const id = `user-${Date.now()}`
-    dispatch({ type: 'ADD_COMMAND_MESSAGE', id, text: raw })
-    dispatch({ type: 'PUSH_HISTORY', text: raw })
-    backend.send({ type: 'slash_command', raw })
-    resetComposer()
-  }, [backend, dispatch, resetComposer])
-
-  const queuePrompt = useCallback((raw: string) => {
-    const trimmed = raw.trim()
-    if (!trimmed || trimmed.startsWith('/')) {
-      return false
-    }
-
-    const id = `queued-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-    dispatch({
-      type: 'QUEUE_SUBMISSION',
-      submission: {
-        id,
-        kind: 'prompt',
-        text: trimmed,
-        queuedAt: Date.now(),
-      },
-    })
-    dispatch({ type: 'PUSH_HISTORY', text: trimmed })
-    resetComposer()
-    return true
-  }, [dispatch, resetComposer])
-
-  const submit = useCallback(() => {
-    if (isBusyRef.current && !pendingQuestion) {
-      queuePrompt(text)
-      return
-    }
-    const trimmed = text.trim()
-    if (!trimmed) {
-      return
-    }
-
-    if (pendingQuestion) {
-      dispatch({ type: 'ADD_USER_MESSAGE', id: `answer-${pendingQuestion.id}`, text: trimmed })
-      dispatch({ type: 'PUSH_HISTORY', text: trimmed })
-      backend.send({ type: 'question_response', id: pendingQuestion.id, text: trimmed })
-      dispatch({ type: 'QUESTION_DISMISS' })
-      resetComposer()
-      return
-    }
-
-    if (trimmed.startsWith('/')) {
-      sendCommand(trimmed)
-      return
-    }
-
-    const id = `user-${Date.now()}`
-    dispatch({ type: 'ADD_USER_MESSAGE', id, text: trimmed })
-    dispatch({ type: 'PUSH_HISTORY', text: trimmed })
-    backend.send({ type: 'submit_prompt', text: trimmed, id })
-    resetComposer()
-  }, [backend, dispatch, pendingQuestion, queuePrompt, resetComposer, sendCommand, text])
-
-  const activateCommand = useCallback((cmd: CommandDef) => {
-    if (cmd.kind === 'select' && cmd.options && cmd.options.length > 0) {
-      const nextText = `/${cmd.name} `
-      setText(nextText)
-      setCursorPos(nextText.length)
-      setSubMode({ cmd, options: cmd.options })
-      setSubIndex(0)
-      return
-    }
-
-    if (cmd.kind === 'input') {
-      const nextText = `/${cmd.name} `
-      setText(nextText)
-      setCursorPos(nextText.length)
-      return
-    }
-
-    sendCommand(`/${cmd.name}`)
-  }, [sendCommand, setCursorPos, setText])
 
   const { navigateUp: navigateHistoryUp, navigateDown: navigateHistoryDown } = useInputHistoryNav({
     setText,
@@ -362,7 +292,7 @@ export function InputPrompt({
           break
         case 'submit':
           if (!isBusyRef.current) {
-            submit()
+            submit(text)
           }
           return
         case 'switch_mode':
@@ -447,14 +377,14 @@ export function InputPrompt({
         if (command && cmdPartial) {
           activateCommand(command)
         } else {
-          submit()
+          submit(text)
         }
         return
       }
     }
 
     if (matchesShortcut('chat:submit', input, key, name, { context: 'Chat', config: keybindingConfig })) {
-      submit()
+      submit(text)
       return
     }
 
@@ -549,25 +479,20 @@ export function InputPrompt({
     }
   })
 
-  const showPasteCompact = isPasted && text.length >= PASTE_COMPACT_CHARS
-  const queuedPreview = queuedSubmissions.length > 0
-    ? summarizeQueuedSubmissions(queuedSubmissions)
-    : ''
-  const before = text.slice(0, cursorPos)
-  const cursorChar = cursorPos < text.length ? text[cursorPos] : ' '
-  const after = cursorPos < text.length ? text.slice(cursorPos + 1) : ''
   const workedMs = isBusy && busyStartedAtRef.current !== null
     ? Math.max(0, time - busyStartedAtRef.current)
     : lastWorkedMs
-  const showWorked = isBusy || lastWorkedMs > 0
-  const modeTag = isStreaming ? 'reasoning' : isWaiting ? 'thinking' : ''
-  const workedTag = showWorked
-    ? `${modeTag ? `${modeTag} ` : ''}${formatWorkedDuration(workedMs)}`
-    : ''
+  const { workedTag } = buildBusyStatus({
+    isStreaming,
+    isWaiting,
+    isBusy,
+    lastWorkedMs,
+    workedMs,
+  })
   const showInlineStatus = !onStatusChange && viewMode === 'prompt'
 
   useEffect(() => {
-    onStatusChange?.(viewMode === 'prompt' && workedTag ? `* ${workedTag}` : '')
+    onStatusChange?.(deriveExternalStatus(viewMode, workedTag))
   }, [onStatusChange, viewMode, workedTag])
 
   return (
@@ -578,51 +503,28 @@ export function InputPrompt({
             <span fg={inputActive ? c.accent : c.dim}>{'> '}</span>
           </strong>
         </text>
-        {isReadOnly ? (
-          text.length > 0 ? (
-            <text fg={c.dim}>{showPasteCompact ? formatPasteSize(text) : text}</text>
-          ) : (
-            <text fg={c.dim}>
-              Transcript mode. {shortcutLabel('app:toggleTranscript', { context: 'Global', config: keybindingConfig })} prompt. {shortcutLabel('transcript:exit', { context: 'Transcript', config: keybindingConfig })} exit.
-            </text>
-          )
-        ) : showPasteCompact ? (
-          <text fg={c.warningBright}>{formatPasteSize(text)}</text>
-        ) : text.length === 0 ? (
-          <text>
-            <span fg={c.bg} bg={inputActive ? c.text : c.dim}> </span>
-            <span fg="#45475A">{promptPlaceholder(isBusy)}</span>
-          </text>
-        ) : (
-          <text fg={isBusy ? c.dim : undefined}>
-            {before}
-            <span fg={c.bg} bg={inputActive ? c.text : c.dim}>{cursorChar}</span>
-            {after}
-          </text>
-        )}
-        {showInlineStatus && workedTag ? (
-          <text fg={c.dim}>  * {workedTag}</text>
-        ) : null}
+        <ComposerBuffer
+          text={text}
+          cursorPos={cursorPos}
+          isActive={inputActive}
+          isReadOnly={isReadOnly}
+          isBusy={isBusy}
+          isPasted={isPasted}
+          keybindingConfig={keybindingConfig}
+        />
+        {showInlineStatus && <ModeIndicator workedTag={workedTag} />}
       </box>
 
-      {showHint && !subMode && (
-        <CommandHint matches={cmdMatches} selectedIndex={hintIndex} partial={cmdPartial} />
-      )}
-      {showHint && subMode && (
-        <CommandHint
-          matches={[]}
-          selectedIndex={0}
-          partial=""
-          subOptions={subMode.options}
-          subSelectedIndex={subIndex}
-        />
-      )}
-      {viewMode === 'prompt' && queuedSubmissions.length > 0 && (
-        <box paddingLeft={3}>
-          <text fg={c.dim}>
-            Queued {queuedSubmissions.length}: {queuedPreview}
-          </text>
-        </box>
+      <SlashCommandHints
+        visible={showHint}
+        matches={cmdMatches}
+        hintIndex={hintIndex}
+        partial={cmdPartial}
+        subMode={subMode}
+        subIndex={subIndex}
+      />
+      {viewMode === 'prompt' && (
+        <QueuedSubmissions submissions={queuedSubmissions} />
       )}
     </box>
   )

--- a/ui/src/components/PromptInput/ComposerBuffer.tsx
+++ b/ui/src/components/PromptInput/ComposerBuffer.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import { shortcutLabel } from '../../keybindings.js'
+import type { KeybindingConfig } from '../../keybindings.js'
+import { c } from '../../theme.js'
+import { formatPasteSize, promptPlaceholder } from './utils.js'
+import { shouldRenderPasteCompact, splitBufferAtCursor } from './prompt-state.js'
+
+/**
+ * Visible composer row — the ⟨before⟩⟨cursor⟩⟨after⟩ triplet, the
+ * paste-compact badge, and the transcript-mode hint. Extracted from
+ * `InputPrompt.tsx` so each rendering path can evolve in one place.
+ *
+ * Mirrors the sample tree's `BaseTextInput`
+ * (`ui/examples/upstream-patterns/src/components/BaseTextInput.tsx`)
+ * at the visual-only layer; the keyboard handler stays in the parent
+ * composer so it can dispatch on app-level shortcuts.
+ */
+
+type Props = {
+  text: string
+  cursorPos: number
+  isActive: boolean
+  isReadOnly: boolean
+  isBusy: boolean
+  isPasted: boolean
+  keybindingConfig: KeybindingConfig | null
+}
+
+export function ComposerBuffer({
+  text,
+  cursorPos,
+  isActive,
+  isReadOnly,
+  isBusy,
+  isPasted,
+  keybindingConfig,
+}: Props) {
+  const pasteCompact = shouldRenderPasteCompact(isPasted, text.length)
+
+  if (isReadOnly) {
+    if (text.length > 0) {
+      return <text fg={c.dim}>{pasteCompact ? formatPasteSize(text) : text}</text>
+    }
+    return (
+      <text fg={c.dim}>
+        Transcript mode. {shortcutLabel('app:toggleTranscript', { context: 'Global', config: keybindingConfig })} prompt.{' '}
+        {shortcutLabel('transcript:exit', { context: 'Transcript', config: keybindingConfig })} exit.
+      </text>
+    )
+  }
+
+  if (pasteCompact) {
+    return <text fg={c.warningBright}>{formatPasteSize(text)}</text>
+  }
+
+  if (text.length === 0) {
+    return (
+      <text>
+        <span fg={c.bg} bg={isActive ? c.text : c.dim}> </span>
+        <span fg="#45475A">{promptPlaceholder(isBusy)}</span>
+      </text>
+    )
+  }
+
+  const { before, cursorChar, after } = splitBufferAtCursor(text, cursorPos)
+  return (
+    <text fg={isBusy ? c.dim : undefined}>
+      {before}
+      <span fg={c.bg} bg={isActive ? c.text : c.dim}>{cursorChar}</span>
+      {after}
+    </text>
+  )
+}

--- a/ui/src/components/PromptInput/ModeIndicator.tsx
+++ b/ui/src/components/PromptInput/ModeIndicator.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { c } from '../../theme.js'
+
+/**
+ * Inline status hint shown to the right of the composer while the
+ * backend is busy. Surfaces the reasoning / thinking phase plus
+ * elapsed seconds.
+ *
+ * Lite-native counterpart of the sample tree's `ThinkingToggle`
+ * (`ui/examples/upstream-patterns/src/components/ThinkingToggle.tsx`)
+ * — we only surface the label here because the active frontend
+ * forwards phase transitions as store flags, not interactive toggles.
+ */
+
+type Props = {
+  /** Prepared label, e.g. `"reasoning 3s"` or `""` when idle. */
+  workedTag: string
+}
+
+export function ModeIndicator({ workedTag }: Props) {
+  if (!workedTag) return null
+  return <text fg={c.dim}>  * {workedTag}</text>
+}

--- a/ui/src/components/PromptInput/QueuedSubmissions.tsx
+++ b/ui/src/components/PromptInput/QueuedSubmissions.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { c } from '../../theme.js'
+import type { QueuedSubmission } from '../../store/app-state.js'
+import { summarizeQueuedSubmissions } from './utils.js'
+
+/**
+ * Preview row showing the currently-queued submissions beneath the
+ * composer. Rendered only in `prompt` view-mode and when at least one
+ * submission is queued.
+ *
+ * Summarization logic lives in `utils.ts` (`summarizeQueuedSubmissions`)
+ * so the truncation + overflow marker behavior is unit-testable.
+ */
+
+type Props = {
+  submissions: readonly QueuedSubmission[]
+}
+
+export function QueuedSubmissions({ submissions }: Props) {
+  if (submissions.length === 0) return null
+  const preview = summarizeQueuedSubmissions([...submissions])
+  return (
+    <box paddingLeft={3}>
+      <text fg={c.dim}>
+        Queued {submissions.length}: {preview}
+      </text>
+    </box>
+  )
+}

--- a/ui/src/components/PromptInput/SlashCommandHints.tsx
+++ b/ui/src/components/PromptInput/SlashCommandHints.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import type { CommandDef } from '../../commands.js'
+import { CommandHint } from '../CommandHint.js'
+
+/**
+ * Wraps `CommandHint` so `InputPrompt.tsx` doesn't have to carry two
+ * branches for "slash command autocomplete" vs "sub-mode option
+ * selector". The caller passes the sub-mode state when active;
+ * otherwise the matches + partial go through.
+ */
+
+type SubMode = { cmd: CommandDef; options: string[] } | null
+
+type Props = {
+  visible: boolean
+  matches: CommandDef[]
+  hintIndex: number
+  partial: string
+  subMode: SubMode
+  subIndex: number
+}
+
+export function SlashCommandHints({
+  visible,
+  matches,
+  hintIndex,
+  partial,
+  subMode,
+  subIndex,
+}: Props) {
+  if (!visible) return null
+
+  if (subMode) {
+    return (
+      <CommandHint
+        matches={[]}
+        selectedIndex={0}
+        partial=""
+        subOptions={subMode.options}
+        subSelectedIndex={subIndex}
+      />
+    )
+  }
+
+  return <CommandHint matches={matches} selectedIndex={hintIndex} partial={partial} />
+}

--- a/ui/src/components/PromptInput/__tests__/prompt-state.test.ts
+++ b/ui/src/components/PromptInput/__tests__/prompt-state.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  buildBusyStatus,
+  deriveExternalStatus,
+  shouldRenderPasteCompact,
+  splitBufferAtCursor,
+  PASTE_COMPACT_CHARS,
+} from '../prompt-state.js'
+
+describe('splitBufferAtCursor', () => {
+  test('splits around an interior cursor', () => {
+    expect(splitBufferAtCursor('hello', 2)).toEqual({
+      before: 'he',
+      cursorChar: 'l',
+      after: 'lo',
+    })
+  })
+
+  test('emits a space sentinel when the cursor sits past the last char', () => {
+    expect(splitBufferAtCursor('hi', 2)).toEqual({
+      before: 'hi',
+      cursorChar: ' ',
+      after: '',
+    })
+  })
+
+  test('clamps negative cursors to zero', () => {
+    expect(splitBufferAtCursor('abc', -5)).toEqual({
+      before: '',
+      cursorChar: 'a',
+      after: 'bc',
+    })
+  })
+
+  test('clamps cursors past end to length', () => {
+    expect(splitBufferAtCursor('abc', 99)).toEqual({
+      before: 'abc',
+      cursorChar: ' ',
+      after: '',
+    })
+  })
+})
+
+describe('shouldRenderPasteCompact', () => {
+  test('requires both the paste flag and a long enough buffer', () => {
+    expect(shouldRenderPasteCompact(true, PASTE_COMPACT_CHARS)).toBe(true)
+    expect(shouldRenderPasteCompact(true, PASTE_COMPACT_CHARS - 1)).toBe(false)
+    expect(shouldRenderPasteCompact(false, PASTE_COMPACT_CHARS + 100)).toBe(false)
+  })
+})
+
+describe('buildBusyStatus', () => {
+  test('returns empty tags when idle and there is no prior run', () => {
+    const status = buildBusyStatus({
+      isStreaming: false,
+      isWaiting: false,
+      isBusy: false,
+      lastWorkedMs: 0,
+      workedMs: 0,
+    })
+    expect(status).toEqual({ modeTag: '', workedTag: '' })
+  })
+
+  test('prefixes duration with reasoning while streaming', () => {
+    const status = buildBusyStatus({
+      isStreaming: true,
+      isWaiting: false,
+      isBusy: true,
+      lastWorkedMs: 0,
+      workedMs: 12_000,
+    })
+    expect(status.modeTag).toBe('reasoning')
+    expect(status.workedTag).toBe('reasoning 12s')
+  })
+
+  test('prefixes duration with thinking while waiting', () => {
+    const status = buildBusyStatus({
+      isStreaming: false,
+      isWaiting: true,
+      isBusy: true,
+      lastWorkedMs: 0,
+      workedMs: 61_000,
+    })
+    expect(status.modeTag).toBe('thinking')
+    expect(status.workedTag).toBe('thinking 1m 1s')
+  })
+
+  test('shows bare duration after a completed run', () => {
+    const status = buildBusyStatus({
+      isStreaming: false,
+      isWaiting: false,
+      isBusy: false,
+      lastWorkedMs: 3_000,
+      workedMs: 3_000,
+    })
+    expect(status.modeTag).toBe('')
+    expect(status.workedTag).toBe('3s')
+  })
+})
+
+describe('deriveExternalStatus', () => {
+  test('returns empty string in transcript mode', () => {
+    expect(deriveExternalStatus('transcript', 'reasoning 3s')).toBe('')
+  })
+
+  test('returns empty string when tag is empty', () => {
+    expect(deriveExternalStatus('prompt', '')).toBe('')
+  })
+
+  test('prefixes the tag with a star in prompt mode', () => {
+    expect(deriveExternalStatus('prompt', 'reasoning 3s')).toBe('* reasoning 3s')
+  })
+})

--- a/ui/src/components/PromptInput/hooks.ts
+++ b/ui/src/components/PromptInput/hooks.ts
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { PasteEvent } from '@opentui/core'
 import { useRenderer } from '@opentui/react'
-import { useAppDispatch, useAppState } from '../store/app-store.js'
-import type { ViewMode } from '../keybindings.js'
-import { insertAtCursor, isPasteInput } from './input-prompt-utils.js'
+import { useAppDispatch, useAppState } from '../../store/app-store.js'
+import type { ViewMode } from '../../keybindings.js'
+import { insertAtCursor, isPasteInput } from './utils.js'
 
 /**
  * Composer state: text buffer, cursor, undo stack, paste indicator.

--- a/ui/src/components/PromptInput/index.ts
+++ b/ui/src/components/PromptInput/index.ts
@@ -1,10 +1,61 @@
 /**
- * Placeholder barrel for the composer/prompt-input migration slice.
+ * Barrel for the Lite-native composer/prompt-input decomposition
+ * (Issue 06).
  *
- * The active composer lives at `ui/src/components/InputPrompt.tsx`. New
- * composer pieces adapted from `ui/examples/upstream-patterns/src/components/PromptInput/`
- * should land here, wired to the current keybinding and store contracts.
+ * Each submodule owns one concern lifted out of the previously
+ * monolithic `InputPrompt.tsx`:
+ * - `ComposerBuffer` — visible buffer row (before/cursor/after, paste
+ *   compact, transcript-mode readonly branch).
+ * - `QueuedSubmissions` — queued-submission preview row.
+ * - `ModeIndicator` — inline reasoning/thinking status label.
+ * - `SlashCommandHints` — slash-command autocomplete + sub-mode
+ *   option selector.
+ * - `useComposerSubmit` — submit / queue / slash-command dispatch
+ *   hook.
+ * - `hooks.ts` — composer state, busy timer, paste handler, history
+ *   navigator (existing hooks, moved here from the flat
+ *   `input-prompt-hooks.ts`).
+ * - `keys.ts` — key-event normalization helpers.
+ * - `utils.ts` — paste detection, placeholder, queued summary, cursor
+ *   insertion.
+ * - `prompt-state.ts` — pure rendering math (cursor split, paste
+ *   compact predicate, busy status tag, external status).
  *
- * No active exports yet — see Issue 06 (composer and prompt input).
+ * Keyboard handling still lives in `InputPrompt.tsx`; the submodules
+ * are consumed from that single orchestrator.
  */
-export {}
+export { ComposerBuffer } from './ComposerBuffer.js'
+export {
+  useBusyTimer,
+  useComposerState,
+  useInputHistoryNav,
+  usePasteHandler,
+  type ComposerState,
+} from './hooks.js'
+export {
+  extractInput,
+  formatWorkedDuration,
+  toShortcutKey,
+  type ShortcutKey,
+} from './keys.js'
+export { ModeIndicator } from './ModeIndicator.js'
+export {
+  PASTE_COMPACT_CHARS,
+  buildBusyStatus,
+  deriveExternalStatus,
+  shouldRenderPasteCompact,
+  splitBufferAtCursor,
+  type BufferSplit,
+  type BusyStatus,
+} from './prompt-state.js'
+export { QueuedSubmissions } from './QueuedSubmissions.js'
+export { SlashCommandHints } from './SlashCommandHints.js'
+export { useComposerSubmit } from './useComposerSubmit.js'
+export {
+  formatPasteSize,
+  insertAtCursor,
+  isPasteInput,
+  isPlainTextInput,
+  promptPlaceholder,
+  summarizeQueuedSubmissions,
+} from './utils.js'

--- a/ui/src/components/PromptInput/keys.ts
+++ b/ui/src/components/PromptInput/keys.ts
@@ -1,6 +1,6 @@
 import type { KeyEvent } from '@opentui/core'
-import type { KeyLike } from '../keybindings.js'
-import { isPlainTextInput } from './input-prompt-utils.js'
+import type { KeyLike } from '../../keybindings.js'
+import { isPlainTextInput } from './utils.js'
 
 export type ShortcutKey = KeyLike & {
   backspace?: boolean

--- a/ui/src/components/PromptInput/prompt-state.ts
+++ b/ui/src/components/PromptInput/prompt-state.ts
@@ -1,0 +1,106 @@
+import { formatWorkedDuration } from './keys.js'
+import { isPasteInput } from './utils.js'
+
+/**
+ * Pure helpers for composing the composer's visible state. The
+ * keyboard handler in `InputPrompt.tsx` already owns the text buffer;
+ * these helpers exist so we can unit-test the derived rendering values
+ * (cursor split, paste-compact predicate, busy-status tag) without
+ * mounting the component.
+ *
+ * Lite-native siblings of the presentational math baked into the
+ * sample tree's `BaseTextInput`
+ * (`ui/examples/upstream-patterns/src/components/BaseTextInput.tsx`).
+ */
+
+/** How many characters of pasted input trigger the compacted
+ *  `pasted text Nkb` badge. Kept in one place so the predicate used by
+ *  the display layer (`shouldRenderPasteCompact`) matches the detection
+ *  threshold in `utils.ts` without drifting. */
+export const PASTE_COMPACT_CHARS = 200
+
+export interface BufferSplit {
+  before: string
+  cursorChar: string
+  after: string
+}
+
+/**
+ * Split the buffer around the cursor for the three-segment render
+ * (`before`, `cursorChar`, `after`). When the cursor sits past the last
+ * character we surface a single space so the inverted cursor square
+ * still has a glyph to paint.
+ */
+export function splitBufferAtCursor(text: string, cursorPos: number): BufferSplit {
+  const clamped = Math.max(0, Math.min(cursorPos, text.length))
+  return {
+    before: text.slice(0, clamped),
+    cursorChar: clamped < text.length ? text[clamped]! : ' ',
+    after: clamped < text.length ? text.slice(clamped + 1) : '',
+  }
+}
+
+/**
+ * When to swap the three-segment buffer for the compact
+ * `pasted text Nkb` badge: the paste marker has been set AND the
+ * current buffer is long enough to actually look like a paste (so a
+ * tiny post-paste deletion doesn't leave the badge behind).
+ */
+export function shouldRenderPasteCompact(
+  isPasted: boolean,
+  textLength: number,
+): boolean {
+  return isPasted && textLength >= PASTE_COMPACT_CHARS
+}
+
+/** Consistency check for callers that want the same detection
+ *  threshold as `shouldRenderPasteCompact`. Re-exports
+ *  `isPasteInput(textLength)` so they don't need to import both modules
+ *  to stay in sync. */
+export { isPasteInput }
+
+export interface BusyStatus {
+  /** `'reasoning'` while the backend is streaming the final answer,
+   *  `'thinking'` while it is preparing tool calls, empty otherwise. */
+  modeTag: string
+  /** Full status label including the elapsed duration — for example
+   *  `"reasoning 3s"`. Empty when the composer is idle. */
+  workedTag: string
+}
+
+/**
+ * Build the busy-status tag shown next to the composer cursor. Centralizes
+ * the reasoning/thinking wording so the inline status hint and the border
+ * title stay in lockstep.
+ */
+export function buildBusyStatus(params: {
+  isStreaming: boolean
+  isWaiting: boolean
+  isBusy: boolean
+  lastWorkedMs: number
+  workedMs: number
+}): BusyStatus {
+  const { isStreaming, isWaiting, isBusy, lastWorkedMs, workedMs } = params
+  const modeTag = isStreaming ? 'reasoning' : isWaiting ? 'thinking' : ''
+  const showWorked = isBusy || lastWorkedMs > 0
+  if (!showWorked) {
+    return { modeTag, workedTag: '' }
+  }
+  const duration = formatWorkedDuration(workedMs)
+  const workedTag = modeTag ? `${modeTag} ${duration}` : duration
+  return { modeTag, workedTag }
+}
+
+/**
+ * Compose the external status string surfaced through the optional
+ * `onStatusChange` callback. Returns an empty string in transcript
+ * mode so the consumer (`App.tsx`) doesn't leak a stale busy tag into
+ * the composer title during a view-mode switch.
+ */
+export function deriveExternalStatus(
+  viewMode: 'prompt' | 'transcript',
+  workedTag: string,
+): string {
+  if (viewMode !== 'prompt' || !workedTag) return ''
+  return `* ${workedTag}`
+}

--- a/ui/src/components/PromptInput/useComposerSubmit.ts
+++ b/ui/src/components/PromptInput/useComposerSubmit.ts
@@ -1,0 +1,132 @@
+import { useCallback, useRef } from 'react'
+import type { CommandDef } from '../../commands.js'
+import { useBackend } from '../../ipc/context.js'
+import { useAppDispatch, useAppState } from '../../store/app-store.js'
+
+/**
+ * Submission + queue + slash-command dispatch hook for the composer.
+ *
+ * Centralizes the code that decides which IPC message to send (and
+ * which store action to dispatch) when the user presses Enter. Kept
+ * out of `InputPrompt.tsx` so the keyboard callback stays focused on
+ * key-to-intent mapping and so submission can be unit-tested via the
+ * store dispatch + backend spy.
+ *
+ * Contracts preserved from the previous monolithic composer:
+ * - Idle user text → `submit_prompt` + `ADD_USER_MESSAGE` + history push
+ * - Idle user text starting with `/` → `slash_command` + `ADD_COMMAND_MESSAGE`
+ * - Idle user text during an ask-user question → `question_response` + dismiss
+ * - Busy prompt submission (and no pending question) → queue under the store
+ * - `activateCommand` → starts select sub-modes or pre-fills input-kind commands
+ *
+ * The caller owns the composer buffer; this hook only asks for a
+ * `reset` callback (clears buffer + sub-mode) and the current
+ * sub-mode opener.
+ */
+
+export interface UseComposerSubmitParams {
+  reset: () => void
+  openSubMode: (cmd: CommandDef, options: string[]) => void
+  prefillInput: (text: string) => void
+}
+
+export interface ComposerSubmit {
+  /** Submit the given text — picks the right IPC message based on
+   *  current busy state, pending question, and leading slash. */
+  submit: (text: string) => void
+  /** Send a pre-formed `/name [arg]` slash command. Used by sub-mode
+   *  resolution after the user picks an option. */
+  sendCommand: (raw: string) => void
+  /** Activate a selected command hint — either open the sub-mode
+   *  selector, pre-fill the input, or send the command directly. */
+  activateCommand: (cmd: CommandDef) => void
+}
+
+export function useComposerSubmit({
+  reset,
+  openSubMode,
+  prefillInput,
+}: UseComposerSubmitParams): ComposerSubmit {
+  const backend = useBackend()
+  const dispatch = useAppDispatch()
+  const { isStreaming, isWaiting, pendingQuestion } = useAppState()
+
+  // Track the current busy flag via ref so callbacks invoked from a
+  // keyboard handler see the latest value without needing to be
+  // re-created on every busy-flag transition.
+  const isBusyRef = useRef(false)
+  isBusyRef.current = isStreaming || isWaiting
+
+  const pendingQuestionRef = useRef(pendingQuestion)
+  pendingQuestionRef.current = pendingQuestion
+
+  const sendCommand = useCallback((raw: string) => {
+    if (isBusyRef.current) {
+      return
+    }
+    const id = `user-${Date.now()}`
+    dispatch({ type: 'ADD_COMMAND_MESSAGE', id, text: raw })
+    dispatch({ type: 'PUSH_HISTORY', text: raw })
+    backend.send({ type: 'slash_command', raw })
+    reset()
+  }, [backend, dispatch, reset])
+
+  const queuePrompt = useCallback((raw: string) => {
+    const trimmed = raw.trim()
+    if (!trimmed || trimmed.startsWith('/')) return false
+    const id = `queued-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    dispatch({
+      type: 'QUEUE_SUBMISSION',
+      submission: { id, kind: 'prompt', text: trimmed, queuedAt: Date.now() },
+    })
+    dispatch({ type: 'PUSH_HISTORY', text: trimmed })
+    reset()
+    return true
+  }, [dispatch, reset])
+
+  const submit = useCallback((text: string) => {
+    const pending = pendingQuestionRef.current
+    if (isBusyRef.current && !pending) {
+      queuePrompt(text)
+      return
+    }
+    const trimmed = text.trim()
+    if (!trimmed) return
+
+    if (pending) {
+      dispatch({ type: 'ADD_USER_MESSAGE', id: `answer-${pending.id}`, text: trimmed })
+      dispatch({ type: 'PUSH_HISTORY', text: trimmed })
+      backend.send({ type: 'question_response', id: pending.id, text: trimmed })
+      dispatch({ type: 'QUESTION_DISMISS' })
+      reset()
+      return
+    }
+
+    if (trimmed.startsWith('/')) {
+      sendCommand(trimmed)
+      return
+    }
+
+    const id = `user-${Date.now()}`
+    dispatch({ type: 'ADD_USER_MESSAGE', id, text: trimmed })
+    dispatch({ type: 'PUSH_HISTORY', text: trimmed })
+    backend.send({ type: 'submit_prompt', text: trimmed, id })
+    reset()
+  }, [backend, dispatch, queuePrompt, reset, sendCommand])
+
+  const activateCommand = useCallback((cmd: CommandDef) => {
+    if (cmd.kind === 'select' && cmd.options && cmd.options.length > 0) {
+      const nextText = `/${cmd.name} `
+      prefillInput(nextText)
+      openSubMode(cmd, cmd.options)
+      return
+    }
+    if (cmd.kind === 'input') {
+      prefillInput(`/${cmd.name} `)
+      return
+    }
+    sendCommand(`/${cmd.name}`)
+  }, [openSubMode, prefillInput, sendCommand])
+
+  return { submit, sendCommand, activateCommand }
+}

--- a/ui/src/components/PromptInput/utils.ts
+++ b/ui/src/components/PromptInput/utils.ts
@@ -1,4 +1,4 @@
-import { truncate } from '../utils.js'
+import { truncate } from '../../utils.js'
 
 const PASTE_DETECT_CHARS = 100
 

--- a/ui/src/components/__tests__/paste-display.test.ts
+++ b/ui/src/components/__tests__/paste-display.test.ts
@@ -6,7 +6,7 @@ import {
   isPlainTextInput,
   promptPlaceholder,
   summarizeQueuedSubmissions,
-} from '../input-prompt-utils.js'
+} from '../PromptInput/utils.js'
 
 describe('isPasteInput', () => {
   test('single char is not paste', () => {


### PR DESCRIPTION
## Summary

Fifth slice of the OpenTUI example-migration effort. Splits the previously 629-line \`InputPrompt.tsx\` into focused submodules under \`ui/src/components/PromptInput/\`, matching the sample tree's decomposition (\`ui/examples/upstream-patterns/src/components/PromptInput/**\`, \`BaseTextInput.tsx\`) while keeping the current OpenTUI keyboard path and store/protocol intact.

### Blame-preserving renames (git mv)

- \`input-prompt-hooks.ts\` → \`PromptInput/hooks.ts\`
- \`input-prompt-keys.ts\`  → \`PromptInput/keys.ts\`
- \`input-prompt-utils.ts\` → \`PromptInput/utils.ts\`

### New submodules

- **\`prompt-state.ts\`** — pure helpers: \`splitBufferAtCursor\`, \`shouldRenderPasteCompact\`, \`buildBusyStatus\` (reasoning/thinking phase tag), \`deriveExternalStatus\`.
- **\`ComposerBuffer.tsx\`** — three-segment cursor row + paste-compact badge + transcript readonly branch.
- **\`QueuedSubmissions.tsx\`** — queued-preview row.
- **\`ModeIndicator.tsx\`** — reasoning/thinking elapsed-time tag.
- **\`SlashCommandHints.tsx\`** — unified autocomplete + sub-mode entry point.
- **\`useComposerSubmit.ts\`** — submit / queue / sendCommand / activateCommand hook. Busy + pending-question guards consolidated, behaviour preserved verbatim.

\`InputPrompt.tsx\` now composes these pieces and keeps the keyboard handler in one place for app-level shortcut dispatch + vim integration.

### Contracts preserved

- Idle prompt → \`submit_prompt\` + ADD_USER_MESSAGE + history push
- Idle prompt starting with \`/\` → \`slash_command\` + ADD_COMMAND_MESSAGE
- Pending-question answer → \`question_response\` + dismiss
- Busy non-question → queue under the store
- Abort (\`app:interrupt\`) while busy → \`abort_query\` IPC
- Transcript toggle / exit → store \`TOGGLE_VIEW_MODE\` / \`SET_VIEW_MODE\`

## Test plan

- [x] \`bun test\` — 141 pass / 0 fail (12 new in \`prompt-state.test.ts\`, existing \`paste-display.test.ts\` updated to new import path and still green).
- [x] \`bun run build\` in \`ui/\` — 110 modules bundled, succeeds.
- [ ] Manual smoke: prompt submission, slash command, queued-while-busy submission, abort while busy, transcript toggle.

Closes #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)