### PR TITLE
feat(lsp): LSP plugin recommendation settings + dialog

### DIFF
--- a/crates/claude-code-rs/src/ipc/subsystem_events.rs
+++ b/crates/claude-code-rs/src/ipc/subsystem_events.rs
@@ -38,6 +38,20 @@ pub enum LspEvent {
     },
     /// Full list of LSP servers (response to `QueryStatus`).
     ServerList { servers: Vec<LspServerInfo> },
+    /// Ask the frontend to show the "install suggested LSP" prompt.
+    ///
+    /// Mirrors upstream `LspRecommendationMenu`. The frontend replies via
+    /// [`LspCommand::RecommendationResponse`].
+    RecommendationRequest {
+        #[serde(flatten)]
+        payload: LspRecommendationPayload,
+    },
+    /// Current persisted settings for recommendation prompts (response to
+    /// [`LspCommand::QuerySettings`]). Lets the frontend show "muted
+    /// plugins" or "all disabled" state in an LSP settings view.
+    SettingsSnapshot {
+        settings: LspRecommendationSettings,
+    },
 }
 
 /// Events emitted by the MCP subsystem.
@@ -193,6 +207,26 @@ pub enum LspCommand {
     StopServer { language_id: String },
     RestartServer { language_id: String },
     QueryStatus,
+    /// Return the currently-persisted recommendation settings as an
+    /// [`LspEvent::SettingsSnapshot`].
+    QuerySettings,
+    /// User's reply to an [`LspEvent::RecommendationRequest`]. `decision`
+    /// is one of `"yes"`, `"no"`, `"never"`, `"disable"`. `never` mutes
+    /// future prompts for the named plugin; `disable` turns the whole
+    /// prompt off. Both persist to the user-level `settings.json`.
+    RecommendationResponse {
+        request_id: String,
+        plugin_name: String,
+        decision: String,
+    },
+    /// Clear a previously-muted plugin from the "never recommend" list.
+    /// Used by an LSP settings view to let the user undo a past
+    /// `"never for X"` choice.
+    UnmutePlugin { plugin_name: String },
+    /// Explicit toggle for the global "disable all recommendations"
+    /// switch, so a settings view can flip it without having to
+    /// synthesize a fake response.
+    SetRecommendationsDisabled { disabled: bool },
 }
 
 /// Commands the frontend can send to the MCP subsystem.
@@ -412,6 +446,84 @@ mod tests {
         let value = serde_json::to_value(&event).expect("serialize");
         assert_eq!(value["kind"], "server_list");
         assert_eq!(value["servers"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn lsp_event_recommendation_request_serializes_flat() {
+        let event = LspEvent::RecommendationRequest {
+            payload: LspRecommendationPayload {
+                request_id: "req-1".into(),
+                plugin_name: "rust-analyzer".into(),
+                plugin_description: Some("Rust language server".into()),
+                file_extension: ".rs".into(),
+                language_id: Some("rust".into()),
+            },
+        };
+        let value = serde_json::to_value(&event).unwrap();
+        assert_eq!(value["kind"], "recommendation_request");
+        // `#[serde(flatten)]` means payload fields sit next to `kind`.
+        assert_eq!(value["request_id"], "req-1");
+        assert_eq!(value["plugin_name"], "rust-analyzer");
+        assert_eq!(value["file_extension"], ".rs");
+    }
+
+    #[test]
+    fn lsp_event_settings_snapshot_serializes() {
+        let event = LspEvent::SettingsSnapshot {
+            settings: LspRecommendationSettings {
+                disabled: false,
+                muted_plugins: vec!["pyright".into()],
+            },
+        };
+        let value = serde_json::to_value(&event).unwrap();
+        assert_eq!(value["kind"], "settings_snapshot");
+        assert_eq!(value["settings"]["disabled"], false);
+        assert_eq!(value["settings"]["muted_plugins"][0], "pyright");
+    }
+
+    #[test]
+    fn lsp_command_recommendation_response_deserializes() {
+        let json = r#"{
+            "kind":"recommendation_response",
+            "request_id":"req-1",
+            "plugin_name":"rust-analyzer",
+            "decision":"never"
+        }"#;
+        let cmd: LspCommand = serde_json::from_str(json).expect("deserialize");
+        match cmd {
+            LspCommand::RecommendationResponse {
+                request_id,
+                plugin_name,
+                decision,
+            } => {
+                assert_eq!(request_id, "req-1");
+                assert_eq!(plugin_name, "rust-analyzer");
+                assert_eq!(decision, "never");
+            }
+            other => panic!("unexpected variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn lsp_command_unmute_plugin_deserializes() {
+        let json = r#"{"kind":"unmute_plugin","plugin_name":"pyright"}"#;
+        let cmd: LspCommand = serde_json::from_str(json).unwrap();
+        match cmd {
+            LspCommand::UnmutePlugin { plugin_name } => {
+                assert_eq!(plugin_name, "pyright");
+            }
+            other => panic!("unexpected variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn lsp_command_set_recommendations_disabled_deserializes() {
+        let json = r#"{"kind":"set_recommendations_disabled","disabled":true}"#;
+        let cmd: LspCommand = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            cmd,
+            LspCommand::SetRecommendationsDisabled { disabled: true }
+        ));
     }
 
     #[test]

--- a/crates/claude-code-rs/src/ipc/subsystem_handlers.rs
+++ b/crates/claude-code-rs/src/ipc/subsystem_handlers.rs
@@ -65,7 +65,164 @@ pub fn handle_lsp_command(cmd: super::subsystem_events::LspCommand) -> Vec<Backe
                 event: LspEvent::ServerList { servers },
             }]
         }
+        LspCommand::QuerySettings => {
+            let settings = load_lsp_recommendation_settings();
+            vec![BackendMessage::LspEvent {
+                event: LspEvent::SettingsSnapshot { settings },
+            }]
+        }
+        LspCommand::RecommendationResponse {
+            request_id,
+            plugin_name,
+            decision,
+        } => {
+            tracing::info!(
+                request_id = %request_id,
+                plugin_name = %plugin_name,
+                decision = %decision,
+                "LSP recommendation response"
+            );
+            let (settings, info_text) = apply_recommendation_decision(&plugin_name, &decision);
+            let mut msgs = Vec::with_capacity(2);
+            msgs.push(BackendMessage::LspEvent {
+                event: LspEvent::SettingsSnapshot { settings },
+            });
+            if let Some(text) = info_text {
+                msgs.push(BackendMessage::SystemInfo {
+                    text,
+                    level: "info".to_string(),
+                });
+            }
+            msgs
+        }
+        LspCommand::UnmutePlugin { plugin_name } => {
+            let settings = unmute_lsp_plugin(&plugin_name);
+            vec![BackendMessage::LspEvent {
+                event: LspEvent::SettingsSnapshot { settings },
+            }]
+        }
+        LspCommand::SetRecommendationsDisabled { disabled } => {
+            let settings = set_lsp_recommendations_disabled(disabled);
+            vec![BackendMessage::LspEvent {
+                event: LspEvent::SettingsSnapshot { settings },
+            }]
+        }
     }
+}
+
+// ---------------------------------------------------------------------------
+// LSP recommendation settings persistence
+// ---------------------------------------------------------------------------
+
+/// Key inside the user-level `settings.json` object that holds the
+/// `LspRecommendationSettings` payload.
+const LSP_RECOMMENDATIONS_KEY: &str = "lspRecommendations";
+
+/// Read the `lspRecommendations` block from the user settings file.
+///
+/// Returns a `Default` value when the file is missing, the key is
+/// absent, or the stored value fails to deserialize — a corrupt entry
+/// should never brick the prompt pipeline.
+pub fn load_lsp_recommendation_settings() -> LspRecommendationSettings {
+    let path = cc_config::settings::user_settings_path();
+    let Ok(value) = read_settings_value(&path) else {
+        return LspRecommendationSettings::default();
+    };
+    value
+        .get(LSP_RECOMMENDATIONS_KEY)
+        .and_then(|v| serde_json::from_value::<LspRecommendationSettings>(v.clone()).ok())
+        .unwrap_or_default()
+}
+
+/// Persist `settings` under the `lspRecommendations` key, preserving every
+/// other field in the user settings file.
+fn save_lsp_recommendation_settings(settings: &LspRecommendationSettings) {
+    let path = cc_config::settings::user_settings_path();
+    let mut value = read_settings_value(&path).unwrap_or_else(|err| {
+        tracing::warn!(error = %err, "LSP recommendations: read user settings failed; overwriting with fresh object");
+        serde_json::Value::Object(serde_json::Map::new())
+    });
+    if !value.is_object() {
+        value = serde_json::Value::Object(serde_json::Map::new());
+    }
+    let encoded = match serde_json::to_value(settings) {
+        Ok(v) => v,
+        Err(err) => {
+            tracing::warn!(error = %err, "LSP recommendations: serialize failed");
+            return;
+        }
+    };
+    value
+        .as_object_mut()
+        .expect("value is object")
+        .insert(LSP_RECOMMENDATIONS_KEY.to_string(), encoded);
+    if let Err(err) = write_settings_value(&path, &value) {
+        tracing::warn!(error = %err, "LSP recommendations: write user settings failed");
+    }
+}
+
+/// Apply a user decision from an [`LspEvent::RecommendationRequest`] prompt.
+///
+/// Returns the updated settings snapshot plus an optional info-level
+/// message the frontend can surface in its system log. `yes` / `no` do
+/// not mutate persistent state — the install itself is carried out
+/// elsewhere (or postponed to the next session); only `never` and
+/// `disable` are sticky.
+fn apply_recommendation_decision(
+    plugin_name: &str,
+    decision: &str,
+) -> (LspRecommendationSettings, Option<String>) {
+    let mut settings = load_lsp_recommendation_settings();
+    let info = match decision {
+        "yes" => Some(format!(
+            "Install of LSP plugin '{}' is not yet wired up — track in /lsp when the install path lands.",
+            plugin_name
+        )),
+        "no" => None,
+        "never" => {
+            if !settings.muted_plugins.iter().any(|p| p == plugin_name) {
+                settings.muted_plugins.push(plugin_name.to_string());
+                save_lsp_recommendation_settings(&settings);
+            }
+            Some(format!(
+                "Muted LSP recommendation for '{}'. Run /lsp to undo.",
+                plugin_name
+            ))
+        }
+        "disable" => {
+            if !settings.disabled {
+                settings.disabled = true;
+                save_lsp_recommendation_settings(&settings);
+            }
+            Some("Disabled all LSP plugin recommendations. Run /lsp to re-enable.".to_string())
+        }
+        other => {
+            tracing::warn!(decision = %other, "LSP recommendations: unknown decision value");
+            None
+        }
+    };
+    (settings, info)
+}
+
+/// Remove `plugin_name` from the muted list and persist the result.
+fn unmute_lsp_plugin(plugin_name: &str) -> LspRecommendationSettings {
+    let mut settings = load_lsp_recommendation_settings();
+    let before = settings.muted_plugins.len();
+    settings.muted_plugins.retain(|p| p != plugin_name);
+    if settings.muted_plugins.len() != before {
+        save_lsp_recommendation_settings(&settings);
+    }
+    settings
+}
+
+/// Flip the global "disable all recommendations" switch.
+fn set_lsp_recommendations_disabled(disabled: bool) -> LspRecommendationSettings {
+    let mut settings = load_lsp_recommendation_settings();
+    if settings.disabled != disabled {
+        settings.disabled = disabled;
+        save_lsp_recommendation_settings(&settings);
+    }
+    settings
 }
 
 /// Handle an MCP subsystem command from the frontend.
@@ -843,6 +1000,32 @@ mod tests {
         });
         assert_eq!(msgs.len(), 1);
         assert!(matches!(&msgs[0], BackendMessage::SystemInfo { .. }));
+    }
+
+    #[test]
+    fn apply_recommendation_decision_no_is_noop() {
+        // `no` should not emit a system-info message or mutate persistence.
+        let (_settings, info) = apply_recommendation_decision("foo-ls", "no");
+        assert!(info.is_none(), "'no' should not produce an info message");
+    }
+
+    #[test]
+    fn apply_recommendation_decision_unknown_is_warned_but_silent() {
+        // Unknown decisions shouldn't blow up or leak into the UI.
+        let (_settings, info) = apply_recommendation_decision("foo-ls", "banana");
+        assert!(info.is_none());
+    }
+
+    #[test]
+    fn apply_recommendation_decision_yes_emits_placeholder_info() {
+        // Until the install path is wired up, `yes` returns the placeholder
+        // info text. When the real install lands this test should be
+        // replaced — the point here is that `yes` *does* surface a message
+        // so the user knows something happened.
+        let (_settings, info) = apply_recommendation_decision("rust-analyzer", "yes");
+        assert!(info.is_some());
+        let text = info.unwrap();
+        assert!(text.contains("rust-analyzer"));
     }
 
     #[test]

--- a/crates/claude-code-rs/src/ipc/subsystem_types.rs
+++ b/crates/claude-code-rs/src/ipc/subsystem_types.rs
@@ -62,6 +62,47 @@ pub struct LspServerInfo {
     pub error: Option<String>,
 }
 
+/// Payload describing an LSP plugin recommendation prompt.
+///
+/// Emitted when the backend detects a file whose extension is served by
+/// a not-yet-installed LSP plugin (mirrors upstream `LspRecommendationMenu`
+/// at `ui/examples/upstream-patterns/src/components/LspRecommendation/`).
+/// The frontend shows a dialog and replies via
+/// [`LspCommand::RecommendationResponse`] with one of `yes` / `no` /
+/// `never` / `disable`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct LspRecommendationPayload {
+    /// Stable identifier the frontend echoes back in the response so the
+    /// backend can correlate multiple in-flight prompts.
+    pub request_id: String,
+    /// Plugin identifier (e.g. `"rust-analyzer"`).
+    pub plugin_name: String,
+    /// Optional longer description shown under the plugin name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plugin_description: Option<String>,
+    /// File extension (including the leading dot) that triggered the prompt.
+    pub file_extension: String,
+    /// Optional language id — provided when the backend wants the frontend
+    /// to display a more specific label than `file_extension` alone.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language_id: Option<String>,
+}
+
+/// Snapshot of the "never recommend" / "disable all" preferences used by
+/// the LSP recommendation prompt. Persisted under the user-level
+/// `settings.json` and echoed back to the frontend when the settings
+/// view asks for them.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct LspRecommendationSettings {
+    /// When `true`, the backend MUST NOT emit any further
+    /// `LspEvent::RecommendationRequest` events.
+    #[serde(default)]
+    pub disabled: bool,
+    /// Plugin names the user explicitly muted via "never for X".
+    #[serde(default)]
+    pub muted_plugins: Vec<String>,
+}
+
 // ---------------------------------------------------------------------------
 // MCP types
 // ---------------------------------------------------------------------------

--- a/ui/docs/ui-panels-deferred.md
+++ b/ui/docs/ui-panels-deferred.md
@@ -48,13 +48,17 @@ Per-server reconnect workflow with retry backoff visualization.
 
 ### `ui/examples/upstream-patterns/src/components/LspRecommendation/LspRecommendationMenu.tsx`
 
-"Install suggested LSPs" flow reached from a menu hint.
+**Ported.** Lives at
+`ui/src/components/LspRecommendationDialog.tsx` and renders inside
+`App.tsx` when the backend emits `LspEvent::RecommendationRequest`.
+Persistence of the "never for X" / "disable all" choices goes through
+new `LspCommand::RecommendationResponse` / `UnmutePlugin` /
+`SetRecommendationsDisabled` commands and is stored under the
+`lspRecommendations` key in the user-level `settings.json`.
 
-- **Blocker**: `LspServerInfo` does not include a `recommended`
-  bucket or an install action channel.
-- **Unblock path**: teach the Rust LSP manager to publish a
-  `recommended_languages` snapshot alongside the active list, and add
-  an `lsp_install_request` IPC message.
+Install path itself is still a TODO — today the backend just
+acknowledges `yes` with an info message. Hook it up to the `/lsp`
+install flow when that lands.
 
 ### `ui/examples/upstream-patterns/src/components/DiagnosticsDisplay.tsx`
 

--- a/ui/src/components/App.tsx
+++ b/ui/src/components/App.tsx
@@ -10,6 +10,7 @@ import { c } from '../theme.js'
 import { AgentsDialog } from './agent-settings/index.js'
 import { AgentTreePanel } from './AgentTreePanel.js'
 import { InputPrompt } from './InputPrompt.js'
+import { LspRecommendationDialog } from './LspRecommendationDialog.js'
 import { MessageList } from './MessageList.js'
 import { PermissionRequestDialog } from './permissions/index.js'
 import { StatusLine } from './StatusLine/index.js'
@@ -240,11 +241,23 @@ export function App() {
         }
 
         // ── Subsystem events ──────────────────────────────────
-        case 'lsp_event':
-          if (msg.event.kind === 'server_state_changed') {
-            dispatch({ type: 'LSP_SERVER_STATE', languageId: msg.event.language_id, state: msg.event.state, error: msg.event.error })
+        case 'lsp_event': {
+          const evt = msg.event
+          switch (evt.kind) {
+            case 'server_state_changed':
+              dispatch({ type: 'LSP_SERVER_STATE', languageId: evt.language_id, state: evt.state, error: evt.error })
+              break
+            case 'recommendation_request': {
+              const { kind: _kind, ...payload } = evt
+              dispatch({ type: 'LSP_RECOMMENDATION_REQUEST', payload })
+              break
+            }
+            case 'settings_snapshot':
+              dispatch({ type: 'LSP_RECOMMENDATION_SETTINGS', settings: evt.settings })
+              break
           }
           break
+        }
         case 'mcp_event':
           if (msg.event.kind === 'server_state_changed') {
             dispatch({ type: 'MCP_SERVER_STATE', serverName: msg.event.server_name, state: msg.event.state, error: msg.event.error })
@@ -433,6 +446,9 @@ export function App() {
         </box>
       )}
       {state.permissionRequest && <PermissionRequestDialog request={state.permissionRequest} />}
+      {!state.permissionRequest && state.lspRecommendation.request && (
+        <LspRecommendationDialog payload={state.lspRecommendation.request} />
+      )}
       <AgentsDialog />
     </box>
   )

--- a/ui/src/components/LspRecommendationDialog.tsx
+++ b/ui/src/components/LspRecommendationDialog.tsx
@@ -1,0 +1,176 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { useBackend } from '../ipc/context.js'
+import type {
+  LspRecommendationDecision,
+  LspRecommendationPayload,
+} from '../ipc/protocol.js'
+import { useAppDispatch } from '../store/app-store.js'
+import { c } from '../theme.js'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/LspRecommendation/LspRecommendationMenu.tsx`.
+ *
+ * Shown when the backend emits an `LspEvent::recommendation_request`.
+ * The user picks `yes` / `no` / `never` / `disable`; the choice is sent
+ * back through `FrontendMessage::lsp_command` with kind
+ * `recommendation_response`. A 30-second auto-dismiss timer counts as
+ * `no` — matching the upstream behaviour.
+ */
+
+const AUTO_DISMISS_MS = 30_000
+
+type Option = {
+  value: LspRecommendationDecision
+  label: string
+  hotkey: string
+}
+
+type Props = {
+  payload: LspRecommendationPayload
+}
+
+function buildOptions(pluginName: string): Option[] {
+  return [
+    { value: 'yes', label: `Yes, install ${pluginName}`, hotkey: 'y' },
+    { value: 'no', label: 'No, not now', hotkey: 'n' },
+    { value: 'never', label: `Never for ${pluginName}`, hotkey: 'x' },
+    { value: 'disable', label: 'Disable all LSP recommendations', hotkey: 'd' },
+  ]
+}
+
+export function LspRecommendationDialog({ payload }: Props) {
+  const backend = useBackend()
+  const dispatch = useAppDispatch()
+  const [selected, setSelected] = useState(0)
+
+  const options = useMemo(() => buildOptions(payload.plugin_name), [payload.plugin_name])
+  const safeIndex = Math.max(0, Math.min(selected, options.length - 1))
+
+  const respond = useRef<(decision: LspRecommendationDecision) => void>(() => {})
+  respond.current = (decision: LspRecommendationDecision) => {
+    backend.send({
+      type: 'lsp_command',
+      command: {
+        kind: 'recommendation_response',
+        request_id: payload.request_id,
+        plugin_name: payload.plugin_name,
+        decision,
+      },
+    })
+    dispatch({ type: 'LSP_RECOMMENDATION_DISMISS' })
+  }
+
+  // 30s auto-dismiss — same as upstream. Counts as `no`.
+  useEffect(() => {
+    const timer = setTimeout(() => respond.current('no'), AUTO_DISMISS_MS)
+    return () => clearTimeout(timer)
+  }, [payload.request_id])
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const seq = event.sequence?.length === 1 ? event.sequence : undefined
+    const input = (seq ?? (name?.length === 1 ? name : '') ?? '').toLowerCase()
+
+    if (input) {
+      const match = options.findIndex(opt => opt.hotkey === input)
+      if (match >= 0) {
+        respond.current(options[match]!.value)
+        return
+      }
+    }
+
+    if (name === 'escape') {
+      respond.current('no')
+      return
+    }
+    if (name === 'up' || input === 'k') {
+      setSelected(Math.max(0, safeIndex - 1))
+      return
+    }
+    if (name === 'down' || input === 'j') {
+      setSelected(Math.min(options.length - 1, safeIndex + 1))
+      return
+    }
+    if (name === 'tab') {
+      setSelected((safeIndex + 1) % options.length)
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      const opt = options[safeIndex]
+      if (opt) respond.current(opt.value)
+    }
+  })
+
+  const triggerLabel = payload.language_id
+    ? `${payload.file_extension} (${payload.language_id})`
+    : payload.file_extension
+
+  return (
+    <box
+      position="absolute"
+      bottom={3}
+      left={1}
+      right={1}
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.warning}
+      title="LSP Plugin Recommendation"
+      titleAlignment="center"
+      paddingX={2}
+      paddingY={1}
+    >
+      <text>
+        <span fg={c.dim}>
+          LSP provides code intelligence like go-to-definition and error checking.
+        </span>
+      </text>
+
+      <box marginTop={1} flexDirection="column">
+        <text>
+          <span fg={c.dim}>Plugin: </span>
+          <strong>{payload.plugin_name}</strong>
+        </text>
+        {payload.plugin_description && (
+          <text>
+            <span fg={c.dim}>{payload.plugin_description}</span>
+          </text>
+        )}
+        <text>
+          <span fg={c.dim}>Triggered by: </span>
+          <span>{triggerLabel} files</span>
+        </text>
+      </box>
+
+      <box marginTop={1}>
+        <text>Would you like to install this LSP plugin?</text>
+      </box>
+
+      <box marginTop={1} flexDirection="column">
+        {options.map((opt, i) => {
+          const isSelected = i === safeIndex
+          return (
+            <box key={opt.value} flexDirection="row">
+              <text fg={isSelected ? c.bg : undefined} bg={isSelected ? c.textBright : undefined}>
+                <strong>{` ${opt.label} `}</strong>
+              </text>
+              <text fg={c.dim}> ({opt.hotkey})</text>
+            </box>
+          )
+        })}
+      </box>
+
+      <box marginTop={1}>
+        <text>
+          <em>
+            <span fg={c.dim}>
+              Up/Down to move · Enter to confirm · Hotkeys y/n/x/d · Esc = No · auto-dismiss in 30s
+            </span>
+          </em>
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/ipc/protocol.ts
+++ b/ui/src/ipc/protocol.ts
@@ -87,6 +87,39 @@ export interface LspServerInfo {
   error?: string
 }
 
+/**
+ * Payload for an LSP plugin recommendation prompt. Mirrors Rust
+ * `LspRecommendationPayload` — `request_id` correlates the frontend's
+ * reply back to the originating backend request, and `plugin_name` +
+ * `file_extension` populate the upstream `LspRecommendationMenu`
+ * template.
+ */
+export interface LspRecommendationPayload {
+  request_id: string
+  plugin_name: string
+  plugin_description?: string
+  file_extension: string
+  language_id?: string
+}
+
+/**
+ * Snapshot of persisted "never recommend" / "disable all" preferences
+ * the backend replies with after every
+ * `LspCommand::recommendation_response` and also in response to
+ * `LspCommand::query_settings`. Used by an LSP settings view.
+ */
+export interface LspRecommendationSettings {
+  disabled: boolean
+  muted_plugins: string[]
+}
+
+/**
+ * Decision values the frontend sends in
+ * `LspCommand::recommendation_response`. Matches the upstream
+ * `LspRecommendationMenu` option keys.
+ */
+export type LspRecommendationDecision = 'yes' | 'no' | 'never' | 'disable'
+
 export interface McpToolInfo { name: string; description?: string }
 export interface McpResourceInfo { uri: string; name?: string; mime_type?: string }
 export interface McpServerStatusInfo {
@@ -327,6 +360,13 @@ export type LspEvent =
   | { kind: 'server_state_changed'; language_id: string; state: string; error?: string }
   | { kind: 'diagnostics_published'; uri: string; diagnostics: LspDiagnostic[] }
   | { kind: 'server_list'; servers: LspServerInfo[] }
+  /**
+   * Recommendation prompt — payload fields are flattened alongside
+   * `kind` because Rust emits it with `#[serde(flatten)]`.
+   */
+  | ({ kind: 'recommendation_request' } & LspRecommendationPayload)
+  /** Reply carrying the persisted recommendation settings. */
+  | { kind: 'settings_snapshot'; settings: LspRecommendationSettings }
 
 export type McpEvent =
   | { kind: 'server_state_changed'; server_name: string; state: string; error?: string }
@@ -374,7 +414,21 @@ export type FrontendMessage =
   | { type: 'agent_command'; command: { kind: 'abort_agent'; agent_id: string } | { kind: 'query_active_agents' } | { kind: 'query_agent_output'; agent_id: string } }
   | { type: 'team_command'; command: { kind: 'inject_message'; team_name: string; to: string; text: string } | { kind: 'query_team_status'; team_name: string } }
   // Subsystem commands
-  | { type: 'lsp_command'; command: { kind: 'start_server' | 'stop_server' | 'restart_server'; language_id: string } | { kind: 'query_status' } }
+  | {
+      type: 'lsp_command'
+      command:
+        | { kind: 'start_server' | 'stop_server' | 'restart_server'; language_id: string }
+        | { kind: 'query_status' }
+        | { kind: 'query_settings' }
+        | {
+            kind: 'recommendation_response'
+            request_id: string
+            plugin_name: string
+            decision: LspRecommendationDecision
+          }
+        | { kind: 'unmute_plugin'; plugin_name: string }
+        | { kind: 'set_recommendations_disabled'; disabled: boolean }
+    }
   | {
       type: 'mcp_command'
       command:

--- a/ui/src/store/app-state.ts
+++ b/ui/src/store/app-state.ts
@@ -3,6 +3,8 @@ import type {
   AgentNode,
   AgentToolInfo,
   FrontendContentBlock,
+  LspRecommendationPayload,
+  LspRecommendationSettings,
   LspServerInfo,
   McpServerStatusInfo,
   PluginInfo,
@@ -65,6 +67,17 @@ export interface SubsystemState {
   plugins: PluginInfo[]
   skills: SkillInfo[]
   lastUpdated: number
+}
+
+/**
+ * Transient state for the LSP plugin recommendation prompt.
+ * `request` is populated while the dialog is visible; `settings` mirrors
+ * the persisted "never/disable" choices so an LSP settings view can
+ * render them without re-querying the backend.
+ */
+export interface LspRecommendationState {
+  request: LspRecommendationPayload | null
+  settings: LspRecommendationSettings
 }
 
 /**
@@ -132,6 +145,7 @@ export interface AppState {
   agentStreams: Record<string, AgentStreamState>
   teams: Record<string, TeamState>
   subsystems: SubsystemState
+  lspRecommendation: LspRecommendationState
   customStatusLine: CustomStatusLineState | null
   agentSettings: AgentSettingsState
 }
@@ -163,6 +177,7 @@ export const initialState: AppState = {
   agentStreams: {},
   teams: {},
   subsystems: { lsp: [], mcp: [], plugins: [], skills: [], lastUpdated: 0 },
+  lspRecommendation: { request: null, settings: { disabled: false, muted_plugins: [] } },
   customStatusLine: null,
   agentSettings: {
     entries: [],
@@ -257,6 +272,9 @@ export type SubsystemAction =
   | { type: 'PLUGIN_STATUS'; pluginId: string; name: string; status: string; error?: string }
   | { type: 'SKILLS_LOADED'; count: number }
   | { type: 'CUSTOM_STATUS_LINE_UPDATE'; lines: string[]; error?: string; updatedAt: number }
+  | { type: 'LSP_RECOMMENDATION_REQUEST'; payload: LspRecommendationPayload }
+  | { type: 'LSP_RECOMMENDATION_DISMISS' }
+  | { type: 'LSP_RECOMMENDATION_SETTINGS'; settings: LspRecommendationSettings }
 
 export type AgentSettingsAction =
   | { type: 'AGENT_SETTINGS_OPEN' }

--- a/ui/src/store/app-store.tsx
+++ b/ui/src/store/app-store.tsx
@@ -78,6 +78,9 @@ export function appReducer(state: AppState, action: AppAction): AppState {
     case 'PLUGIN_STATUS':
     case 'SKILLS_LOADED':
     case 'CUSTOM_STATUS_LINE_UPDATE':
+    case 'LSP_RECOMMENDATION_REQUEST':
+    case 'LSP_RECOMMENDATION_DISMISS':
+    case 'LSP_RECOMMENDATION_SETTINGS':
       return reduceSubsystems(state, action)
 
     case 'AGENT_SETTINGS_OPEN':

--- a/ui/src/store/reducers/subsystems.ts
+++ b/ui/src/store/reducers/subsystems.ts
@@ -51,5 +51,32 @@ export function reduceSubsystems(state: AppState, action: SubsystemAction): AppS
           updatedAt: action.updatedAt,
         },
       }
+
+    case 'LSP_RECOMMENDATION_REQUEST':
+      return {
+        ...state,
+        lspRecommendation: {
+          ...state.lspRecommendation,
+          request: action.payload,
+        },
+      }
+
+    case 'LSP_RECOMMENDATION_DISMISS':
+      return {
+        ...state,
+        lspRecommendation: {
+          ...state.lspRecommendation,
+          request: null,
+        },
+      }
+
+    case 'LSP_RECOMMENDATION_SETTINGS':
+      return {
+        ...state,
+        lspRecommendation: {
+          ...state.lspRecommendation,
+          settings: action.settings,
+        },
+      }
   }
 }


### PR DESCRIPTION
## Summary

End-to-end port of the upstream `LspRecommendationMenu`
(`ui/examples/upstream-patterns/src/components/LspRecommendation/LspRecommendationMenu.tsx`)
into the current OpenTUI frontend + Rust backend. Addresses the
deferred LSP entry tracked in `ui/docs/ui-panels-deferred.md` by
providing both the prompt and the settings path for persisting the
user's \"never for X\" / \"disable all\" choices.

- Frontend dialog: `ui/src/components/LspRecommendationDialog.tsx`
  (keyboard navigation, hotkeys `y/n/x/d`, 30s auto-dismiss matching
  upstream).
- Protocol: new `LspEvent::RecommendationRequest` (flattened payload) +
  `SettingsSnapshot`; new `LspCommand` variants
  `RecommendationResponse` / `QuerySettings` / `UnmutePlugin` /
  `SetRecommendationsDisabled`.
- Persistence: `never` / `disable` choices land under a new
  `lspRecommendations` key in the user-level `settings.json`.
- State: new `lspRecommendation` slice on `AppState` + 3 reducer
  actions, wired into `App.tsx`.

## Notes for reviewers

- The `yes → install` path is still a TODO — the backend currently
  replies with a placeholder info message pointing at `/lsp`. The
  settings entry in `ui/docs/ui-panels-deferred.md` was updated to
  call this out rather than silently drop it.
- The recommendation dialog waits behind the permission prompt when
  both are pending (see `App.tsx`), so we don't stack two modal
  overlays.
- New serde tests cover the flattened payload + every new command
  shape; handler tests cover the decision logic without mutating real
  user settings (they only exercise `no` / `yes` / unknown paths).

## Test plan

- [x] `cargo test -p claude-code-rs --bins ipc::subsystem_events -- `
      (44 passed — includes 5 new LSP serde cases).
- [x] `cargo test -p claude-code-rs --bins ipc::subsystem_handlers::tests::apply_recommendation -- `
      (3 passed).
- [x] `cargo build -p claude-code-rs` — no new warnings beyond the two
      pre-existing `web::handlers::session_id` dead-code ones.
- [x] `bun build src/main.tsx --target=bun --outdir=dist` — bundles
      140 modules without errors.
- [x] `bunx tsc --noEmit` — zero new type errors in touched files
      (remaining errors are all pre-existing environmental / unrelated
      issues).
- [ ] Manual smoke: trigger `LspEvent::RecommendationRequest` from a
      future backend hookup and confirm the dialog renders + the
      response round-trips. Not yet wired to a real LSP discovery
      trigger — tracked in the deferred doc TODO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)