### PR TITLE
Add /agents-ui settings editor (list/create/edit/delete)

### DIFF
--- a/crates/claude-code-rs/src/ipc/agent_settings.rs
+++ b/crates/claude-code-rs/src/ipc/agent_settings.rs
@@ -1,0 +1,533 @@
+//! Agent-definition settings — loader, writer, and IPC handler.
+//!
+//! Backs the `/agents` settings dialog. Parallels
+//! [`super::subsystem_handlers`]' MCP config editor but for agent-definition
+//! markdown files (`{scope}/agents/<name>.md`).
+//!
+//! File format: YAML frontmatter + markdown body.
+//!
+//! ```text
+//! ---
+//! name: reviewer
+//! description: Reviews code against the plan
+//! tools: Read, Grep
+//! model: sonnet
+//! color: blue
+//! ---
+//!
+//! You are a thorough reviewer. …
+//! ```
+//!
+//! Sources:
+//!   * `Builtin`  — engine-provided (general-purpose, Explore, Plan, code-reviewer), read-only
+//!   * `User`     — `~/.cc-rust/agents/*.md`, editable
+//!   * `Project`  — `{cwd}/.cc-rust/agents/*.md`, editable
+//!   * `Plugin`   — contributed by plugins, read-only (future hook; none registered today)
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::protocol::BackendMessage;
+use super::subsystem_events::{AgentSettingsCommand, AgentSettingsEvent};
+use super::subsystem_types::{AgentDefinitionEntry, AgentDefinitionSource};
+
+/// Built-in subagent types the engine honours out of the box. Kept in sync
+/// with [`crate::commands::agents_cmd::BUILTIN_SUBAGENTS`] — duplicated here
+/// rather than imported to avoid a cyclic dependency with the command layer.
+const BUILTIN_AGENTS: &[(&str, &str)] = &[
+    (
+        "general-purpose",
+        "Default agent for multi-step research and coding tasks",
+    ),
+    (
+        "Explore",
+        "Fast codebase exploration — globbing, grepping, and file reads",
+    ),
+    (
+        "Plan",
+        "Software architect — produces an implementation plan without editing code",
+    ),
+    (
+        "code-reviewer",
+        "Reviews a completed change against the plan and coding standards",
+    ),
+];
+
+// ---------------------------------------------------------------------------
+// Public handler
+// ---------------------------------------------------------------------------
+
+/// Handle an `AgentSettingsCommand` from the frontend.
+pub fn handle(cmd: AgentSettingsCommand) -> Vec<BackendMessage> {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    match cmd {
+        AgentSettingsCommand::QueryList => {
+            let entries = list_all_agents(&cwd);
+            vec![BackendMessage::AgentSettingsEvent {
+                event: AgentSettingsEvent::List { entries },
+            }]
+        }
+        AgentSettingsCommand::Upsert { entry } => match upsert_agent(&cwd, entry) {
+            Ok(saved) => vec![BackendMessage::AgentSettingsEvent {
+                event: AgentSettingsEvent::Changed {
+                    name: saved.name.clone(),
+                    entry: Some(saved),
+                },
+            }],
+            Err((name, error)) => {
+                tracing::warn!(agent = %name, %error, "agent upsert rejected");
+                vec![BackendMessage::AgentSettingsEvent {
+                    event: AgentSettingsEvent::Error { name, error },
+                }]
+            }
+        },
+        AgentSettingsCommand::Delete { name, source } => {
+            match delete_agent(&cwd, &name, &source) {
+                Ok(()) => vec![BackendMessage::AgentSettingsEvent {
+                    event: AgentSettingsEvent::Changed { name, entry: None },
+                }],
+                Err(error) => {
+                    tracing::warn!(agent = %name, %error, "agent delete rejected");
+                    vec![BackendMessage::AgentSettingsEvent {
+                        event: AgentSettingsEvent::Error { name, error },
+                    }]
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Discovery — list every definition across all sources
+// ---------------------------------------------------------------------------
+
+/// Return every agent the UI should know about: built-ins + user + project.
+pub fn list_all_agents(cwd: &Path) -> Vec<AgentDefinitionEntry> {
+    let mut out: Vec<AgentDefinitionEntry> = BUILTIN_AGENTS
+        .iter()
+        .map(|(name, desc)| AgentDefinitionEntry {
+            name: (*name).to_string(),
+            description: (*desc).to_string(),
+            system_prompt: String::new(),
+            tools: vec![],
+            model: None,
+            color: None,
+            source: AgentDefinitionSource::Builtin,
+            file_path: None,
+        })
+        .collect();
+
+    let user_dir = cc_config::paths::data_root().join("agents");
+    out.extend(load_agents_from_dir(&user_dir, AgentDefinitionSource::User));
+
+    let project_dir = cwd.join(".cc-rust").join("agents");
+    out.extend(load_agents_from_dir(
+        &project_dir,
+        AgentDefinitionSource::Project,
+    ));
+
+    out
+}
+
+fn load_agents_from_dir(dir: &Path, source: AgentDefinitionSource) -> Vec<AgentDefinitionEntry> {
+    let Ok(read_dir) = fs::read_dir(dir) else {
+        return vec![];
+    };
+    let mut out = Vec::new();
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        if path.extension().and_then(|e| e.to_str()) != Some("md") {
+            continue;
+        }
+        let Ok(raw) = fs::read_to_string(&path) else {
+            continue;
+        };
+        if let Some(parsed) = parse_agent_file(&path, &raw, source.clone()) {
+            out.push(parsed);
+        }
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter parsing / rendering
+// ---------------------------------------------------------------------------
+
+/// Parse a single agent markdown file. Returns `None` if the file is
+/// malformed.
+pub fn parse_agent_file(
+    path: &Path,
+    content: &str,
+    source: AgentDefinitionSource,
+) -> Option<AgentDefinitionEntry> {
+    let (fm, body) = parse_frontmatter(content);
+    let name = fm
+        .iter()
+        .find(|(k, _)| k == "name")
+        .map(|(_, v)| v.clone())
+        .or_else(|| {
+            path.file_stem()
+                .and_then(|s| s.to_str())
+                .map(|s| s.to_string())
+        })?;
+    let description = fm
+        .iter()
+        .find(|(k, _)| k == "description")
+        .map(|(_, v)| v.clone())
+        .unwrap_or_default();
+    let tools = fm
+        .iter()
+        .find(|(k, _)| k == "tools")
+        .map(|(_, v)| split_list(v))
+        .unwrap_or_default();
+    let model = fm
+        .iter()
+        .find(|(k, _)| k == "model")
+        .map(|(_, v)| v.clone())
+        .filter(|s| !s.is_empty());
+    let color = fm
+        .iter()
+        .find(|(k, _)| k == "color")
+        .map(|(_, v)| v.clone())
+        .filter(|s| !s.is_empty());
+
+    Some(AgentDefinitionEntry {
+        name,
+        description,
+        system_prompt: body.trim_start_matches('\n').to_string(),
+        tools,
+        model,
+        color,
+        source,
+        file_path: Some(path.to_string_lossy().to_string()),
+    })
+}
+
+/// Render an `AgentDefinitionEntry` back to on-disk markdown.
+fn render_agent_file(entry: &AgentDefinitionEntry) -> String {
+    let mut out = String::new();
+    out.push_str("---\n");
+    out.push_str(&format!("name: {}\n", entry.name));
+    if !entry.description.is_empty() {
+        out.push_str(&format!(
+            "description: {}\n",
+            one_line(&entry.description)
+        ));
+    }
+    if !entry.tools.is_empty() {
+        out.push_str(&format!("tools: {}\n", entry.tools.join(", ")));
+    }
+    if let Some(model) = &entry.model {
+        if !model.is_empty() {
+            out.push_str(&format!("model: {}\n", model));
+        }
+    }
+    if let Some(color) = &entry.color {
+        if !color.is_empty() {
+            out.push_str(&format!("color: {}\n", color));
+        }
+    }
+    out.push_str("---\n\n");
+    out.push_str(entry.system_prompt.trim_start_matches('\n'));
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+/// Minimal YAML-frontmatter parser. Matches the permissive shape used by
+/// `cc_skills::loader::parse_frontmatter` — we intentionally reimplement
+/// locally to avoid dragging a dependency on the skills crate and to return
+/// the raw key list (preserving case for `name` etc.).
+fn parse_frontmatter(content: &str) -> (Vec<(String, String)>, String) {
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return (vec![], content.to_string());
+    }
+    let after_open = &trimmed[3..];
+    let Some(close_pos) = after_open.find("\n---") else {
+        return (vec![], content.to_string());
+    };
+    let yaml_block = &after_open[..close_pos];
+    let body = &after_open[close_pos + 4..];
+    let mut out = Vec::new();
+    for line in yaml_block.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        let key = key.trim().to_string();
+        let value = value.trim();
+        let value = value
+            .strip_prefix('"')
+            .and_then(|v| v.strip_suffix('"'))
+            .unwrap_or(value)
+            .to_string();
+        out.push((key, value));
+    }
+    (out, body.to_string())
+}
+
+fn split_list(value: &str) -> Vec<String> {
+    value
+        .split([',', ' '])
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+        .collect()
+}
+
+fn one_line(s: &str) -> String {
+    s.replace('\n', " ").trim().to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Persistence: upsert + delete
+// ---------------------------------------------------------------------------
+
+fn upsert_agent(
+    cwd: &Path,
+    entry: AgentDefinitionEntry,
+) -> Result<AgentDefinitionEntry, (String, String)> {
+    if !entry.source.is_editable() {
+        return Err((
+            entry.name.clone(),
+            format!(
+                "source `{}` is read-only — cannot edit agent",
+                entry.source.label()
+            ),
+        ));
+    }
+    validate_name(&entry.name).map_err(|e| (entry.name.clone(), e))?;
+
+    let dir = agents_dir_for_source(cwd, &entry.source);
+    fs::create_dir_all(&dir).map_err(|e| {
+        (
+            entry.name.clone(),
+            format!("failed to create {}: {}", dir.display(), e),
+        )
+    })?;
+
+    let path = dir.join(format!("{}.md", entry.name));
+    let rendered = render_agent_file(&entry);
+    let tmp = path.with_extension("md.tmp");
+    fs::write(&tmp, &rendered).map_err(|e| {
+        (
+            entry.name.clone(),
+            format!("failed to write {}: {}", tmp.display(), e),
+        )
+    })?;
+    fs::rename(&tmp, &path).map_err(|e| {
+        (
+            entry.name.clone(),
+            format!(
+                "failed to rename {} -> {}: {}",
+                tmp.display(),
+                path.display(),
+                e
+            ),
+        )
+    })?;
+
+    let mut saved = entry;
+    saved.file_path = Some(path.to_string_lossy().to_string());
+    Ok(saved)
+}
+
+fn delete_agent(
+    cwd: &Path,
+    name: &str,
+    source: &AgentDefinitionSource,
+) -> Result<(), String> {
+    if !source.is_editable() {
+        return Err(format!(
+            "source `{}` is read-only — cannot delete agent",
+            source.label()
+        ));
+    }
+    validate_name(name)?;
+    let path = agents_dir_for_source(cwd, source).join(format!("{}.md", name));
+    if !path.exists() {
+        return Err(format!(
+            "no agent file at {} — nothing to delete",
+            path.display()
+        ));
+    }
+    fs::remove_file(&path).map_err(|e| format!("failed to remove {}: {}", path.display(), e))?;
+    Ok(())
+}
+
+fn agents_dir_for_source(cwd: &Path, source: &AgentDefinitionSource) -> PathBuf {
+    match source {
+        AgentDefinitionSource::User => cc_config::paths::data_root().join("agents"),
+        AgentDefinitionSource::Project => cwd.join(".cc-rust").join("agents"),
+        // Read-only scopes are rejected earlier, but return something
+        // harmless just in case.
+        AgentDefinitionSource::Builtin | AgentDefinitionSource::Plugin { .. } => cwd.join(""),
+    }
+}
+
+/// Agent names become filenames on disk — reject anything that would escape
+/// the directory or produce an ambiguous path. This is stricter than the
+/// upstream TS loader; the extra caution is worth it because writes happen
+/// without a confirmation prompt.
+fn validate_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("agent name must not be empty".to_string());
+    }
+    if name.len() > 64 {
+        return Err("agent name must be 64 characters or fewer".to_string());
+    }
+    let ok = name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
+    if !ok {
+        return Err(
+            "agent name may only contain letters, digits, `-`, and `_`".to_string(),
+        );
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn make_entry(name: &str, source: AgentDefinitionSource) -> AgentDefinitionEntry {
+        AgentDefinitionEntry {
+            name: name.to_string(),
+            description: format!("Agent {} description", name),
+            system_prompt: "You are a helpful agent.\n\nDo your best work.\n".to_string(),
+            tools: vec!["Read".to_string(), "Grep".to_string()],
+            model: Some("sonnet".to_string()),
+            color: Some("blue".to_string()),
+            source,
+            file_path: None,
+        }
+    }
+
+    #[test]
+    fn validate_name_rejects_traversal_and_weirdness() {
+        assert!(validate_name("").is_err());
+        assert!(validate_name("../escape").is_err());
+        assert!(validate_name("slash/inside").is_err());
+        assert!(validate_name("dot.inside").is_err());
+        assert!(validate_name("good_name-1").is_ok());
+    }
+
+    #[test]
+    fn upsert_and_reload_round_trips_project_scope() {
+        let tmp = tempdir().unwrap();
+        let entry = make_entry("reviewer", AgentDefinitionSource::Project);
+
+        let saved = upsert_agent(tmp.path(), entry.clone()).unwrap();
+        assert_eq!(saved.name, "reviewer");
+        let expected = tmp
+            .path()
+            .join(".cc-rust")
+            .join("agents")
+            .join("reviewer.md");
+        assert!(expected.exists(), "file should have been written");
+
+        let loaded = load_agents_from_dir(
+            &tmp.path().join(".cc-rust").join("agents"),
+            AgentDefinitionSource::Project,
+        );
+        assert_eq!(loaded.len(), 1);
+        let back = &loaded[0];
+        assert_eq!(back.name, "reviewer");
+        assert_eq!(back.description, "Agent reviewer description");
+        assert_eq!(back.tools, vec!["Read".to_string(), "Grep".to_string()]);
+        assert_eq!(back.model.as_deref(), Some("sonnet"));
+        assert_eq!(back.color.as_deref(), Some("blue"));
+        assert!(back.system_prompt.contains("You are a helpful agent."));
+    }
+
+    #[test]
+    fn upsert_rejects_builtin_source() {
+        let tmp = tempdir().unwrap();
+        let entry = make_entry("general-purpose", AgentDefinitionSource::Builtin);
+        let err = upsert_agent(tmp.path(), entry).unwrap_err();
+        assert!(err.1.contains("read-only"));
+    }
+
+    #[test]
+    fn delete_round_trips_and_is_rejected_for_builtin() {
+        let tmp = tempdir().unwrap();
+        let entry = make_entry("temp", AgentDefinitionSource::Project);
+        upsert_agent(tmp.path(), entry).unwrap();
+
+        let path = tmp
+            .path()
+            .join(".cc-rust")
+            .join("agents")
+            .join("temp.md");
+        assert!(path.exists());
+
+        delete_agent(tmp.path(), "temp", &AgentDefinitionSource::Project).unwrap();
+        assert!(!path.exists());
+
+        let err = delete_agent(tmp.path(), "general-purpose", &AgentDefinitionSource::Builtin)
+            .unwrap_err();
+        assert!(err.contains("read-only"));
+    }
+
+    #[test]
+    fn parse_agent_file_extracts_frontmatter_and_body() {
+        let raw = "---\nname: foo\ndescription: A foo agent\ntools: Read, Bash\nmodel: opus\ncolor: red\n---\n\nBody text here.\n";
+        let parsed = parse_agent_file(
+            &PathBuf::from("/tmp/foo.md"),
+            raw,
+            AgentDefinitionSource::User,
+        )
+        .expect("should parse");
+        assert_eq!(parsed.name, "foo");
+        assert_eq!(parsed.description, "A foo agent");
+        assert_eq!(parsed.tools, vec!["Read".to_string(), "Bash".to_string()]);
+        assert_eq!(parsed.model.as_deref(), Some("opus"));
+        assert_eq!(parsed.color.as_deref(), Some("red"));
+        assert!(parsed.system_prompt.starts_with("Body text here."));
+    }
+
+    #[test]
+    fn list_all_agents_always_includes_builtins() {
+        let tmp = tempdir().unwrap();
+        let list = list_all_agents(tmp.path());
+        let names: Vec<&str> = list.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"general-purpose"));
+        assert!(names.contains(&"Explore"));
+        assert!(names.contains(&"Plan"));
+        assert!(names.contains(&"code-reviewer"));
+    }
+
+    #[test]
+    fn render_agent_file_roundtrips() {
+        let entry = make_entry("rtrip", AgentDefinitionSource::User);
+        let rendered = render_agent_file(&entry);
+        assert!(rendered.starts_with("---\n"));
+        assert!(rendered.contains("name: rtrip"));
+        assert!(rendered.contains("tools: Read, Grep"));
+        assert!(rendered.contains("model: sonnet"));
+        assert!(rendered.contains("color: blue"));
+        assert!(rendered.contains("You are a helpful agent."));
+    }
+
+    #[test]
+    fn agent_source_editable_flag() {
+        assert!(!AgentDefinitionSource::Builtin.is_editable());
+        assert!(AgentDefinitionSource::User.is_editable());
+        assert!(AgentDefinitionSource::Project.is_editable());
+        assert!(!AgentDefinitionSource::Plugin { id: "p".into() }.is_editable());
+    }
+}

--- a/crates/claude-code-rs/src/ipc/ingress.rs
+++ b/crates/claude-code-rs/src/ipc/ingress.rs
@@ -129,6 +129,11 @@ pub(crate) async fn dispatch(
             let msgs = super::subsystem_handlers::handle_ide_command(command);
             let _ = sink.send_many(msgs);
         }
+        FrontendMessage::AgentSettingsCommand { command } => {
+            debug!("headless: AgentSettings command: {:?}", command);
+            let msgs = super::agent_settings::handle(command);
+            let _ = sink.send_many(msgs);
+        }
         FrontendMessage::QuerySubsystemStatus => {
             debug!("headless: subsystem status query");
             let status = super::subsystem_handlers::build_subsystem_status_snapshot();

--- a/crates/claude-code-rs/src/ipc/mod.rs
+++ b/crates/claude-code-rs/src/ipc/mod.rs
@@ -1,6 +1,7 @@
 pub mod agent_channel;
 pub mod agent_events;
 pub mod agent_handlers;
+pub mod agent_settings;
 pub mod agent_tree;
 pub mod agent_types;
 pub mod callbacks;

--- a/crates/claude-code-rs/src/ipc/protocol/mod.rs
+++ b/crates/claude-code-rs/src/ipc/protocol/mod.rs
@@ -78,6 +78,10 @@ pub enum FrontendMessage {
     IdeCommand {
         command: super::subsystem_events::IdeCommand,
     },
+    /// Agent-definition settings command (backs the `/agents` editor UI).
+    AgentSettingsCommand {
+        command: super::subsystem_events::AgentSettingsCommand,
+    },
     /// Query all subsystem statuses.
     QuerySubsystemStatus,
 
@@ -240,6 +244,10 @@ pub enum BackendMessage {
     /// IDE-integration subsystem event.
     IdeEvent {
         event: super::subsystem_events::IdeEvent,
+    },
+    /// Agent-definition settings event.
+    AgentSettingsEvent {
+        event: super::subsystem_events::AgentSettingsEvent,
     },
     /// Aggregated subsystem status snapshot.
     SubsystemStatus {

--- a/crates/claude-code-rs/src/ipc/runtime.rs
+++ b/crates/claude-code-rs/src/ipc/runtime.rs
@@ -272,6 +272,9 @@ impl HeadlessRuntime {
                         super::subsystem_events::SubsystemEvent::Ide(e) => {
                             BackendMessage::IdeEvent { event: e }
                         }
+                        super::subsystem_events::SubsystemEvent::AgentSettings(e) => {
+                            BackendMessage::AgentSettingsEvent { event: e }
+                        }
                     };
                     let _ = self.sink.send(&msg);
                 }

--- a/crates/claude-code-rs/src/ipc/subsystem_events.rs
+++ b/crates/claude-code-rs/src/ipc/subsystem_events.rs
@@ -145,6 +145,25 @@ pub enum SkillEvent {
     SkillList { skills: Vec<SkillInfo> },
 }
 
+/// Events emitted by the agent-definition settings subsystem.
+///
+/// Distinct from `AgentEvent` (runtime agent lifecycle) — these drive the
+/// `/agents` settings dialog.
+#[derive(Serialize, Debug, Clone)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AgentSettingsEvent {
+    /// Full list of agent definitions (response to `QueryList`).
+    List { entries: Vec<AgentDefinitionEntry> },
+    /// An agent was upserted (entry present) or removed (entry `None`).
+    Changed {
+        name: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        entry: Option<AgentDefinitionEntry>,
+    },
+    /// Validation or persistence failure.
+    Error { name: String, error: String },
+}
+
 // ===========================================================================
 // Command enums (Frontend → Backend)
 // ===========================================================================
@@ -229,6 +248,25 @@ pub enum SkillCommand {
     QueryStatus,
 }
 
+/// Commands the frontend can send to manage agent definitions.
+///
+/// Backs the `/agents` settings dialog; sibling to `McpCommand` for server
+/// configs. `Builtin` and `Plugin` sources are read-only — upsert/delete calls
+/// against those scopes must be rejected with `AgentSettingsEvent::Error`.
+#[derive(Deserialize, Debug)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AgentSettingsCommand {
+    /// Return every known agent definition across all sources.
+    QueryList,
+    /// Create or replace an agent definition in its scope.
+    Upsert { entry: AgentDefinitionEntry },
+    /// Delete an agent definition from the given scope.
+    Delete {
+        name: String,
+        source: AgentDefinitionSource,
+    },
+}
+
 // ===========================================================================
 // Unified event wrapper
 // ===========================================================================
@@ -241,6 +279,7 @@ pub enum SubsystemEvent {
     Plugin(PluginEvent),
     Skill(SkillEvent),
     Ide(IdeEvent),
+    AgentSettings(AgentSettingsEvent),
 }
 
 // ===========================================================================
@@ -770,6 +809,7 @@ mod tests {
         let _mcp = SubsystemEvent::Mcp(McpEvent::ServerList { servers: vec![] });
         let _plugin = SubsystemEvent::Plugin(PluginEvent::PluginList { plugins: vec![] });
         let _skill = SubsystemEvent::Skill(SkillEvent::SkillList { skills: vec![] });
+        let _agents = SubsystemEvent::AgentSettings(AgentSettingsEvent::List { entries: vec![] });
     }
 
     #[test]

--- a/crates/claude-code-rs/src/ipc/subsystem_types.rs
+++ b/crates/claude-code-rs/src/ipc/subsystem_types.rs
@@ -276,6 +276,78 @@ pub struct SkillInfo {
 }
 
 // ---------------------------------------------------------------------------
+// Agent-definition types (Rust issue #34, UI settings editor)
+// ---------------------------------------------------------------------------
+
+/// Source/scope where an agent definition lives.
+///
+/// The first three variants (`Builtin`, `User`, `Project`) describe where the
+/// definition was loaded from. `Builtin` and `Plugin` are read-only — attempts
+/// to upsert/delete them are rejected by the handler with
+/// `AgentSettingsEvent::Error`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AgentDefinitionSource {
+    /// Engine-provided subagent types (general-purpose, Explore, Plan, code-reviewer).
+    Builtin,
+    /// Global user scope (`~/.cc-rust/agents/*.md`).
+    User,
+    /// Current project scope (`{cwd}/.cc-rust/agents/*.md`).
+    Project,
+    /// Contributed by a plugin (read-only).
+    Plugin { id: String },
+}
+
+impl AgentDefinitionSource {
+    /// True when this source can be edited directly via the filesystem.
+    pub fn is_editable(&self) -> bool {
+        matches!(self, AgentDefinitionSource::User | AgentDefinitionSource::Project)
+    }
+
+    /// Short label used in error messages and lists.
+    pub fn label(&self) -> String {
+        match self {
+            AgentDefinitionSource::Builtin => "built-in".to_string(),
+            AgentDefinitionSource::User => "user".to_string(),
+            AgentDefinitionSource::Project => "project".to_string(),
+            AgentDefinitionSource::Plugin { id } if id.is_empty() => "plugin".to_string(),
+            AgentDefinitionSource::Plugin { id } => format!("plugin:{}", id),
+        }
+    }
+}
+
+/// Full editable agent definition — round-trips between the frontend editor
+/// and an on-disk markdown file (`{scope}/agents/<name>.md`) with YAML
+/// frontmatter.
+///
+/// Parallel to `McpServerConfigEntry`: the frontend treats this as the source
+/// of truth for a single agent and persists changes by sending an
+/// `AgentSettingsCommand::Upsert { entry }`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AgentDefinitionEntry {
+    /// Unique agent name / type (matches the filename without extension).
+    pub name: String,
+    /// One-line description — told to the orchestrator for "when to use".
+    pub description: String,
+    /// Markdown system prompt body.
+    pub system_prompt: String,
+    /// Tool allow-list. Empty means "inherit all tools" (no restriction).
+    #[serde(default)]
+    pub tools: Vec<String>,
+    /// Optional model override (e.g. `"sonnet"`, `"opus"`, or a full ID).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Optional display color (named: red, orange, yellow, green, blue, purple, pink, cyan).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+    /// Where this definition lives.
+    pub source: AgentDefinitionSource,
+    /// Absolute path to the backing file, when known. `None` for built-ins.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file_path: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
 // Aggregated snapshot
 // ---------------------------------------------------------------------------
 

--- a/ui/src/commands.ts
+++ b/ui/src/commands.ts
@@ -32,6 +32,7 @@ export const COMMANDS: CommandDef[] = [
   { name: 'skills',           aliases: [],                      description: 'List available skills',            kind: 'display' },
   { name: 'diff',             aliases: [],                      description: 'Show git diff of current changes', kind: 'display' },
   { name: 'mcp',              aliases: [],                      description: 'MCP server management',           kind: 'display' },
+  { name: 'agents-ui',        aliases: ['au'],                  description: 'Open the agents settings dialog', kind: 'action' },
   { name: 'assistant',        aliases: ['kairos'],              description: 'View assistant mode status',       kind: 'display' },
   { name: 'daemon',           aliases: [],                      description: 'View/control daemon process',      kind: 'display' },
   { name: 'channels',         aliases: [],                      description: 'View connected channels',          kind: 'display' },

--- a/ui/src/components/App.tsx
+++ b/ui/src/components/App.tsx
@@ -6,6 +6,7 @@ import type { KeybindingConfig } from '../keybindings.js'
 import { shortcutLabel, transcriptTitle } from '../keybindings.js'
 import { useAppDispatch, useAppState } from '../store/app-store.js'
 import { conversationToRawMessage } from '../store/message-model.js'
+import { AgentsDialog } from './agent-settings/index.js'
 import { AgentTreePanel } from './AgentTreePanel.js'
 import { InputPrompt } from './InputPrompt.js'
 import { MessageList } from './MessageList.js'
@@ -250,6 +251,21 @@ export function App() {
         case 'subsystem_status':
           dispatch({ type: 'SUBSYSTEM_STATUS', lsp: msg.status.lsp, mcp: msg.status.mcp, plugins: msg.status.plugins, skills: msg.status.skills })
           break
+        case 'agent_settings_event': {
+          const evt = msg.event
+          switch (evt.kind) {
+            case 'list':
+              dispatch({ type: 'AGENT_SETTINGS_LIST', entries: evt.entries })
+              break
+            case 'changed':
+              dispatch({ type: 'AGENT_SETTINGS_CHANGED', name: evt.name, entry: evt.entry })
+              break
+            case 'error':
+              dispatch({ type: 'AGENT_SETTINGS_ERROR', name: evt.name, error: evt.error })
+              break
+          }
+          break
+        }
         case 'status_line_update':
           dispatch({
             type: 'CUSTOM_STATUS_LINE_UPDATE',
@@ -379,6 +395,7 @@ export function App() {
         </box>
       )}
       {state.permissionRequest && <PermissionRequestDialog request={state.permissionRequest} />}
+      <AgentsDialog />
     </box>
   )
 }

--- a/ui/src/components/PromptInput/useComposerSubmit.ts
+++ b/ui/src/components/PromptInput/useComposerSubmit.ts
@@ -64,6 +64,17 @@ export function useComposerSubmit({
     if (isBusyRef.current) {
       return
     }
+    // Client-side-only commands that open UI dialogs without contacting
+    // the backend. Each one has a corresponding store action; add new
+    // entries here when introducing another UI-driven modal.
+    const trimmed = raw.trim()
+    const head = trimmed.split(/\s+/)[0] ?? ''
+    if (head === '/agents-ui' || head === '/au') {
+      dispatch({ type: 'PUSH_HISTORY', text: raw })
+      dispatch({ type: 'AGENT_SETTINGS_OPEN' })
+      reset()
+      return
+    }
     const id = `user-${Date.now()}`
     dispatch({ type: 'ADD_COMMAND_MESSAGE', id, text: raw })
     dispatch({ type: 'PUSH_HISTORY', text: raw })

--- a/ui/src/components/agent-settings/AgentDetailView.tsx
+++ b/ui/src/components/agent-settings/AgentDetailView.tsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import type { AgentDefinitionEntry } from '../../ipc/protocol.js'
+import { c } from '../../theme.js'
+import { isEditableSource, sourceColor, sourceLabel } from './constants.js'
+
+/**
+ * Read-only detail view for a single agent. Shown when the user highlights
+ * an entry in the list and presses Enter. Edits happen via the form view.
+ */
+
+export interface AgentDetailViewProps {
+  entry: AgentDefinitionEntry
+}
+
+export function AgentDetailView({ entry }: AgentDetailViewProps) {
+  return (
+    <box flexDirection="column">
+      <text>
+        <strong><span fg={c.textBright}>{entry.name}</span></strong>
+        <span fg={c.dim}>{'  ·  '}</span>
+        <span fg={sourceColor(entry.source)}>{sourceLabel(entry.source)}</span>
+        {isEditableSource(entry.source) ? null : (
+          <>
+            <span fg={c.dim}>{'  ·  '}</span>
+            <span fg={c.warning}>read-only</span>
+          </>
+        )}
+      </text>
+
+      {entry.file_path ? (
+        <text><span fg={c.dim}>{entry.file_path}</span></text>
+      ) : null}
+
+      <box marginTop={1} flexDirection="column">
+        <text>
+          <strong>Description</strong>
+          <span fg={c.dim}>{' (tells the orchestrator when to delegate)'}</span>
+        </text>
+        <box paddingLeft={2}>
+          <text fg={c.text}>{entry.description || <span fg={c.dim}>(none)</span>}</text>
+        </box>
+      </box>
+
+      <box marginTop={1} flexDirection="column">
+        <text>
+          <strong>Tools</strong>
+          <span fg={c.dim}>{': '}</span>
+          <span fg={c.text}>
+            {entry.tools.length === 0 ? '(inherit all tools)' : entry.tools.join(', ')}
+          </span>
+        </text>
+      </box>
+
+      <box flexDirection="column">
+        <text>
+          <strong>Model</strong>
+          <span fg={c.dim}>{': '}</span>
+          <span fg={c.text}>{entry.model ?? '(inherit)'}</span>
+        </text>
+      </box>
+
+      {entry.color ? (
+        <box flexDirection="column">
+          <text>
+            <strong>Color</strong>
+            <span fg={c.dim}>{': '}</span>
+            <span fg={c.text}>{entry.color}</span>
+          </text>
+        </box>
+      ) : null}
+
+      {entry.system_prompt ? (
+        <box marginTop={1} flexDirection="column">
+          <text>
+            <strong>System prompt</strong>
+          </text>
+          <box paddingLeft={2}>
+            <text fg={c.text}>{previewPrompt(entry.system_prompt)}</text>
+          </box>
+        </box>
+      ) : null}
+    </box>
+  )
+}
+
+/** Trim the system prompt for the detail pane — full text is in the file. */
+function previewPrompt(prompt: string): string {
+  const maxLines = 20
+  const lines = prompt.trim().split(/\r?\n/)
+  if (lines.length <= maxLines) return lines.join('\n')
+  return lines.slice(0, maxLines).join('\n') + '\n…'
+}

--- a/ui/src/components/agent-settings/AgentFormView.tsx
+++ b/ui/src/components/agent-settings/AgentFormView.tsx
@@ -1,0 +1,177 @@
+import React from 'react'
+import { c } from '../../theme.js'
+import { COLOR_CHOICES, MODEL_CHOICES } from './constants.js'
+import { TextField } from './TextField.js'
+
+/**
+ * Edit / create form. Fields are single-line except the system prompt, which
+ * is a simple multi-line buffer rendered verbatim (the dialog's keyboard
+ * handler feeds characters and `Enter` as newlines when this field is
+ * focused).
+ *
+ * The form is deliberately a dumb renderer; every piece of state (values,
+ * cursor positions, focus) is owned by `AgentsDialog` so a single keyboard
+ * handler can coordinate field movement with the dialog's modal state.
+ */
+
+export type FormField =
+  | 'name'
+  | 'description'
+  | 'tools'
+  | 'model'
+  | 'color'
+  | 'prompt'
+
+export interface FormState {
+  name: string
+  description: string
+  tools: string
+  model: string
+  color: string
+  prompt: string
+  /** Cursor offsets for the text fields — prompt has its own below. */
+  cursors: Record<'name' | 'description' | 'tools', number>
+  promptCursor: number
+}
+
+export interface AgentFormViewProps {
+  mode: 'create' | 'edit'
+  readOnlyName: boolean
+  state: FormState
+  focused: FormField
+  /** Validation message to show under the fields, or `null` if all good. */
+  error: string | null
+}
+
+export function AgentFormView({
+  mode,
+  readOnlyName,
+  state,
+  focused,
+  error,
+}: AgentFormViewProps) {
+  return (
+    <box flexDirection="column">
+      <text>
+        <strong><span fg={c.accent}>{mode === 'create' ? 'Create agent' : 'Edit agent'}</span></strong>
+      </text>
+      <text>
+        <span fg={c.dim}>
+          Tab / ↑↓ move · Enter submits from any single-line field · Esc cancels
+        </span>
+      </text>
+
+      <box marginTop={1} flexDirection="column">
+        <TextField
+          label="name"
+          value={state.name}
+          cursor={state.cursors.name}
+          active={focused === 'name' && !readOnlyName}
+          placeholder="my-agent"
+          hint={readOnlyName ? '(name is locked after creation)' : undefined}
+        />
+        <TextField
+          label="description"
+          value={state.description}
+          cursor={state.cursors.description}
+          active={focused === 'description'}
+          placeholder="When should the orchestrator delegate?"
+        />
+        <TextField
+          label="tools"
+          value={state.tools}
+          cursor={state.cursors.tools}
+          active={focused === 'tools'}
+          placeholder="Read, Grep, Bash (empty = all)"
+        />
+        {renderChoiceRow('model', 'model', state.model, focused, MODEL_CHOICES)}
+        {renderChoiceRow('color', 'color', state.color, focused, COLOR_CHOICES)}
+      </box>
+
+      <box marginTop={1} flexDirection="column">
+        <text>
+          <span fg={focused === 'prompt' ? c.textBright : c.dim}>system prompt </span>
+          <span fg={c.dim}>(Shift+Enter for newline on all platforms)</span>
+        </text>
+        <box paddingLeft={2} flexDirection="column">
+          {renderPromptBuffer(state.prompt, state.promptCursor, focused === 'prompt')}
+        </box>
+      </box>
+
+      {error ? (
+        <box marginTop={1}>
+          <text>
+            <span fg={c.error}>⚠ {error}</span>
+          </text>
+        </box>
+      ) : null}
+    </box>
+  )
+}
+
+function renderChoiceRow(
+  label: string,
+  field: FormField,
+  value: string,
+  focused: FormField,
+  options: ReadonlyArray<{ value: string; label: string }>,
+): React.ReactNode {
+  const active = focused === field
+  return (
+    <box flexDirection="row">
+      <text>
+        <span fg={active ? c.textBright : c.dim}>{label.padEnd(14, ' ')} </span>
+      </text>
+      {options.map((opt, i) => {
+        const isSelected = opt.value === value
+        const fg = isSelected ? (active ? c.bg : c.accent) : c.text
+        const bg = isSelected && active ? c.accent : undefined
+        return (
+          <text key={opt.value || '__empty'}>
+            <span fg={fg} bg={bg}>
+              {` ${opt.label} `}
+            </span>
+            {i < options.length - 1 ? <span fg={c.dim}>·</span> : null}
+          </text>
+        )
+      })}
+      {active ? (
+        <text>
+          <span fg={c.dim}>{'  ←/→ pick'}</span>
+        </text>
+      ) : null}
+    </box>
+  )
+}
+
+function renderPromptBuffer(
+  prompt: string,
+  cursor: number,
+  active: boolean,
+): React.ReactNode {
+  if (prompt.length === 0) {
+    return (
+      <text>
+        <span fg={c.bg} bg={active ? c.text : c.dim}> </span>
+        <span fg="#45475A">Describe how this agent should behave…</span>
+      </text>
+    )
+  }
+  if (!active) {
+    return <text fg={c.text}>{prompt}</text>
+  }
+  const clamped = Math.max(0, Math.min(cursor, prompt.length))
+  const before = prompt.slice(0, clamped)
+  const cursorChar = clamped < prompt.length ? prompt[clamped]! : ' '
+  const after = clamped < prompt.length ? prompt.slice(clamped + 1) : ''
+  // Newlines are passed through by `<text>` in OpenTUI so multi-line content
+  // wraps correctly; we only need to keep the cursor glyph separate.
+  return (
+    <text>
+      <span fg={c.text}>{before}</span>
+      <span fg={c.bg} bg={c.text}>{cursorChar === '\n' ? ' ' : cursorChar}</span>
+      {cursorChar === '\n' ? <span fg={c.text}>{'\n'}</span> : null}
+      <span fg={c.text}>{after}</span>
+    </text>
+  )
+}

--- a/ui/src/components/agent-settings/AgentsDialog.tsx
+++ b/ui/src/components/agent-settings/AgentsDialog.tsx
@@ -1,0 +1,604 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { useBackend } from '../../ipc/context.js'
+import type { AgentDefinitionEntry, AgentDefinitionSource } from '../../ipc/protocol.js'
+import { useAppDispatch, useAppState } from '../../store/app-store.js'
+import { c } from '../../theme.js'
+import { AgentDetailView } from './AgentDetailView.js'
+import { AgentFormView, type FormField, type FormState } from './AgentFormView.js'
+import { AgentsListView } from './AgentsListView.js'
+import {
+  COLOR_CHOICES,
+  MODEL_CHOICES,
+  isEditableSource,
+  sourceLabel,
+} from './constants.js'
+
+/**
+ * Top-level modal for the `/agents` settings editor. Mirrors the mode machine
+ * from `ui/examples/upstream-patterns/src/components/agents/AgentsMenu.tsx`
+ * (list → detail → edit / create / delete-confirm) but in the OpenTUI idiom
+ * and against the cc-rust backend protocol.
+ *
+ * The dialog owns its own transient state (current mode, form buffer, focused
+ * field). The agent list itself comes from `state.agentSettings.entries` in
+ * the app store — the backend emits that via `AgentSettingsEvent::List` in
+ * response to the `query_list` command we fire on mount.
+ */
+
+type Mode =
+  | { kind: 'list' }
+  | { kind: 'detail'; entry: AgentDefinitionEntry }
+  | { kind: 'edit'; entry: AgentDefinitionEntry; form: FormState; focused: FormField; error: string | null }
+  | { kind: 'create'; form: FormState; focused: FormField; scope: 'user' | 'project'; error: string | null }
+  | { kind: 'delete-confirm'; entry: AgentDefinitionEntry }
+
+const FIELD_ORDER: FormField[] = ['name', 'description', 'tools', 'model', 'color', 'prompt']
+
+export function AgentsDialog() {
+  const { agentSettings } = useAppState()
+  const dispatch = useAppDispatch()
+  const backend = useBackend()
+
+  const [mode, setMode] = useState<Mode>({ kind: 'list' })
+  const [cursor, setCursor] = useState(0)
+  const [createNewSelected, setCreateNewSelected] = useState(true)
+
+  // Fetch the current list every time the dialog opens.
+  useEffect(() => {
+    if (!agentSettings.open) return
+    setMode({ kind: 'list' })
+    setCursor(0)
+    setCreateNewSelected(true)
+    backend.send({
+      type: 'agent_settings_command',
+      command: { kind: 'query_list' },
+    })
+  }, [agentSettings.open, backend])
+
+  const entries = agentSettings.entries
+
+  const close = useCallback(() => {
+    dispatch({ type: 'AGENT_SETTINGS_CLOSE' })
+  }, [dispatch])
+
+  // When the backend confirms a change (upsert / delete), drop back to the
+  // list view so the user sees the fresh entry. We key off `lastUpdated` —
+  // it only moves forward when `AGENT_SETTINGS_LIST` or `…_CHANGED` fires.
+  useEffect(() => {
+    if (mode.kind === 'edit' || mode.kind === 'create') {
+      const lastMessage = agentSettings.lastMessage
+      if (lastMessage) {
+        setMode({ kind: 'list' })
+        setCreateNewSelected(true)
+        setCursor(0)
+      }
+    }
+  }, [agentSettings.lastMessage, agentSettings.lastUpdated])
+
+  // ── Keyboard dispatch ──────────────────────────────────────────────
+  useKeyboard(event => {
+    if (event.eventType === 'release' || !agentSettings.open) return
+    if (event.name === 'escape') {
+      onEscape()
+      return
+    }
+
+    if (mode.kind === 'list') {
+      handleListKey(event)
+    } else if (mode.kind === 'detail') {
+      handleDetailKey(event)
+    } else if (mode.kind === 'edit' || mode.kind === 'create') {
+      handleFormKey(event)
+    } else if (mode.kind === 'delete-confirm') {
+      handleDeleteKey(event)
+    }
+  })
+
+  function onEscape() {
+    if (mode.kind === 'list') {
+      close()
+    } else if (mode.kind === 'detail' || mode.kind === 'delete-confirm') {
+      setMode({ kind: 'list' })
+    } else {
+      // In edit / create, bounce to list without saving.
+      setMode({ kind: 'list' })
+    }
+  }
+
+  function handleListKey(event: KeyEvent) {
+    const totalItems = entries.length + 1 // +1 for the "Create new" row
+    if (totalItems === 0) return
+
+    const currentIdx = createNewSelected ? 0 : cursor + 1
+
+    if (event.name === 'up') {
+      const next = (currentIdx - 1 + totalItems) % totalItems
+      applyListIndex(next)
+    } else if (event.name === 'down' || event.name === 'tab') {
+      const next = (currentIdx + 1) % totalItems
+      applyListIndex(next)
+    } else if (event.name === 'return' || event.name === 'enter') {
+      if (createNewSelected) {
+        setMode(buildInitialCreateMode())
+      } else {
+        const entry = entries[cursor]
+        if (entry) setMode({ kind: 'detail', entry })
+      }
+    }
+  }
+
+  function applyListIndex(next: number) {
+    if (next === 0) {
+      setCreateNewSelected(true)
+    } else {
+      setCreateNewSelected(false)
+      setCursor(next - 1)
+    }
+  }
+
+  function handleDetailKey(event: KeyEvent) {
+    if (mode.kind !== 'detail') return
+    const input = (event.sequence ?? event.name ?? '').toLowerCase()
+    if (event.name === 'return' || event.name === 'enter') {
+      setMode({ kind: 'list' })
+      return
+    }
+    if (input === 'e' && isEditableSource(mode.entry.source)) {
+      setMode(buildEditMode(mode.entry))
+    } else if (input === 'd' && isEditableSource(mode.entry.source)) {
+      setMode({ kind: 'delete-confirm', entry: mode.entry })
+    }
+  }
+
+  function handleDeleteKey(event: KeyEvent) {
+    if (mode.kind !== 'delete-confirm') return
+    const input = (event.sequence ?? event.name ?? '').toLowerCase()
+    if (input === 'y') {
+      backend.send({
+        type: 'agent_settings_command',
+        command: {
+          kind: 'delete',
+          name: mode.entry.name,
+          source: mode.entry.source,
+        },
+      })
+      setMode({ kind: 'list' })
+    } else if (input === 'n') {
+      setMode({ kind: 'detail', entry: mode.entry })
+    }
+  }
+
+  function handleFormKey(event: KeyEvent) {
+    if (mode.kind !== 'edit' && mode.kind !== 'create') return
+    const current = mode
+    const focused = current.focused
+    const state = current.form
+
+    // Navigation between fields
+    if (event.name === 'tab') {
+      moveFocus(1)
+      return
+    }
+    if (event.name === 'up' && focused !== 'prompt') {
+      moveFocus(-1)
+      return
+    }
+    if (event.name === 'down' && focused !== 'prompt') {
+      moveFocus(1)
+      return
+    }
+
+    // Choice fields (model, color)
+    if (focused === 'model' || focused === 'color') {
+      const choices = focused === 'model' ? MODEL_CHOICES : COLOR_CHOICES
+      const current = focused === 'model' ? state.model : state.color
+      const idx = Math.max(0, choices.findIndex(opt => opt.value === current))
+      if (event.name === 'left' || event.name === 'right') {
+        const next = event.name === 'left'
+          ? (idx - 1 + choices.length) % choices.length
+          : (idx + 1) % choices.length
+        updateForm(f => focused === 'model'
+          ? { ...f, model: choices[next]!.value }
+          : { ...f, color: choices[next]!.value })
+        return
+      }
+      if (event.name === 'return' || event.name === 'enter') {
+        submitForm()
+        return
+      }
+      return
+    }
+
+    // Text fields & prompt
+    handleTextFieldKey(event, focused)
+  }
+
+  function handleTextFieldKey(event: KeyEvent, focused: FormField) {
+    const isPrompt = focused === 'prompt'
+
+    if (event.name === 'return' || event.name === 'enter') {
+      if (isPrompt || event.shift) {
+        // Insert newline in prompt; shift+enter inserts newline anywhere.
+        insertAtCursor(focused, '\n')
+      } else {
+        submitForm()
+      }
+      return
+    }
+
+    if (event.name === 'left') {
+      moveCursor(focused, -1)
+      return
+    }
+    if (event.name === 'right') {
+      moveCursor(focused, +1)
+      return
+    }
+    if (event.name === 'home') {
+      setCursor0(focused, 0)
+      return
+    }
+    if (event.name === 'end') {
+      setCursor0(focused, getValue(focused).length)
+      return
+    }
+    if (event.name === 'backspace') {
+      deleteAtCursor(focused, -1)
+      return
+    }
+    if (event.name === 'delete') {
+      deleteAtCursor(focused, +1)
+      return
+    }
+
+    // Printable character
+    const seq = event.sequence
+    if (typeof seq === 'string' && seq.length === 1 && seq >= ' ') {
+      insertAtCursor(focused, seq)
+    }
+  }
+
+  function moveFocus(delta: number) {
+    if (mode.kind !== 'edit' && mode.kind !== 'create') return
+    const idx = FIELD_ORDER.indexOf(mode.focused)
+    let next = (idx + delta + FIELD_ORDER.length) % FIELD_ORDER.length
+    // Skip the locked name field when editing.
+    if (mode.kind === 'edit' && FIELD_ORDER[next] === 'name') {
+      next = (next + delta + FIELD_ORDER.length) % FIELD_ORDER.length
+    }
+    updateMode({ focused: FIELD_ORDER[next]! })
+  }
+
+  function getValue(field: FormField): string {
+    if (mode.kind !== 'edit' && mode.kind !== 'create') return ''
+    return readField(mode.form, field)
+  }
+
+  function moveCursor(field: FormField, delta: number) {
+    const value = getValue(field)
+    if (field === 'prompt') {
+      if (mode.kind !== 'edit' && mode.kind !== 'create') return
+      const next = clamp(mode.form.promptCursor + delta, 0, value.length)
+      updateForm(f => ({ ...f, promptCursor: next }))
+    } else if (field === 'name' || field === 'description' || field === 'tools') {
+      if (mode.kind !== 'edit' && mode.kind !== 'create') return
+      const next = clamp(mode.form.cursors[field] + delta, 0, value.length)
+      updateForm(f => ({ ...f, cursors: { ...f.cursors, [field]: next } }))
+    }
+  }
+
+  function setCursor0(field: FormField, pos: number) {
+    if (mode.kind !== 'edit' && mode.kind !== 'create') return
+    if (field === 'prompt') {
+      updateForm(f => ({ ...f, promptCursor: clamp(pos, 0, f.prompt.length) }))
+    } else if (field === 'name' || field === 'description' || field === 'tools') {
+      updateForm(f => ({
+        ...f,
+        cursors: {
+          ...f.cursors,
+          [field]: clamp(pos, 0, readField(f, field).length),
+        },
+      }))
+    }
+  }
+
+  function insertAtCursor(field: FormField, text: string) {
+    if (mode.kind !== 'edit' && mode.kind !== 'create') return
+    if (field === 'prompt') {
+      updateForm(f => {
+        const cursor = clamp(f.promptCursor, 0, f.prompt.length)
+        const next = f.prompt.slice(0, cursor) + text + f.prompt.slice(cursor)
+        return { ...f, prompt: next, promptCursor: cursor + text.length }
+      })
+      return
+    }
+    if (field === 'name' || field === 'description' || field === 'tools') {
+      updateForm(f => {
+        const value = readField(f, field)
+        const cursor = clamp(f.cursors[field], 0, value.length)
+        const next = value.slice(0, cursor) + text + value.slice(cursor)
+        return writeField(f, field, next, cursor + text.length)
+      })
+    }
+  }
+
+  function deleteAtCursor(field: FormField, direction: -1 | 1) {
+    if (mode.kind !== 'edit' && mode.kind !== 'create') return
+    if (field === 'prompt') {
+      updateForm(f => {
+        const cursor = clamp(f.promptCursor, 0, f.prompt.length)
+        if (direction === -1 && cursor === 0) return f
+        if (direction === 1 && cursor === f.prompt.length) return f
+        const start = direction === -1 ? cursor - 1 : cursor
+        const end = direction === -1 ? cursor : cursor + 1
+        return {
+          ...f,
+          prompt: f.prompt.slice(0, start) + f.prompt.slice(end),
+          promptCursor: start,
+        }
+      })
+      return
+    }
+    if (field === 'name' || field === 'description' || field === 'tools') {
+      updateForm(f => {
+        const value = readField(f, field)
+        const cursor = clamp(f.cursors[field], 0, value.length)
+        if (direction === -1 && cursor === 0) return f
+        if (direction === 1 && cursor === value.length) return f
+        const start = direction === -1 ? cursor - 1 : cursor
+        const end = direction === -1 ? cursor : cursor + 1
+        return writeField(f, field, value.slice(0, start) + value.slice(end), start)
+      })
+    }
+  }
+
+  function updateForm(mut: (f: FormState) => FormState) {
+    if (mode.kind !== 'edit' && mode.kind !== 'create') return
+    setMode({ ...mode, form: mut(mode.form), error: null })
+  }
+
+  function updateMode(patch: Partial<Extract<Mode, { kind: 'edit' | 'create' }>>) {
+    if (mode.kind !== 'edit' && mode.kind !== 'create') return
+    setMode({ ...mode, ...patch } as Mode)
+  }
+
+  function submitForm() {
+    if (mode.kind !== 'edit' && mode.kind !== 'create') return
+    const form = mode.form
+    const nameTrim = form.name.trim()
+    if (!nameTrim) {
+      setMode({ ...mode, error: 'name is required' })
+      return
+    }
+    if (!/^[A-Za-z0-9_-]+$/.test(nameTrim)) {
+      setMode({
+        ...mode,
+        error: 'name may only contain letters, digits, `-`, and `_`',
+      })
+      return
+    }
+
+    const source: AgentDefinitionSource =
+      mode.kind === 'edit' ? mode.entry.source : { kind: mode.scope }
+
+    const entry: AgentDefinitionEntry = {
+      name: nameTrim,
+      description: form.description.trim(),
+      system_prompt: form.prompt,
+      tools: parseToolsList(form.tools),
+      model: form.model.trim() ? form.model.trim() : undefined,
+      color: form.color.trim() ? form.color.trim() : undefined,
+      source,
+      file_path: mode.kind === 'edit' ? mode.entry.file_path : undefined,
+    }
+
+    backend.send({
+      type: 'agent_settings_command',
+      command: { kind: 'upsert', entry },
+    })
+  }
+
+  // ── Rendering ──────────────────────────────────────────────────────
+  if (!agentSettings.open) return null
+
+  const footer = useMemo(() => renderFooter(mode), [mode])
+  const title = renderTitle(mode)
+
+  return (
+    <box
+      position="absolute"
+      top={1}
+      left={2}
+      right={2}
+      bottom={2}
+      flexDirection="column"
+      border
+      borderStyle="rounded"
+      borderColor={c.accent}
+      paddingX={2}
+      paddingY={1}
+      title={title}
+      titleAlignment="left"
+    >
+      <box flexDirection="column" flexGrow={1}>
+        {mode.kind === 'list' && (
+          <AgentsListView
+            entries={entries}
+            selectedIndex={cursor}
+            createNewSelected={createNewSelected}
+          />
+        )}
+        {mode.kind === 'detail' && <AgentDetailView entry={mode.entry} />}
+        {mode.kind === 'edit' && (
+          <AgentFormView
+            mode="edit"
+            readOnlyName
+            state={mode.form}
+            focused={mode.focused}
+            error={mode.error}
+          />
+        )}
+        {mode.kind === 'create' && (
+          <AgentFormView
+            mode="create"
+            readOnlyName={false}
+            state={mode.form}
+            focused={mode.focused}
+            error={mode.error}
+          />
+        )}
+        {mode.kind === 'delete-confirm' && renderDeleteConfirm(mode.entry)}
+      </box>
+
+      <box marginTop={1} flexDirection="column">
+        {agentSettings.lastError ? (
+          <text>
+            <span fg={c.error}>{agentSettings.lastError}</span>
+          </text>
+        ) : null}
+        {agentSettings.lastMessage && !agentSettings.lastError ? (
+          <text>
+            <span fg={c.success}>{agentSettings.lastMessage}</span>
+          </text>
+        ) : null}
+        <text>
+          <span fg={c.dim}>{footer}</span>
+        </text>
+      </box>
+    </box>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type KeyEvent = Parameters<Parameters<typeof useKeyboard>[0]>[0]
+
+function buildInitialCreateMode(): Extract<Mode, { kind: 'create' }> {
+  const form: FormState = {
+    name: '',
+    description: '',
+    tools: '',
+    model: '',
+    color: '',
+    prompt: '',
+    cursors: { name: 0, description: 0, tools: 0 },
+    promptCursor: 0,
+  }
+  return { kind: 'create', form, focused: 'name', scope: 'project', error: null }
+}
+
+function buildEditMode(entry: AgentDefinitionEntry): Extract<Mode, { kind: 'edit' }> {
+  const form: FormState = {
+    name: entry.name,
+    description: entry.description,
+    tools: entry.tools.join(', '),
+    model: entry.model ?? '',
+    color: entry.color ?? '',
+    prompt: entry.system_prompt,
+    cursors: {
+      name: entry.name.length,
+      description: entry.description.length,
+      tools: entry.tools.join(', ').length,
+    },
+    promptCursor: entry.system_prompt.length,
+  }
+  return { kind: 'edit', entry, form, focused: 'description', error: null }
+}
+
+function renderTitle(mode: Mode): string {
+  switch (mode.kind) {
+    case 'list':
+      return 'Agents · settings'
+    case 'detail':
+      return `Agents · ${mode.entry.name} (${sourceLabel(mode.entry.source)})`
+    case 'edit':
+      return `Agents · edit ${mode.entry.name}`
+    case 'create':
+      return 'Agents · new agent'
+    case 'delete-confirm':
+      return `Agents · delete ${mode.entry.name}?`
+  }
+}
+
+function renderFooter(mode: Mode): string {
+  switch (mode.kind) {
+    case 'list':
+      return '↑/↓ navigate · Enter open · Esc close'
+    case 'detail':
+      return 'e edit · d delete · Enter / Esc back'
+    case 'edit':
+    case 'create':
+      return 'Tab/↑↓ field · ←/→ choice · Enter save · Esc cancel'
+    case 'delete-confirm':
+      return 'y delete · n cancel'
+  }
+}
+
+function renderDeleteConfirm(entry: AgentDefinitionEntry): React.ReactNode {
+  return (
+    <box flexDirection="column">
+      <text>
+        Delete <strong>{entry.name}</strong>{' '}
+        <span fg={c.dim}>({sourceLabel(entry.source)})</span>?
+      </text>
+      <box marginTop={1}>
+        <text>
+          <span fg={c.dim}>This removes the backing markdown file. There is no undo.</span>
+        </text>
+      </box>
+      <box marginTop={1}>
+        <text>
+          <span fg={c.error}>[y] yes, delete</span>
+          <span fg={c.dim}>{'   '}</span>
+          <span fg={c.info}>[n] cancel</span>
+        </text>
+      </box>
+    </box>
+  )
+}
+
+function readField(f: FormState, field: FormField): string {
+  switch (field) {
+    case 'name':
+      return f.name
+    case 'description':
+      return f.description
+    case 'tools':
+      return f.tools
+    case 'model':
+      return f.model
+    case 'color':
+      return f.color
+    case 'prompt':
+      return f.prompt
+  }
+}
+
+function writeField(
+  f: FormState,
+  field: 'name' | 'description' | 'tools',
+  value: string,
+  cursor: number,
+): FormState {
+  return {
+    ...f,
+    [field]: value,
+    cursors: { ...f.cursors, [field]: cursor },
+  }
+}
+
+function parseToolsList(raw: string): string[] {
+  return raw
+    .split(/[,\s]+/)
+    .map(t => t.trim())
+    .filter(t => t.length > 0)
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  if (n < lo) return lo
+  if (n > hi) return hi
+  return n
+}

--- a/ui/src/components/agent-settings/AgentsListView.tsx
+++ b/ui/src/components/agent-settings/AgentsListView.tsx
@@ -1,0 +1,135 @@
+import React from 'react'
+import type { AgentDefinitionEntry } from '../../ipc/protocol.js'
+import { c } from '../../theme.js'
+import { sourceColor, sourceLabel } from './constants.js'
+
+/**
+ * Read-only list rendering for the agents dialog. Keyboard handling lives
+ * one level up (`AgentsDialog`) so we can share arrow-key logic between the
+ * list, detail, and form views.
+ *
+ * Agents are grouped by source with a visible section header. Within each
+ * section entries are sorted alphabetically by the parent — we render them
+ * in the order given.
+ */
+
+export interface AgentsListViewProps {
+  entries: AgentDefinitionEntry[]
+  selectedIndex: number
+  createNewSelected: boolean
+}
+
+export function AgentsListView({
+  entries,
+  selectedIndex,
+  createNewSelected,
+}: AgentsListViewProps) {
+  if (entries.length === 0 && !createNewSelected) {
+    return (
+      <box flexDirection="column" paddingY={1}>
+        <text><span fg={c.dim}>No agents discovered yet.</span></text>
+      </box>
+    )
+  }
+
+  // Render "create new" first, then a single flat list keyed by overall
+  // index so keyboard navigation stays predictable.
+  return (
+    <box flexDirection="column">
+      <box flexDirection="row">
+        <text>
+          <span fg={createNewSelected ? c.accent : c.dim}>
+            {createNewSelected ? '▸ ' : '  '}
+          </span>
+          <span fg={createNewSelected ? c.accent : c.text}>Create new agent…</span>
+        </text>
+      </box>
+
+      {renderGroupedList(entries, selectedIndex, createNewSelected)}
+    </box>
+  )
+}
+
+function renderGroupedList(
+  entries: AgentDefinitionEntry[],
+  selectedIndex: number,
+  createNewSelected: boolean,
+): React.ReactNode {
+  const groups: Array<{ label: string; start: number; items: AgentDefinitionEntry[] }> = []
+
+  let cursor = 0
+  const orderedKinds: ReadonlyArray<'user' | 'project' | 'plugin' | 'builtin'> = [
+    'user',
+    'project',
+    'plugin',
+    'builtin',
+  ]
+  const byKind: Record<string, AgentDefinitionEntry[]> = {}
+  for (const entry of entries) {
+    const key = entry.source.kind === 'plugin' ? `plugin:${entry.source.id}` : entry.source.kind
+    ;(byKind[key] ??= []).push(entry)
+  }
+
+  for (const kind of orderedKinds) {
+    const keys = Object.keys(byKind).filter(k => k === kind || k.startsWith(`${kind}:`))
+    for (const k of keys) {
+      const items = byKind[k]!
+      const label =
+        k === 'user'
+          ? 'User agents'
+          : k === 'project'
+            ? 'Project agents'
+            : k === 'builtin'
+              ? 'Built-in (read-only)'
+              : `Plugin ${k.replace(/^plugin:/, '')} (read-only)`
+      groups.push({ label, start: cursor, items })
+      cursor += items.length
+    }
+  }
+
+  return (
+    <box flexDirection="column">
+      {groups.map(group => (
+        <box key={group.label} flexDirection="column" marginTop={1}>
+          <text>
+            <strong><span fg={c.info}>{group.label}</span></strong>
+          </text>
+          {group.items.map((entry, localIdx) => {
+            const globalIdx = group.start + localIdx
+            const isSelected = !createNewSelected && globalIdx === selectedIndex
+            const color = sourceColor(entry.source)
+            return (
+              <box key={`${entry.source.kind}-${entry.name}`} flexDirection="row">
+                <text>
+                  <span fg={isSelected ? c.accent : c.dim}>
+                    {isSelected ? '▸ ' : '  '}
+                  </span>
+                  <span fg={isSelected ? c.textBright : c.text}>{entry.name}</span>
+                  <span fg={c.dim}>{' · '}</span>
+                  <span fg={color}>{sourceLabel(entry.source)}</span>
+                  {entry.model ? (
+                    <>
+                      <span fg={c.dim}>{' · '}</span>
+                      <span fg={c.dim}>{entry.model}</span>
+                    </>
+                  ) : null}
+                  {entry.description ? (
+                    <>
+                      <span fg={c.dim}>{'  — '}</span>
+                      <span fg={c.dim}>{truncate(entry.description, 70)}</span>
+                    </>
+                  ) : null}
+                </text>
+              </box>
+            )
+          })}
+        </box>
+      ))}
+    </box>
+  )
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s
+  return s.slice(0, max - 1) + '…'
+}

--- a/ui/src/components/agent-settings/TextField.tsx
+++ b/ui/src/components/agent-settings/TextField.tsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import { c } from '../../theme.js'
+
+/**
+ * Inline single-line text field. The cursor column is rendered with
+ * an inverted glyph so users can see where keystrokes land; editing is
+ * handled by the parent dialog's keyboard handler (we don't run our own
+ * `useKeyboard` here because the dialog juggles focus between multiple
+ * fields and modal actions).
+ *
+ * Matches the visual idiom already used by `ComposerBuffer` — distinct
+ * from `@opentui/react`'s missing built-in input.
+ */
+
+export interface TextFieldProps {
+  label: string
+  value: string
+  cursor: number
+  active: boolean
+  placeholder?: string
+  /** Shown in dim text to the right of the label; useful for validation hints. */
+  hint?: string
+  /** Widen the label column so multiple fields line up. */
+  labelWidth?: number
+}
+
+export function TextField({
+  label,
+  value,
+  cursor,
+  active,
+  placeholder = '',
+  hint,
+  labelWidth = 14,
+}: TextFieldProps) {
+  const padded = label.padEnd(labelWidth, ' ')
+  return (
+    <box flexDirection="row">
+      <text>
+        <span fg={active ? c.textBright : c.dim}>{padded}</span>
+        <span fg={c.dim}>{' '}</span>
+      </text>
+      {renderBuffer(value, cursor, active, placeholder)}
+      {hint ? (
+        <text>
+          <span fg={c.dim}>{'  '}</span>
+          <em><span fg={c.dim}>{hint}</span></em>
+        </text>
+      ) : null}
+    </box>
+  )
+}
+
+function renderBuffer(value: string, cursor: number, active: boolean, placeholder: string) {
+  if (value.length === 0) {
+    return (
+      <text>
+        <span fg={c.bg} bg={active ? c.text : c.dim}> </span>
+        <span fg="#45475A">{placeholder}</span>
+      </text>
+    )
+  }
+  const clamped = Math.max(0, Math.min(cursor, value.length))
+  const before = value.slice(0, clamped)
+  const cursorChar = clamped < value.length ? value[clamped]! : ' '
+  const after = clamped < value.length ? value.slice(clamped + 1) : ''
+  if (!active) {
+    return <text fg={c.text}>{value}</text>
+  }
+  return (
+    <text>
+      <span fg={c.text}>{before}</span>
+      <span fg={c.bg} bg={c.text}>{cursorChar}</span>
+      <span fg={c.text}>{after}</span>
+    </text>
+  )
+}

--- a/ui/src/components/agent-settings/constants.ts
+++ b/ui/src/components/agent-settings/constants.ts
@@ -1,0 +1,61 @@
+import type { AgentDefinitionSource } from '../../ipc/protocol.js'
+
+/**
+ * Fixed color palette exposed by the editor. Matches the eight-color set in
+ * the upstream upstream-patterns example; `""` means "unset / inherit".
+ */
+export const COLOR_CHOICES: ReadonlyArray<{ value: string; label: string }> = [
+  { value: '', label: '(default)' },
+  { value: 'red', label: 'red' },
+  { value: 'orange', label: 'orange' },
+  { value: 'yellow', label: 'yellow' },
+  { value: 'green', label: 'green' },
+  { value: 'blue', label: 'blue' },
+  { value: 'purple', label: 'purple' },
+  { value: 'pink', label: 'pink' },
+  { value: 'cyan', label: 'cyan' },
+]
+
+/**
+ * Model aliases the backend's `resolve_model_alias` understands plus the
+ * common long-form IDs. Empty value = "inherit from parent session".
+ */
+export const MODEL_CHOICES: ReadonlyArray<{ value: string; label: string }> = [
+  { value: '', label: '(inherit)' },
+  { value: 'sonnet', label: 'sonnet' },
+  { value: 'opus', label: 'opus' },
+  { value: 'haiku', label: 'haiku' },
+]
+
+/** Short human label for a source — used in lists. */
+export function sourceLabel(source: AgentDefinitionSource): string {
+  switch (source.kind) {
+    case 'builtin':
+      return 'built-in'
+    case 'user':
+      return 'user'
+    case 'project':
+      return 'project'
+    case 'plugin':
+      return source.id ? `plugin:${source.id}` : 'plugin'
+  }
+}
+
+/** Display color for the source tag. */
+export function sourceColor(source: AgentDefinitionSource): string {
+  switch (source.kind) {
+    case 'builtin':
+      return '#6C7086'
+    case 'user':
+      return '#89B4FA'
+    case 'project':
+      return '#A6E3A1'
+    case 'plugin':
+      return '#F9E2AF'
+  }
+}
+
+/** Non-editable sources (builtin, plugin) must surface as read-only in the UI. */
+export function isEditableSource(source: AgentDefinitionSource): boolean {
+  return source.kind === 'user' || source.kind === 'project'
+}

--- a/ui/src/components/agent-settings/index.ts
+++ b/ui/src/components/agent-settings/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Barrel for the `/agents` settings dialog. The dialog is mounted once
+ * inside `App` and shows itself when `state.agentSettings.open` is true.
+ */
+export { AgentsDialog } from './AgentsDialog.js'

--- a/ui/src/ipc/protocol.ts
+++ b/ui/src/ipc/protocol.ts
@@ -159,6 +159,33 @@ export interface SkillInfo {
   model_invocable: boolean
 }
 
+// ---------------------------------------------------------------------------
+// Agent-definition settings (mirror Rust `AgentDefinitionEntry` /
+// `AgentDefinitionSource` in `ipc/subsystem_types.rs`)
+// ---------------------------------------------------------------------------
+
+export type AgentDefinitionSource =
+  | { kind: 'builtin' }
+  | { kind: 'user' }
+  | { kind: 'project' }
+  | { kind: 'plugin'; id: string }
+
+export interface AgentDefinitionEntry {
+  name: string
+  description: string
+  system_prompt: string
+  tools: string[]
+  model?: string
+  color?: string
+  source: AgentDefinitionSource
+  file_path?: string
+}
+
+export type AgentSettingsEvent =
+  | { kind: 'list'; entries: AgentDefinitionEntry[] }
+  | { kind: 'changed'; name: string; entry?: AgentDefinitionEntry }
+  | { kind: 'error'; name: string; error: string }
+
 export interface SubsystemStatusSnapshot {
   lsp: LspServerInfo[]
   mcp: McpServerStatusInfo[]
@@ -336,6 +363,13 @@ export type FrontendMessage =
         | { kind: 'reconnect' }
         | { kind: 'query_status' }
     }
+  | {
+      type: 'agent_settings_command'
+      command:
+        | { kind: 'query_list' }
+        | { kind: 'upsert'; entry: AgentDefinitionEntry }
+        | { kind: 'delete'; name: string; source: AgentDefinitionSource }
+    }
   | { type: 'query_subsystem_status' }
 
 // ---------------------------------------------------------------------------
@@ -410,4 +444,5 @@ export type BackendMessage =
   | { type: 'plugin_event'; event: PluginEvent }
   | { type: 'skill_event'; event: SkillEvent }
   | { type: 'ide_event'; event: IdeEvent }
+  | { type: 'agent_settings_event'; event: AgentSettingsEvent }
   | { type: 'subsystem_status'; status: SubsystemStatusSnapshot }

--- a/ui/src/store/agent-settings.test.ts
+++ b/ui/src/store/agent-settings.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'bun:test'
+import type { AgentDefinitionEntry } from '../ipc/protocol.js'
+import { appReducer, initialState } from './app-store.js'
+
+const userEntry: AgentDefinitionEntry = {
+  name: 'reviewer',
+  description: 'Reviews code',
+  system_prompt: 'You are a code reviewer.',
+  tools: ['Read', 'Grep'],
+  model: 'sonnet',
+  color: 'blue',
+  source: { kind: 'user' },
+  file_path: '/fake/.cc-rust/agents/reviewer.md',
+}
+
+const projectEntry: AgentDefinitionEntry = {
+  ...userEntry,
+  system_prompt: 'Project-local reviewer.',
+  source: { kind: 'project' },
+  file_path: '/proj/.cc-rust/agents/reviewer.md',
+}
+
+describe('agent-settings reducer', () => {
+  test('open then list populates entries and leaves dialog open', () => {
+    const opened = appReducer(initialState, { type: 'AGENT_SETTINGS_OPEN' })
+    const listed = appReducer(opened, {
+      type: 'AGENT_SETTINGS_LIST',
+      entries: [userEntry, projectEntry],
+    })
+
+    expect(listed.agentSettings.open).toBe(true)
+    expect(listed.agentSettings.entries).toHaveLength(2)
+    expect(listed.agentSettings.entries[0]!.name).toBe('reviewer')
+  })
+
+  test('changed with entry upserts by (name, source) — sibling sources co-exist', () => {
+    const seeded = appReducer(initialState, {
+      type: 'AGENT_SETTINGS_LIST',
+      entries: [userEntry],
+    })
+    // New project-scope agent with the same name should be added, not replace.
+    const afterProject = appReducer(seeded, {
+      type: 'AGENT_SETTINGS_CHANGED',
+      name: 'reviewer',
+      entry: projectEntry,
+    })
+
+    expect(afterProject.agentSettings.entries).toHaveLength(2)
+    expect(afterProject.agentSettings.entries.map(e => e.source.kind).sort()).toEqual([
+      'project',
+      'user',
+    ])
+    expect(afterProject.agentSettings.lastMessage).toBe('Saved agent: reviewer')
+    expect(afterProject.agentSettings.lastError).toBeNull()
+  })
+
+  test('changed with entry replaces an existing same-source entry in place', () => {
+    const seeded = appReducer(initialState, {
+      type: 'AGENT_SETTINGS_LIST',
+      entries: [userEntry],
+    })
+    const updated: AgentDefinitionEntry = { ...userEntry, description: 'Updated!' }
+    const after = appReducer(seeded, {
+      type: 'AGENT_SETTINGS_CHANGED',
+      name: 'reviewer',
+      entry: updated,
+    })
+
+    expect(after.agentSettings.entries).toHaveLength(1)
+    expect(after.agentSettings.entries[0]!.description).toBe('Updated!')
+  })
+
+  test('changed with no entry removes matching-name entries', () => {
+    const seeded = appReducer(initialState, {
+      type: 'AGENT_SETTINGS_LIST',
+      entries: [userEntry, projectEntry],
+    })
+    const after = appReducer(seeded, {
+      type: 'AGENT_SETTINGS_CHANGED',
+      name: 'reviewer',
+    })
+
+    // Fallback-path with no entry strips every entry matching the name.
+    expect(after.agentSettings.entries).toHaveLength(0)
+    expect(after.agentSettings.lastMessage).toBe('Deleted agent: reviewer')
+  })
+
+  test('error event surfaces on lastError and clears lastMessage', () => {
+    const seeded = appReducer(initialState, { type: 'AGENT_SETTINGS_LIST', entries: [userEntry] })
+    const withSuccess = appReducer(seeded, {
+      type: 'AGENT_SETTINGS_CHANGED',
+      name: 'reviewer',
+      entry: { ...userEntry, description: 'v2' },
+    })
+    expect(withSuccess.agentSettings.lastMessage).not.toBeNull()
+
+    const withError = appReducer(withSuccess, {
+      type: 'AGENT_SETTINGS_ERROR',
+      name: 'reviewer',
+      error: 'scope is read-only',
+    })
+    expect(withError.agentSettings.lastError).toBe('reviewer: scope is read-only')
+    expect(withError.agentSettings.lastMessage).toBeNull()
+  })
+
+  test('close resets transient notices and open flag', () => {
+    const open = appReducer(initialState, { type: 'AGENT_SETTINGS_OPEN' })
+    const closed = appReducer(open, { type: 'AGENT_SETTINGS_CLOSE' })
+    expect(closed.agentSettings.open).toBe(false)
+    expect(closed.agentSettings.lastError).toBeNull()
+    expect(closed.agentSettings.lastMessage).toBeNull()
+  })
+})

--- a/ui/src/store/app-state.ts
+++ b/ui/src/store/app-state.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentDefinitionEntry,
   AgentNode,
   FrontendContentBlock,
   LspServerInfo,
@@ -78,6 +79,19 @@ export interface CustomStatusLineState {
   updatedAt: number
 }
 
+/**
+ * State for the `/agents` settings dialog. `entries` is the full list
+ * returned by the backend's `AgentSettingsEvent::List`; `lastError` surfaces
+ * the most recent `error` event so the dialog can show an inline message.
+ */
+export interface AgentSettingsState {
+  entries: AgentDefinitionEntry[]
+  open: boolean
+  lastError: string | null
+  lastMessage: string | null
+  lastUpdated: number
+}
+
 export interface AppState {
   messages: RawMessage[]
   streamingText: string
@@ -106,6 +120,7 @@ export interface AppState {
   teams: Record<string, TeamState>
   subsystems: SubsystemState
   customStatusLine: CustomStatusLineState | null
+  agentSettings: AgentSettingsState
 }
 
 export const initialState: AppState = {
@@ -136,6 +151,13 @@ export const initialState: AppState = {
   teams: {},
   subsystems: { lsp: [], mcp: [], plugins: [], skills: [], lastUpdated: 0 },
   customStatusLine: null,
+  agentSettings: {
+    entries: [],
+    open: false,
+    lastError: null,
+    lastMessage: null,
+    lastUpdated: 0,
+  },
 }
 
 export type CoreAction =
@@ -219,6 +241,14 @@ export type SubsystemAction =
   | { type: 'SKILLS_LOADED'; count: number }
   | { type: 'CUSTOM_STATUS_LINE_UPDATE'; lines: string[]; error?: string; updatedAt: number }
 
+export type AgentSettingsAction =
+  | { type: 'AGENT_SETTINGS_OPEN' }
+  | { type: 'AGENT_SETTINGS_CLOSE' }
+  | { type: 'AGENT_SETTINGS_LIST'; entries: AgentDefinitionEntry[] }
+  | { type: 'AGENT_SETTINGS_CHANGED'; name: string; entry?: AgentDefinitionEntry }
+  | { type: 'AGENT_SETTINGS_ERROR'; name: string; error: string }
+  | { type: 'AGENT_SETTINGS_CLEAR_NOTICE' }
+
 export type InputAction =
   | { type: 'PUSH_HISTORY'; text: string }
   | { type: 'SET_HISTORY_INDEX'; index: number }
@@ -238,4 +268,5 @@ export type AppAction =
   | AgentTreeAction
   | TeamAction
   | SubsystemAction
+  | AgentSettingsAction
   | InputAction

--- a/ui/src/store/app-store.tsx
+++ b/ui/src/store/app-store.tsx
@@ -4,6 +4,7 @@ import {
   type AppAction,
   type AppState,
 } from './app-state.js'
+import { reduceAgentSettings } from './reducers/agent-settings.js'
 import { reduceAgentTree } from './reducers/agent-tree.js'
 import { reduceBackgroundAgents } from './reducers/background-agents.js'
 import { reduceCore } from './reducers/core.js'
@@ -78,6 +79,14 @@ export function appReducer(state: AppState, action: AppAction): AppState {
     case 'SKILLS_LOADED':
     case 'CUSTOM_STATUS_LINE_UPDATE':
       return reduceSubsystems(state, action)
+
+    case 'AGENT_SETTINGS_OPEN':
+    case 'AGENT_SETTINGS_CLOSE':
+    case 'AGENT_SETTINGS_LIST':
+    case 'AGENT_SETTINGS_CHANGED':
+    case 'AGENT_SETTINGS_ERROR':
+    case 'AGENT_SETTINGS_CLEAR_NOTICE':
+      return reduceAgentSettings(state, action)
 
     case 'PUSH_HISTORY':
     case 'SET_HISTORY_INDEX':

--- a/ui/src/store/reducers/agent-settings.ts
+++ b/ui/src/store/reducers/agent-settings.ts
@@ -1,0 +1,114 @@
+import type { AppState, AgentSettingsAction } from '../app-state.js'
+
+/**
+ * Reducer for the `/agents` settings dialog. Owns both transient UI state
+ * (open flag, last error/message notice) and the persisted entries list that
+ * the backend sends via `AgentSettingsEvent`.
+ */
+export function reduceAgentSettings(state: AppState, action: AgentSettingsAction): AppState {
+  switch (action.type) {
+    case 'AGENT_SETTINGS_OPEN':
+      return {
+        ...state,
+        agentSettings: {
+          ...state.agentSettings,
+          open: true,
+          lastError: null,
+          lastMessage: null,
+        },
+      }
+
+    case 'AGENT_SETTINGS_CLOSE':
+      return {
+        ...state,
+        agentSettings: {
+          ...state.agentSettings,
+          open: false,
+          lastError: null,
+          lastMessage: null,
+        },
+      }
+
+    case 'AGENT_SETTINGS_LIST':
+      return {
+        ...state,
+        agentSettings: {
+          ...state.agentSettings,
+          entries: action.entries,
+          lastUpdated: Date.now(),
+          lastError: null,
+        },
+      }
+
+    case 'AGENT_SETTINGS_CHANGED': {
+      const existing = state.agentSettings.entries
+      const next = action.entry
+        ? upsertEntry(existing, action.entry)
+        : existing.filter(
+            e =>
+              !(e.name === action.name && entrySourceMatches(e, action.entry?.source ?? null)),
+          )
+      const verb = action.entry ? 'Saved' : 'Deleted'
+      return {
+        ...state,
+        agentSettings: {
+          ...state.agentSettings,
+          entries: next,
+          lastUpdated: Date.now(),
+          lastError: null,
+          lastMessage: `${verb} agent: ${action.name}`,
+        },
+      }
+    }
+
+    case 'AGENT_SETTINGS_ERROR':
+      return {
+        ...state,
+        agentSettings: {
+          ...state.agentSettings,
+          lastError: `${action.name}: ${action.error}`,
+          lastMessage: null,
+        },
+      }
+
+    case 'AGENT_SETTINGS_CLEAR_NOTICE':
+      return {
+        ...state,
+        agentSettings: {
+          ...state.agentSettings,
+          lastError: null,
+          lastMessage: null,
+        },
+      }
+  }
+}
+
+function upsertEntry(
+  list: AppState['agentSettings']['entries'],
+  entry: AppState['agentSettings']['entries'][number],
+): AppState['agentSettings']['entries'] {
+  const idx = list.findIndex(
+    e => e.name === entry.name && entrySourceMatches(e, entry.source),
+  )
+  if (idx < 0) return [...list, entry]
+  const next = [...list]
+  next[idx] = entry
+  return next
+}
+
+/**
+ * Entries are keyed on `(name, source)` — two sources can contribute an
+ * agent with the same name (e.g. a project override of a user agent), so we
+ * compare the full source tag plus any source-specific id.
+ */
+function entrySourceMatches(
+  a: AppState['agentSettings']['entries'][number],
+  b: AppState['agentSettings']['entries'][number]['source'] | null,
+): boolean {
+  if (b === null) return true
+  if (a.source.kind !== b.kind) return false
+  if (a.source.kind === 'plugin' && b.kind === 'plugin') {
+    return a.source.id === b.id
+  }
+  return true
+}


### PR DESCRIPTION
## Summary
- Adds a full CRUD UI for agent definitions — markdown files with YAML frontmatter under `~/.cc-rust/agents/` (user) and `{cwd}/.cc-rust/agents/` (project). Built-in and plugin sources surface as read-only.
- Modelled after [ui/examples/upstream-patterns/src/components/agents](../tree/tui/ui/examples/upstream-patterns/src/components/agents), adapted to OpenTUI + the Lite IPC protocol.
- Invoked client-side via `/agents-ui` (alias `/au`).

## What changed

### Backend (`crates/claude-code-rs/src/ipc/`)
- `subsystem_types.rs`: `AgentDefinitionEntry` + `AgentDefinitionSource` tagged enum with `is_editable()` / `label()` helpers.
- `subsystem_events.rs`: `AgentSettingsCommand` (`query_list` / `upsert` / `delete`) and `AgentSettingsEvent` (`list` / `changed` / `error`); wrapped into the `SubsystemEvent` bus.
- `agent_settings.rs` (new): loader + writer with frontmatter parsing, atomic rename, and traversal-safe name validation. 8 unit tests cover round-trip, read-only rejection, and deletion.
- `protocol/mod.rs` / `ingress.rs` / `runtime.rs`: new message variants + dispatch.

### Frontend (`ui/src/`)
- `ipc/protocol.ts`: mirrored types + `agent_settings_command` / `agent_settings_event` wire variants.
- `store/app-state.ts` + `store/reducers/agent-settings.ts`: dialog state (`open`, `entries`, `lastError`, `lastMessage`) keyed on `(name, source)` so user and project overrides co-exist. 6 reducer tests.
- `components/agent-settings/`: `AgentsDialog` orchestrator + `AgentsListView` / `AgentDetailView` / `AgentFormView` / `TextField` / `constants`. Dialog modes: list → detail → edit / create / delete-confirm, with full keyboard navigation (Tab/↑↓ fields, ←/→ choices, Enter save, Esc cancel).
- `commands.ts` + `PromptInput/useComposerSubmit.ts`: `/agents-ui` (alias `/au`) is intercepted client-side and opens the dialog without contacting the backend.
- `components/App.tsx`: mounts the dialog + routes `agent_settings_event` messages to the reducer.

## Reviewer notes

- **Name validation is stricter than the upstream TS loader** on purpose — writes happen without a confirmation prompt, so the regex `/^[A-Za-z0-9_-]+$/` and a 64-char cap prevent directory-traversal surprises.
- The dialog is a modal overlay (absolute-positioned), rendered alongside `PermissionRequestDialog` in `App`.
- Built-in sources are hard-coded in `agent_settings.rs::BUILTIN_AGENTS` to match the list in `commands/agents_cmd.rs::BUILTIN_SUBAGENTS`. Kept as two const arrays rather than a shared one to avoid a cyclic dep with the command layer; if they drift the `/agents` text output and the dialog will disagree.
- The client-side `/agents-ui` keeps the existing text-based `/agents` command unchanged so existing workflows keep working.
- Multi-line prompt editing uses a simple buffer — Shift+Enter inserts newlines (Enter from single-line fields submits).

## Test plan
- [x] `cargo test -p claude-code-rs --bin claude-code-rs -- ipc::` — 119/119 pass (8 new agent_settings tests + all existing)
- [x] `bun test src/store/ src/adapters/ src/ipc/` — 76/76 pass (6 new reducer tests)
- [x] `cargo build -p claude-code-rs` — no new warnings
- [x] UI typecheck: no new errors in my files (one pre-existing `App.tsx` warning unchanged)
- [ ] Manual: run `cc-rust`, type `/agents-ui`, exercise list → create → edit → delete → roundtrip across a `.cc-rust/agents/*.md` file on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)