### PR TITLE
feat(ui): align messages/PromptInput/tasks with upstream OpenTUI patterns

### DIFF
--- a/ui/src/components/App.tsx
+++ b/ui/src/components/App.tsx
@@ -16,6 +16,7 @@ import { PermissionRequestDialog } from './permissions/index.js'
 import { StatusLine } from './StatusLine/index.js'
 import { SubsystemStatus } from './SubsystemStatus.js'
 import { Suggestions } from './Suggestions.js'
+import { BackgroundTaskStatus } from './tasks/index.js'
 import { TeamPanel } from './TeamPanel.js'
 import { WelcomeScreen } from './WelcomeScreen.js'
 import { registerOpaqueFrameClear } from './frame-clear.js'
@@ -435,6 +436,7 @@ export function App() {
           </box>
           <AgentTreePanel />
           <TeamPanel />
+          <BackgroundTaskStatus />
           <SubsystemStatus />
           <box
             width="100%"

--- a/ui/src/components/InputPrompt.tsx
+++ b/ui/src/components/InputPrompt.tsx
@@ -13,6 +13,7 @@ import { VimState } from '../vim/index.js'
 import {
   ComposerBuffer,
   ModeIndicator,
+  PromptInputFooter,
   QueuedSubmissions,
   SlashCommandHints,
   buildBusyStatus,
@@ -23,7 +24,9 @@ import {
   useComposerState,
   useComposerSubmit,
   useInputHistoryNav,
+  useMaybeTruncateInput,
   usePasteHandler,
+  usePromptInputPlaceholder,
 } from './PromptInput/index.js'
 
 interface InputPromptProps {
@@ -53,6 +56,7 @@ export function InputPrompt({
     historyIndex,
     keybindingConfig,
     vimEnabled,
+    vimMode,
     queuedSubmissions,
   } = useAppState()
   const dispatch = useAppDispatch()
@@ -101,6 +105,18 @@ export function InputPrompt({
     resetBuffer()
     clearSubMode()
   }, [clearSubMode, resetBuffer])
+
+  // Guard against pasting enough text to lag the renderer. The hook
+  // swaps the middle slice for a short `[...Truncated #N +L lines...]`
+  // placeholder in the buffer but keeps the full content in an internal
+  // ref so `rehydrate` can splice it back on submit.
+  useMaybeTruncateInput({ text, setText, setCursorPos })
+
+  const placeholder = usePromptInputPlaceholder({
+    text,
+    isBusy,
+    hasQueuedSubmissions: queuedSubmissions.length > 0,
+  })
 
   const prefillInput = useCallback((nextText: string) => {
     setText(nextText)
@@ -511,6 +527,7 @@ export function InputPrompt({
           isBusy={isBusy}
           isPasted={isPasted}
           keybindingConfig={keybindingConfig}
+          placeholder={placeholder}
         />
         {showInlineStatus && <ModeIndicator workedTag={workedTag} />}
       </box>
@@ -523,6 +540,15 @@ export function InputPrompt({
         subMode={subMode}
         subIndex={subIndex}
       />
+      {viewMode === 'prompt' && !isReadOnly && !showHint && (
+        <PromptInputFooter
+          vimMode={vimEnabled ? vimMode : undefined}
+          workedTag={workedTag}
+          queuedCount={queuedSubmissions.length}
+          isActive={inputActive}
+          keybindingConfig={keybindingConfig}
+        />
+      )}
       {viewMode === 'prompt' && (
         <QueuedSubmissions submissions={queuedSubmissions} />
       )}

--- a/ui/src/components/PromptInput/ComposerBuffer.tsx
+++ b/ui/src/components/PromptInput/ComposerBuffer.tsx
@@ -24,6 +24,14 @@ type Props = {
   isBusy: boolean
   isPasted: boolean
   keybindingConfig: KeybindingConfig | null
+  /**
+   * Optional caller-provided placeholder shown when the buffer is empty
+   * and the backend is idle. `usePromptInputPlaceholder` surfaces the
+   * rotating onboarding hints / queued-message hint through this prop so
+   * the static `promptPlaceholder(isBusy)` only fires as a last-resort
+   * fallback.
+   */
+  placeholder?: string
 }
 
 export function ComposerBuffer({
@@ -34,6 +42,7 @@ export function ComposerBuffer({
   isBusy,
   isPasted,
   keybindingConfig,
+  placeholder,
 }: Props) {
   const pasteCompact = shouldRenderPasteCompact(isPasted, text.length)
 
@@ -54,10 +63,17 @@ export function ComposerBuffer({
   }
 
   if (text.length === 0) {
+    // `placeholder` is the dynamic (rotating / queued-aware) copy from
+    // `usePromptInputPlaceholder`. When the caller doesn't supply one —
+    // or when busy — fall back to the static `promptPlaceholder` so we
+    // always render *something* under the cursor.
+    const activePlaceholder = isBusy || !placeholder
+      ? promptPlaceholder(isBusy)
+      : ` ${placeholder}`
     return (
       <text bg={c.bg}>
         <span fg={c.bg} bg={isActive ? c.text : c.dim}> </span>
-        <span fg="#45475A" bg={c.bg}>{promptPlaceholder(isBusy)}</span>
+        <span fg="#45475A" bg={c.bg}>{activePlaceholder}</span>
       </text>
     )
   }

--- a/ui/src/components/PromptInput/PromptInputFooter.tsx
+++ b/ui/src/components/PromptInput/PromptInputFooter.tsx
@@ -1,0 +1,98 @@
+import React from 'react'
+import { c } from '../../theme.js'
+import { shortcutLabel, type KeybindingConfig } from '../../keybindings.js'
+
+/**
+ * Compact inline footer rendered directly under the composer.
+ *
+ * Complements (does NOT duplicate) the top `StatusLine`:
+ *   - StatusLine surfaces persistent session telemetry: cwd, model,
+ *     tokens, cost, agent/team/MCP/LSP counts.
+ *   - This footer surfaces *composer-local* signals: vim mode hint,
+ *     busy tag, queued count, and the "press ? for help" affordance.
+ *
+ * Mirrors the spirit of upstream `PromptInputFooter` +
+ * `PromptInputFooterLeftSide`
+ * (`ui/examples/upstream-patterns/src/components/PromptInput/PromptInputFooter*.tsx`)
+ * but trimmed to fields we can derive from the existing store without
+ * extending the IPC surface. Anything that would require backend
+ * streams we don't plumb (voice, swarm, sandbox, notifications) is
+ * intentionally skipped.
+ */
+
+type Props = {
+  /** Set when vim is enabled — the raw mode string (`NORMAL` / `INSERT`
+   *  / `VISUAL` / etc.) as surfaced by `VimState.indicator`. */
+  vimMode?: string
+  /** Non-empty while the backend is working; the formatted tag from
+   *  `buildBusyStatus` (e.g. `"thinking 3s"`). */
+  workedTag: string
+  /** Number of queued prompts — shown as a compact pill when > 0 so the
+   *  user sees that their Enter landed in the queue instead of
+   *  vanishing. Matches the visible count rendered by
+   *  `QueuedSubmissions` below. */
+  queuedCount: number
+  /** `true` when composer input is live (active, not readonly, not
+   *  busy). Controls whether the shortcut-hint row is shown so we
+   *  don't bait the user with affordances that won't respond. */
+  isActive: boolean
+  keybindingConfig: KeybindingConfig | null
+}
+
+export function PromptInputFooter({
+  vimMode,
+  workedTag,
+  queuedCount,
+  isActive,
+  keybindingConfig,
+}: Props) {
+  // Gather the parts we want to show, dropping anything that's empty.
+  // Rendering an empty row would reserve vertical space under the
+  // composer — Yoga reserves a row even if every child is absent — so
+  // we bail out entirely when there's nothing to say.
+  const showVim = !!vimMode && vimMode !== 'NORMAL'
+  const showBusy = workedTag.length > 0
+  const showQueued = queuedCount > 0
+  const showHint = isActive && !showBusy
+
+  if (!showVim && !showBusy && !showQueued && !showHint) {
+    return null
+  }
+
+  const submitLabel = shortcutLabel('chat:submit', {
+    context: 'Chat',
+    config: keybindingConfig,
+  })
+  const cancelLabel = shortcutLabel('chat:cancel', {
+    context: 'Chat',
+    config: keybindingConfig,
+  })
+
+  return (
+    <box flexDirection="row" paddingX={2}>
+      {showVim && (
+        <>
+          <text fg={c.warning}>-- {vimMode} --</text>
+          <text fg={c.dim}> </text>
+        </>
+      )}
+      {showBusy && (
+        <>
+          <text fg={c.dim}>* {workedTag}</text>
+          <text fg={c.dim}> </text>
+        </>
+      )}
+      {showQueued && (
+        <>
+          <text fg={c.info}>queued {queuedCount}</text>
+          <text fg={c.dim}> </text>
+        </>
+      )}
+      {showHint && (
+        <text fg={c.muted}>
+          {submitLabel} send * {cancelLabel} cancel
+        </text>
+      )}
+    </box>
+  )
+}

--- a/ui/src/components/PromptInput/QueuedSubmissions.tsx
+++ b/ui/src/components/PromptInput/QueuedSubmissions.tsx
@@ -1,29 +1,66 @@
 import React from 'react'
 import { c } from '../../theme.js'
 import type { QueuedSubmission } from '../../store/app-state.js'
-import { summarizeQueuedSubmissions } from './utils.js'
+import { truncate } from '../../utils.js'
 
 /**
- * Preview row showing the currently-queued submissions beneath the
- * composer. Rendered only in `prompt` view-mode and when at least one
- * submission is queued.
+ * Preview block for queued submissions.
  *
- * Summarization logic lives in `utils.ts` (`summarizeQueuedSubmissions`)
- * so the truncation + overflow marker behavior is unit-testable.
+ * Upgraded from the original single-line summary to a numbered list
+ * (upstream parity with `PromptInputQueuedCommands`) so operators can
+ * see *which* prompts will run and in what order. Kept to a capped
+ * preview (`MAX_VISIBLE`) to avoid stealing too many rows from the
+ * message list; an overflow marker shows how many more are pending.
+ *
+ * Rendering rules:
+ * - Numbered `1. / 2. / ...` prefix matching execution order.
+ * - Each entry trimmed of whitespace + truncated (ellipsis) to a
+ *   single-line preview — the full text still runs when dequeued.
+ * - When `selectedIndex` is provided (e.g. by a future keyboard-driven
+ *   queue inspector), that row is highlighted with the accent color so
+ *   the user can see which one they are about to edit.
+ * - When `submissions.length > MAX_VISIBLE`, an `+N more` row is
+ *   appended so the total is always visible at a glance.
  */
 
 type Props = {
   submissions: readonly QueuedSubmission[]
+  /**
+   * Optional index of the "active" queued item — when set, that row
+   * is rendered with the accent color. Out-of-range values are
+   * silently ignored.
+   */
+  selectedIndex?: number
 }
 
-export function QueuedSubmissions({ submissions }: Props) {
+const MAX_VISIBLE = 3
+const PREVIEW_CHARS = 60
+
+export function QueuedSubmissions({ submissions, selectedIndex }: Props) {
   if (submissions.length === 0) return null
-  const preview = summarizeQueuedSubmissions([...submissions])
+
+  const visible = submissions.slice(0, MAX_VISIBLE)
+  const overflow = submissions.length - visible.length
+
   return (
-    <box paddingLeft={3}>
-      <text fg={c.dim}>
-        Queued {submissions.length}: {preview}
-      </text>
+    <box flexDirection="column" paddingLeft={3} paddingTop={1}>
+      <text fg={c.dim}>Queued ({submissions.length}):</text>
+      {visible.map((item, index) => {
+        const selected = index === selectedIndex
+        const preview = truncate(item.text.replace(/\s+/g, ' ').trim(), PREVIEW_CHARS)
+        const prefix = `${index + 1}. `
+        return (
+          <box key={item.id} flexDirection="row" paddingLeft={1}>
+            <text fg={selected ? c.accent : c.dim}>{prefix}</text>
+            <text fg={selected ? c.text : c.dim}>{preview}</text>
+          </box>
+        )
+      })}
+      {overflow > 0 && (
+        <box paddingLeft={1}>
+          <text fg={c.muted}>+{overflow} more</text>
+        </box>
+      )}
     </box>
   )
 }

--- a/ui/src/components/PromptInput/index.ts
+++ b/ui/src/components/PromptInput/index.ts
@@ -1,20 +1,29 @@
 /**
- * Barrel for the Lite-native composer/prompt-input decomposition
+ * Barrel for the native composer/prompt-input decomposition
  * (Issue 06).
  *
  * Each submodule owns one concern lifted out of the previously
  * monolithic `InputPrompt.tsx`:
  * - `ComposerBuffer` — visible buffer row (before/cursor/after, paste
  *   compact, transcript-mode readonly branch).
- * - `QueuedSubmissions` — queued-submission preview row.
+ * - `QueuedSubmissions` — numbered queue preview with truncation +
+ *   optional selected-row highlight (upstream parity with
+ *   `PromptInputQueuedCommands`).
  * - `ModeIndicator` — inline reasoning/thinking status label.
+ * - `PromptInputFooter` — compact hint row below the composer (vim
+ *   mode, busy tag, queued count, submit/cancel affordance). Trimmed
+ *   port of upstream `PromptInputFooter` + `PromptInputFooterLeftSide`.
  * - `SlashCommandHints` — slash-command autocomplete + sub-mode
  *   option selector.
- * - `useComposerSubmit` — submit / queue / slash-command dispatch
- *   hook.
+ * - `useComposerSubmit` — submit / queue / slash-command dispatch hook.
  * - `hooks.ts` — composer state, busy timer, paste handler, history
- *   navigator (existing hooks, moved here from the flat
- *   `input-prompt-hooks.ts`).
+ *   navigator.
+ * - `usePromptInputPlaceholder` — rotating placeholder copy + queued
+ *   hint when the buffer is empty (upstream parity with
+ *   `usePromptInputPlaceholder`).
+ * - `useMaybeTruncateInput` — placeholder-swap for pasted content that
+ *   would otherwise lag the renderer (upstream parity with
+ *   `useMaybeTruncateInput`).
  * - `keys.ts` — key-event normalization helpers.
  * - `utils.ts` — paste detection, placeholder, queued summary, cursor
  *   insertion.
@@ -39,6 +48,7 @@ export {
   type ShortcutKey,
 } from './keys.js'
 export { ModeIndicator } from './ModeIndicator.js'
+export { PromptInputFooter } from './PromptInputFooter.js'
 export {
   PASTE_COMPACT_CHARS,
   buildBusyStatus,
@@ -51,6 +61,18 @@ export {
 export { QueuedSubmissions } from './QueuedSubmissions.js'
 export { SlashCommandHints } from './SlashCommandHints.js'
 export { useComposerSubmit } from './useComposerSubmit.js'
+export {
+  PROMPT_PLACEHOLDER_HINTS,
+  usePromptInputPlaceholder,
+  type PromptInputPlaceholderOptions,
+} from './usePromptInputPlaceholder.js'
+export {
+  TRUNCATION_THRESHOLD_CHARS,
+  useMaybeTruncateInput,
+  type TruncatedPasteRef,
+  type UseMaybeTruncateInputParams,
+  type UseMaybeTruncateInputResult,
+} from './useMaybeTruncateInput.js'
 export {
   formatPasteSize,
   insertAtCursor,

--- a/ui/src/components/PromptInput/useMaybeTruncateInput.ts
+++ b/ui/src/components/PromptInput/useMaybeTruncateInput.ts
@@ -1,0 +1,110 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Guard against pasted / typed inputs that are large enough to lag the
+ * OpenTUI renderer. Mirrors upstream
+ * `ui/examples/upstream-patterns/src/components/PromptInput/useMaybeTruncateInput.ts`
+ * at a reduced scope: we only stash a placeholder marker in place of
+ * the middle slice — the full text is kept in a ref so the caller can
+ * reconstitute it on submit without round-tripping through the store.
+ *
+ * The truncation is idempotent per buffer instance: once we've applied
+ * it, we don't re-truncate the same input until the buffer is cleared
+ * (which happens on submit / cancel). That avoids feedback loops when
+ * the parent effect replays the current buffer back through
+ * `setText`.
+ */
+
+const TRUNCATION_THRESHOLD = 10_000
+const PREVIEW_LENGTH = 1_000
+
+export interface TruncatedPasteRef {
+  id: number
+  content: string
+}
+
+export interface UseMaybeTruncateInputParams {
+  text: string
+  setText: (value: string) => void
+  setCursorPos: (value: number) => void
+}
+
+export interface UseMaybeTruncateInputResult {
+  /**
+   * Pop the stashed full-size text on submit. Returns the supplied
+   * `currentText` unchanged if no truncation happened during this
+   * buffer's lifetime.
+   */
+  rehydrate: (currentText: string) => string
+  /** Read-only access to the most recent stash (null when nothing was
+   *  truncated during this buffer's lifetime). */
+  getStash: () => TruncatedPasteRef | null
+}
+
+export function useMaybeTruncateInput({
+  text,
+  setText,
+  setCursorPos,
+}: UseMaybeTruncateInputParams): UseMaybeTruncateInputResult {
+  // Stashed middle slice of the current oversized buffer — null unless
+  // we've already truncated this particular input.
+  const stashRef = useRef<TruncatedPasteRef | null>(null)
+  // Next unique id for the placeholder label. Monotonic across the life
+  // of the component so sequential truncations don't collide visually.
+  const nextIdRef = useRef(1)
+
+  useEffect(() => {
+    // Drop the stash as soon as the buffer empties so the next paste
+    // starts from a clean slate.
+    if (text.length === 0) {
+      stashRef.current = null
+      return
+    }
+
+    if (stashRef.current !== null) {
+      // Already truncated this buffer — don't re-run the effect even if
+      // the caller replays text into the buffer (React dev-mode effect
+      // replays, undo/redo, etc.).
+      return
+    }
+
+    if (text.length <= TRUNCATION_THRESHOLD) {
+      return
+    }
+
+    const half = Math.floor(PREVIEW_LENGTH / 2)
+    const startText = text.slice(0, half)
+    const endText = text.slice(-half)
+    const middle = text.slice(half, text.length - half)
+    const id = nextIdRef.current
+    nextIdRef.current += 1
+    const lineCount = middle.split('\n').length
+    const placeholder = `[...Truncated #${id} +${lineCount} lines...]`
+    const truncated = startText + placeholder + endText
+    stashRef.current = { id, content: middle }
+    setText(truncated)
+    setCursorPos(truncated.length)
+  }, [text, setText, setCursorPos])
+
+  const rehydrate = (currentText: string): string => {
+    const stash = stashRef.current
+    if (!stash) return currentText
+    const marker = `[...Truncated #${stash.id} `
+    const start = currentText.indexOf(marker)
+    if (start === -1) {
+      // Placeholder was edited out by the user — honor their edit.
+      return currentText
+    }
+    const end = currentText.indexOf(']', start)
+    if (end === -1) return currentText
+    return currentText.slice(0, start) + stash.content + currentText.slice(end + 1)
+  }
+
+  return {
+    rehydrate,
+    getStash: () => stashRef.current,
+  }
+}
+
+/** Exported for tests. */
+export const TRUNCATION_THRESHOLD_CHARS = TRUNCATION_THRESHOLD

--- a/ui/src/components/PromptInput/usePromptInputPlaceholder.ts
+++ b/ui/src/components/PromptInput/usePromptInputPlaceholder.ts
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Dynamic placeholder for the empty-buffer composer.
+ *
+ * Mirrors upstream `usePromptInputPlaceholder` at
+ * `ui/examples/upstream-patterns/src/components/PromptInput/usePromptInputPlaceholder.ts`
+ * with a Lite-friendly shape:
+ *   - surfaces a "press up to edit queued messages" hint when at least
+ *     one prompt is queued (the Lite queue cannot be edited in place, but
+ *     Up-arrow navigates history which lets the user pull the last queued
+ *     text back for editing before it runs);
+ *   - otherwise rotates through a small set of onboarding hints so the
+ *     composer never looks static.
+ *
+ * Returns `undefined` when the caller should render no placeholder (for
+ * example while the buffer is non-empty or while the backend is busy —
+ * the busy hint has its own copy baked into `ComposerBuffer`).
+ */
+
+const ONBOARDING_HINTS: string[] = [
+  'Type a message or /command...',
+  'Try /help to list commands',
+  '/status for session info',
+  '/cost to see token usage',
+  '? for keyboard shortcuts',
+]
+
+const ROTATION_INTERVAL_MS = 6000
+
+export interface PromptInputPlaceholderOptions {
+  text: string
+  isBusy: boolean
+  hasQueuedSubmissions: boolean
+}
+
+export function usePromptInputPlaceholder({
+  text,
+  isBusy,
+  hasQueuedSubmissions,
+}: PromptInputPlaceholderOptions): string | undefined {
+  const [hintIndex, setHintIndex] = useState(0)
+
+  useEffect(() => {
+    // Only rotate while the composer is idle and empty. Stopping the
+    // interval keeps React's scheduler quiet while the user is typing.
+    if (text !== '' || isBusy) {
+      return
+    }
+    const id = setInterval(() => {
+      setHintIndex(index => (index + 1) % ONBOARDING_HINTS.length)
+    }, ROTATION_INTERVAL_MS)
+    return () => clearInterval(id)
+  }, [text, isBusy])
+
+  if (text !== '') {
+    return undefined
+  }
+
+  if (isBusy) {
+    // Busy placeholder is owned by ComposerBuffer to keep the "Working…"
+    // copy consistent with the inline status tag; signal absent here.
+    return undefined
+  }
+
+  if (hasQueuedSubmissions) {
+    return 'Press up to edit queued messages'
+  }
+
+  return ONBOARDING_HINTS[hintIndex] ?? ONBOARDING_HINTS[0]
+}
+
+/** Exported for unit tests — the list of rotating hints. */
+export const PROMPT_PLACEHOLDER_HINTS = ONBOARDING_HINTS

--- a/ui/src/components/messages/AssistantTextMessage.tsx
+++ b/ui/src/components/messages/AssistantTextMessage.tsx
@@ -4,12 +4,18 @@ import { c } from '../../theme.js'
 import { ThinkingPreview } from './ThinkingPreview.js'
 
 /**
- * Lite-native assistant-text bubble. Mirrors the decomposition used by
- * the sample tree's `AssistantTextMessage`
- * (`ui/examples/upstream-patterns/src/components/messages/AssistantTextMessage.tsx`)
- * — thinking preview on top, markdown body underneath — but without the
- * Ink-only error-path branches that are handled elsewhere in the Lite
- * shell.
+ * OpenTUI port of the upstream `AssistantTextMessage`
+ * (`ui/examples/upstream-patterns/src/components/messages/AssistantTextMessage.tsx`).
+ *
+ * Upstream uses a leading `●` (BLACK_CIRCLE) glyph on the left gutter as a
+ * stable visual anchor for assistant turns — mirrors the bullet convention
+ * in `SystemTextMessage` / `AssistantToolUseMessage`. The markdown body sits
+ * to the right of the gutter so content aligns across turns.
+ *
+ * Upstream's error-case branches (rate-limit, invalid-api-key, token-revoked,
+ * custom-off-switch, etc.) are deliberately not ported here: those errors
+ * surface as structured IPC messages in cc-rust and already land on the
+ * system-text pipeline via `SystemMessage` instead.
  */
 type Props = {
   item: AssistantTextRenderItem
@@ -19,8 +25,13 @@ export function AssistantTextMessage({ item }: Props) {
   return (
     <box flexDirection="column" paddingX={1} marginBottom={1} width="100%">
       {item.thinking && <ThinkingPreview content={item.thinking} />}
-      <box paddingLeft={1} flexDirection="column" width="100%" selectable backgroundColor={c.bg}>
-        <markdown content={item.content} bg={c.bg} />
+      <box flexDirection="row" width="100%">
+        <box minWidth={2} flexShrink={0}>
+          <text fg={c.text} bg={c.bg}>●</text>
+        </box>
+        <box flexDirection="column" width="100%" selectable backgroundColor={c.bg}>
+          <markdown content={item.content} bg={c.bg} />
+        </box>
       </box>
     </box>
   )

--- a/ui/src/components/messages/CompactBoundaryMessage.tsx
+++ b/ui/src/components/messages/CompactBoundaryMessage.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { c } from '../../theme.js'
+import { shortcutLabel } from '../../keybindings.js'
+import { useAppState } from '../../store/app-store.js'
+
+/**
+ * OpenTUI port of the upstream `CompactBoundaryMessage`
+ * (`ui/examples/upstream-patterns/src/components/messages/CompactBoundaryMessage.tsx`).
+ *
+ * Shown as a dim, centered separator whenever the backend signals that the
+ * conversation was compacted — on the cc-rust IPC this arrives as a
+ * `system_info` message with `level === 'compact_boundary'`. The optional
+ * content from the backend supplies a one-line summary that replaces the
+ * default label.
+ */
+
+type Props = {
+  /** Optional summary line from the backend. Falls back to the default label. */
+  content?: string
+}
+
+export function CompactBoundaryMessage({ content }: Props) {
+  const { keybindingConfig } = useAppState()
+  const shortcut = shortcutLabel('app:toggleTranscript', {
+    context: 'Global',
+    config: keybindingConfig,
+  })
+  const summary = content && content.trim() ? content.trim() : 'Conversation compacted'
+
+  return (
+    <box flexDirection="column" paddingX={1} marginTop={1} marginBottom={1} width="100%">
+      <text fg={c.dim} bg={c.bg}>
+        ✻ {summary} ({shortcut} for history)
+      </text>
+    </box>
+  )
+}

--- a/ui/src/components/messages/StreamingMessage.tsx
+++ b/ui/src/components/messages/StreamingMessage.tsx
@@ -4,11 +4,14 @@ import type { StreamingRenderItem } from '../../store/message-model.js'
 import { ThinkingPreview } from './ThinkingPreview.js'
 
 /**
- * Lite-native rendering of the in-flight streaming assistant segment.
- * Distinct from `AssistantTextMessage` because (a) the markdown is
- * rendered with `streaming` so partial tokens don't trigger layout
- * jitter, and (b) we show a dim `...` placeholder while the first tokens
- * are still in flight.
+ * In-flight streaming segment — OpenTUI sibling of `AssistantTextMessage`
+ * that (a) passes `streaming` to the markdown renderer to avoid layout
+ * jitter on partial tokens, and (b) shows a dim `...` placeholder while
+ * the first tokens are still in flight.
+ *
+ * Matches the upstream `AssistantTextMessage` visual shape (leading `●`
+ * anchor glyph + indented body) so the bubble geometry doesn't shift
+ * when the streaming segment is replaced by a finalised one.
  */
 type Props = {
   item: StreamingRenderItem
@@ -18,10 +21,15 @@ export function StreamingMessage({ item }: Props) {
   return (
     <box flexDirection="column" paddingX={1} marginBottom={1} width="100%">
       {item.thinking && <ThinkingPreview content={item.thinking} />}
-      <box paddingLeft={1} flexDirection="column" width="100%" selectable backgroundColor={c.bg}>
-        {item.content
-          ? <markdown content={item.content} streaming bg={c.bg} />
-          : <text fg={c.dim} bg={c.bg}>...</text>}
+      <box flexDirection="row" width="100%">
+        <box minWidth={2} flexShrink={0}>
+          <text fg={c.dim} bg={c.bg}>●</text>
+        </box>
+        <box flexDirection="column" width="100%" selectable backgroundColor={c.bg}>
+          {item.content
+            ? <markdown content={item.content} streaming bg={c.bg} />
+            : <text fg={c.dim} bg={c.bg}>...</text>}
+        </box>
       </box>
     </box>
   )

--- a/ui/src/components/messages/SystemMessage.tsx
+++ b/ui/src/components/messages/SystemMessage.tsx
@@ -3,57 +3,80 @@ import { systemLevelFromRaw } from '../../adapters/index.js'
 import type { SystemLevel } from '../../view-model/types.js'
 import { c } from '../../theme.js'
 import type { SystemTextRenderItem } from '../../store/message-model.js'
+import { CompactBoundaryMessage } from './CompactBoundaryMessage.js'
 
 /**
- * Lite-native port of the sample tree's `SystemTextMessage`
+ * OpenTUI port of the upstream `SystemTextMessage`
  * (`ui/examples/upstream-patterns/src/components/messages/SystemTextMessage.tsx`).
- * Normalizes the free-form `item.level` string through
- * `systemLevelFromRaw` (from the Issue 01 adapter layer) so downstream
- * style picks always see a closed set of `SystemLevel` values.
  *
- * The current Lite shell also shows a `'question'` level that the
- * adapter does not yet model. We continue to treat that as a distinct
- * prompt-style callout to avoid regressing the ask-user flow while the
- * view-model catches up.
+ * Upstream renders a left-gutter bullet (● for non-info levels, nothing for
+ * info) + the body text coloured by level. We mirror that layout here and
+ * extend with two cc-rust-specific levels:
+ * - `question` — Lite-only "ask-user" callout with a left border
+ * - `compact_boundary` — the `✻ Conversation compacted` separator
+ *
+ * The `systemLevelFromRaw` adapter keeps unrecognised levels mapping to
+ * `'info'` so the style table always hits.
  */
 
 type Props = {
   item: SystemTextRenderItem
 }
 
-type DisplayLevel = SystemLevel | 'question'
+type DisplayLevel = SystemLevel | 'question' | 'compact_boundary'
 
-const STYLES: Record<DisplayLevel, { prefix: string; color: string }> = {
-  error: { prefix: '[error]', color: c.error },
-  warning: { prefix: '[warn]', color: c.warning },
-  info: { prefix: '[info]', color: c.text },
-  success: { prefix: '[ok]', color: c.success },
-  debug: { prefix: '[debug]', color: c.dim },
-  question: { prefix: '[?]', color: c.warning },
+const STYLES: Record<DisplayLevel, { color: string; dim: boolean; showBullet: boolean; bullet: string }> = {
+  error:            { color: c.error,   dim: false, showBullet: true,  bullet: '●' },
+  warning:          { color: c.warning, dim: false, showBullet: true,  bullet: '●' },
+  info:             { color: c.dim,     dim: true,  showBullet: false, bullet: '' },
+  success:          { color: c.success, dim: false, showBullet: true,  bullet: '●' },
+  debug:            { color: c.dim,     dim: true,  showBullet: true,  bullet: '◌' },
+  question:         { color: c.warning, dim: false, showBullet: false, bullet: '?' },
+  compact_boundary: { color: c.dim,     dim: true,  showBullet: false, bullet: '' },
 }
 
 function resolveLevel(raw: string | undefined): DisplayLevel {
   if (raw === 'question') return 'question'
+  if (raw === 'compact_boundary' || raw === 'compact') return 'compact_boundary'
   return systemLevelFromRaw(raw)
 }
 
 export function SystemMessage({ item }: Props) {
   const level = resolveLevel(item.level)
-  const { prefix, color } = STYLES[level]
 
-  return (
-    <box flexDirection="column" paddingX={1} marginBottom={1} width="100%">
-      {level === 'question' ? (
+  // Compact boundary is a dedicated separator — no bullet, centered label,
+  // matches upstream `CompactBoundaryMessage`.
+  if (level === 'compact_boundary') {
+    return <CompactBoundaryMessage content={item.content} />
+  }
+
+  const style = STYLES[level]
+
+  // Question is a prompt-style callout — keep the left border for emphasis.
+  if (level === 'question') {
+    return (
+      <box flexDirection="column" paddingX={1} marginBottom={1} width="100%">
         <box border={['left']} borderColor={c.warning} paddingLeft={1} backgroundColor={c.bg}>
-          <text selectable fg={color} bg={c.bg}>
-            {prefix} {item.content}
+          <text selectable fg={style.color} bg={c.bg}>
+            [?] {item.content}
           </text>
         </box>
-      ) : (
-        <text selectable fg={color} bg={c.bg}>
-          {prefix} {item.content}
-        </text>
+      </box>
+    )
+  }
+
+  return (
+    <box flexDirection="row" paddingX={1} marginBottom={1} width="100%">
+      {style.showBullet && (
+        <box minWidth={2} flexShrink={0}>
+          <text fg={style.color} bg={c.bg}>{style.bullet}</text>
+        </box>
       )}
+      <box flexDirection="column" width="100%">
+        <text selectable fg={style.color} bg={c.bg}>
+          {item.content}
+        </text>
+      </box>
     </box>
   )
 }

--- a/ui/src/components/messages/ThinkingPreview.tsx
+++ b/ui/src/components/messages/ThinkingPreview.tsx
@@ -2,16 +2,14 @@ import React from 'react'
 import { c } from '../../theme.js'
 
 /**
- * Small header + preview shown above assistant or streaming text when the
- * underlying segment carries thinking content. Lite-native sibling of the
- * sample tree's `AssistantThinkingMessage`
- * (`ui/examples/upstream-patterns/src/components/messages/AssistantThinkingMessage.tsx`)
- * but pared down to the one bubble-preview slot the Lite shell actually
- * surfaces today.
+ * Thinking-content header shown above assistant / streaming text when the
+ * underlying segment carries extended-thinking output. OpenTUI sibling of
+ * upstream `AssistantThinkingMessage`
+ * (`ui/examples/upstream-patterns/src/components/messages/AssistantThinkingMessage.tsx`).
  *
- * Kept as a leaf under `ui/src/components/messages/` so it can be reused
- * from multiple parent message types (assistant + streaming) without
- * round-tripping through `MessageBubble`.
+ * Mirrors upstream's `∴ Thinking…` label style (dim italic) and indents the
+ * preview under it. Long thinking is truncated with an ellipsis — we keep
+ * the full text in-store so the transcript view can still expand it.
  */
 
 const PREVIEW_LIMIT = 100
@@ -21,22 +19,22 @@ type Props = {
 }
 
 export function ThinkingPreview({ content }: Props) {
-  const preview = content.length > PREVIEW_LIMIT
-    ? `${content.slice(0, PREVIEW_LIMIT)}\u2026`
-    : content
+  const trimmed = content.trim()
+  if (!trimmed) {
+    return null
+  }
+  const preview = trimmed.length > PREVIEW_LIMIT
+    ? `${trimmed.slice(0, PREVIEW_LIMIT)}\u2026`
+    : trimmed
 
   return (
     <box flexDirection="column" paddingX={1} marginBottom={1}>
-      <text>
-        <em>
-          <span fg={c.dim}>[thinking] {content.length} chars</span>
-        </em>
+      <text fg={c.dim}>
+        <em>{'\u2234 Thinking\u2026'}</em>
       </text>
       <box paddingLeft={2}>
-        <text>
-          <em>
-            <span fg={c.dim}>{preview}</span>
-          </em>
+        <text fg={c.dim}>
+          <em>{preview}</em>
         </text>
       </box>
     </box>

--- a/ui/src/components/messages/ToolActivityMessage.tsx
+++ b/ui/src/components/messages/ToolActivityMessage.tsx
@@ -6,15 +6,17 @@ import type { ToolStatus } from '../../view-model/types.js'
 import { FileEditToolPreview, isFileEditToolName } from './FileEditToolPreview.js'
 
 /**
- * Lite-native port of the sample tree's `AssistantToolUseMessage` +
- * `UserToolResultMessage` pair, collapsed into one leaf that reads the
- * current render item's merged `status` / `outputSummary`. See:
+ * OpenTUI port of the upstream `AssistantToolUseMessage` +
+ * `UserToolResultMessage` pair:
  * - `ui/examples/upstream-patterns/src/components/messages/AssistantToolUseMessage.tsx`
  * - `ui/examples/upstream-patterns/src/components/messages/UserToolResultMessage/`
  *
- * The status-style table uses `ToolStatus` from the view-model layer
- * (Issue 01 adapter), so the closed set here stays in sync with the
- * adapter's `classifyToolStatus` output.
+ * Upstream shows a status glyph (● for queued, animated loader while running,
+ * ✓ on success, ✗ on error) followed by a bold tool name and a parenthesised
+ * input summary. We reproduce that shape here — OpenTUI doesn't animate, so
+ * `running` gets a filled circle and `pending` a hollow one. The status-style
+ * table keys on `ToolStatus` from the view-model layer (Issue 01 adapter) so
+ * it stays aligned with `classifyToolStatus`.
  */
 
 type Props = {
@@ -22,12 +24,18 @@ type Props = {
   viewMode: ViewMode
 }
 
-const STATUS_STYLES: Record<ToolStatus, { label: string; color: string }> = {
-  pending: { label: 'PENDING', color: c.dim },
-  running: { label: 'RUN', color: c.info },
-  success: { label: 'OK', color: c.success },
-  error: { label: 'ERROR', color: c.error },
-  cancelled: { label: 'CANCELLED', color: c.warning },
+interface StatusStyle {
+  label: string
+  color: string
+  glyph: string
+}
+
+const STATUS_STYLES: Record<ToolStatus, StatusStyle> = {
+  pending:   { label: 'PENDING',   color: c.dim,     glyph: '\u25CC' }, // ◌
+  running:   { label: 'RUN',       color: c.info,    glyph: '\u25CF' }, // ●
+  success:   { label: 'OK',        color: c.success, glyph: '\u2713' }, // ✓
+  error:     { label: 'ERROR',     color: c.error,   glyph: '\u2717' }, // ✗
+  cancelled: { label: 'CANCELLED', color: c.warning, glyph: '\u25A0' }, // ■
 }
 
 function extractAskUserQuestion(item: ToolActivityRenderItem): string | undefined {
@@ -62,38 +70,43 @@ export function ToolActivityMessage({ item, viewMode }: Props) {
   const status = STATUS_STYLES[item.status]
   const question = extractAskUserQuestion(item)
   const showEditPreview = isFileEditToolName(item.name)
-  const detail = item.outputSummary
-    ? `${item.inputSummary} -> ${item.outputSummary}`
-    : item.inputSummary || '(no input summary)'
 
   if (viewMode === 'prompt') {
     return (
       <box flexDirection="column" paddingX={1} marginBottom={1} width="100%">
-        <box gap={1} width="100%">
-          <text fg={status.color}>
-            <strong>[{status.label}]</strong>
-          </text>
+        <box flexDirection="row" gap={1} width="100%">
+          <box minWidth={2} flexShrink={0}>
+            <text fg={status.color}>{status.glyph}</text>
+          </box>
           <text fg={c.warning}>
             <strong>{item.name}</strong>
           </text>
           {!question && !showEditPreview && (
             <text fg={item.isError ? c.error : c.dim} selectable>
-              {detail}
+              ({item.inputSummary || '(no input)'})
             </text>
           )}
         </box>
+        {item.outputSummary && !question && !showEditPreview && (
+          <box paddingLeft={3} width="100%" flexDirection="row">
+            <text fg={c.dim}>{'\u23BF '}</text>
+            <text selectable fg={item.isError ? c.error : c.dim}>
+              {item.outputSummary}
+            </text>
+          </box>
+        )}
         {showEditPreview && (
-          <box paddingLeft={2} width="100%">
+          <box paddingLeft={3} width="100%">
             <FileEditToolPreview toolName={item.name} input={item.input} />
           </box>
         )}
         {question && (
-          <box paddingLeft={2} paddingTop={1} width="100%">
+          <box paddingLeft={3} paddingTop={1} width="100%">
             <AskUserQuestionCallout question={question} />
           </box>
         )}
         {question && item.outputSummary && (
-          <box paddingLeft={2} paddingTop={1} flexDirection="column" width="100%">
+          <box paddingLeft={3} paddingTop={1} flexDirection="column" width="100%">
             <text fg={c.dim}>Answer</text>
             <text selectable fg={item.isError ? c.error : c.text}>
               {item.outputSummary}
@@ -108,6 +121,7 @@ export function ToolActivityMessage({ item, viewMode }: Props) {
     <box flexDirection="column" paddingX={1} marginBottom={1} width="100%">
       <box border={['left']} borderColor={status.color} paddingLeft={1} flexDirection="column">
         <box gap={1}>
+          <text fg={status.color}>{status.glyph}</text>
           <text fg={status.color}>
             <strong>[{status.label}]</strong>
           </text>

--- a/ui/src/components/messages/ToolGroupMessage.tsx
+++ b/ui/src/components/messages/ToolGroupMessage.tsx
@@ -6,57 +6,69 @@ import { useAppState } from '../../store/app-store.js'
 import type { ToolStatus } from '../../view-model/types.js'
 
 /**
- * Lite-native port of the sample tree's `GroupedToolUseContent`
- * (`ui/examples/upstream-patterns/src/components/messages/GroupedToolUseContent.tsx`),
- * re-hosted on top of the Lite render pipeline's `ToolGroupRenderItem`
- * shape.
+ * OpenTUI port of upstream `CollapsedReadSearchContent`
+ * (`ui/examples/upstream-patterns/src/components/messages/CollapsedReadSearchContent.tsx`)
+ * — the collapsed Read/Glob/Grep group row shown in prompt view.
  *
- * The colour map is keyed by `ToolStatus` from the view-model layer so
- * it stays aligned with the adapter's status classification.
+ * Upstream anchors the group with a status dot + one-line summary, followed
+ * by a `⎿` continuation line showing the most recent target (file path or
+ * search pattern). We reproduce that layout here: latest-item hint comes
+ * from `item.previewLines[last]` which `buildRenderItems` already
+ * populates.
+ *
+ * The colour map is keyed by `ToolStatus` from the view-model layer so it
+ * stays aligned with the adapter's status classification.
  */
 
 type Props = {
   item: ToolGroupRenderItem
 }
 
-const STATUS_COLORS: Record<ToolStatus, string> = {
-  pending: c.dim,
-  running: c.info,
-  success: c.success,
-  error: c.error,
-  cancelled: c.warning,
+interface StatusStyle {
+  color: string
+  glyph: string
+}
+
+const STATUS_STYLES: Record<ToolStatus, StatusStyle> = {
+  pending:   { color: c.dim,     glyph: '\u25CC' }, // ◌
+  running:   { color: c.info,    glyph: '\u25CF' }, // ●
+  success:   { color: c.success, glyph: '\u2713' }, // ✓
+  error:     { color: c.error,   glyph: '\u2717' }, // ✗
+  cancelled: { color: c.warning, glyph: '\u25A0' }, // ■
 }
 
 export function ToolGroupMessage({ item }: Props) {
   const { keybindingConfig } = useAppState()
-  const color = STATUS_COLORS[item.status]
+  const style = STATUS_STYLES[item.status]
   const expandHint = `${shortcutLabel('app:toggleTranscript', { context: 'Global', config: keybindingConfig })} to expand`
+  const latestHint = item.previewLines[item.previewLines.length - 1]
 
   return (
     <box flexDirection="column" paddingX={1} marginBottom={1} width="100%">
-      <box border={['left']} borderColor={color} paddingLeft={1} flexDirection="column" width="100%">
-        <box gap={1} width="100%">
-          <text fg={color}>
-            <strong>{item.title}</strong>
-          </text>
-          <text fg={c.dim}>({expandHint})</text>
+      <box flexDirection="row" gap={1} width="100%">
+        <box minWidth={2} flexShrink={0}>
+          <text fg={style.color}>{style.glyph}</text>
         </box>
-        <box paddingLeft={2} flexDirection="column" width="100%">
-          {item.previewLines.map((line, index) => {
-            const isLatestRunning = item.status === 'running' && index === item.previewLines.length - 1
-            return (
-              <text key={`${item.id}:preview:${index}`} fg={isLatestRunning ? color : c.dim} selectable>
-                {line}
-              </text>
-            )
-          })}
-          {item.hiddenCount > 0 && (
-            <text fg={c.dim}>
-              +{item.hiddenCount} more tool uses ({expandHint})
-            </text>
-          )}
-        </box>
+        <text fg={style.color}>
+          <strong>{item.title}</strong>
+        </text>
+        <text fg={c.dim}>({expandHint})</text>
       </box>
+      {latestHint && (
+        <box paddingLeft={3} flexDirection="row" width="100%">
+          <text fg={c.dim}>{'\u23BF '}</text>
+          <text fg={item.status === 'running' ? style.color : c.dim} selectable>
+            {latestHint}
+          </text>
+        </box>
+      )}
+      {item.hiddenCount > 0 && (
+        <box paddingLeft={3} width="100%">
+          <text fg={c.dim}>
+            +{item.hiddenCount} more tool uses ({expandHint})
+          </text>
+        </box>
+      )}
     </box>
   )
 }

--- a/ui/src/components/messages/ToolResultOrphanMessage.tsx
+++ b/ui/src/components/messages/ToolResultOrphanMessage.tsx
@@ -3,11 +3,15 @@ import { c } from '../../theme.js'
 import type { OrphanToolResultRenderItem } from '../../store/message-model.js'
 
 /**
- * Lite-native port of the sample tree's orphan-result rendering from
- * `UserToolResultMessage` (the branch taken when there is no matching
- * `tool_use` parent). Shown only when the pipeline sees a `tool_result`
- * with no corresponding `tool_use` — usually a replay artifact or a
- * cancelled call.
+ * OpenTUI port of the orphan-result branch of upstream
+ * `UserToolResultMessage` (the one taken when no matching `tool_use`
+ * parent exists). Shown only when the pipeline sees a `tool_result`
+ * with no corresponding `tool_use` — usually a replay artefact, a
+ * cancelled call, or a background-task completion.
+ *
+ * Upstream doesn't render a dedicated glyph for this case — we use the
+ * `⎿` continuation glyph so it reads as "result detached from its tool"
+ * against the surrounding assistant / tool-use rows.
  */
 
 type Props = {
@@ -20,17 +24,24 @@ export function ToolResultOrphanMessage({ item }: Props) {
     : item.status === 'cancelled'
       ? c.warning
       : c.success
-  const label = item.isError ? 'ORPHAN ERROR' : 'ORPHAN RESULT'
+  const label = item.isError
+    ? 'orphan error'
+    : item.status === 'cancelled'
+      ? 'orphan cancelled'
+      : 'orphan result'
 
   return (
     <box flexDirection="column" paddingX={1} marginBottom={1} width="100%">
-      <box gap={1}>
+      <box flexDirection="row" gap={1}>
+        <box minWidth={2} flexShrink={0}>
+          <text fg={color}>{'\u23BF'}</text>
+        </box>
         <text fg={color}>
-          <strong>[{label}]</strong>
+          <strong>{label}</strong>
         </text>
         <text fg={c.dim}>({item.toolUseId.slice(0, 8)})</text>
       </box>
-      <box paddingLeft={2} width="100%">
+      <box paddingLeft={3} width="100%">
         <text selectable fg={item.isError ? c.error : c.dim}>
           {item.outputSummary}
         </text>

--- a/ui/src/components/messages/UserTextMessage.tsx
+++ b/ui/src/components/messages/UserTextMessage.tsx
@@ -3,17 +3,93 @@ import { c } from '../../theme.js'
 import type { UserTextRenderItem } from '../../store/message-model.js'
 
 /**
- * Lite-native user-text bubble. Re-hosts the visual shape of the sample
- * tree's `UserPromptMessage` / `UserTextMessage`
- * (`ui/examples/upstream-patterns/src/components/messages/UserPromptMessage.tsx`)
- * but consumes the local `UserTextRenderItem` shape so it plugs straight
- * into the existing `buildRenderItems` pipeline.
+ * OpenTUI port of upstream's `UserTextMessage` router
+ * (`ui/examples/upstream-patterns/src/components/messages/UserTextMessage.tsx`)
+ * + its downstream leaves `UserPromptMessage`, `UserCommandMessage`,
+ * `UserBashInputMessage`, `UserMemoryInputMessage`.
+ *
+ * Upstream dispatches by XML tag (`<bash-input>`, `<command-message>`,
+ * `<user-memory-input>`). cc-rust strips those tags before IPC delivery, so
+ * `message-model.classifyUserTextKind` infers the kind from the first
+ * non-space character of the prompt text (`/`, `!`, `#`) — matching the
+ * prompt widget's own shortcut conventions.
+ *
+ * Each kind renders with its upstream visual shape:
+ * - `command` — `❯ /foo bar` in a dim prefix + bubble
+ * - `bash`    — `! command` with yellow caret
+ * - `memory`  — `# note` with a magenta caret
+ * - `prompt`  — the standard markdown bubble with a left border
  */
 type Props = {
   item: UserTextRenderItem
 }
 
-export function UserTextMessage({ item }: Props) {
+function stripLeading(text: string, prefix: string): string {
+  const trimmed = text.trimStart()
+  if (trimmed.startsWith(prefix)) {
+    return trimmed.slice(prefix.length).trimStart()
+  }
+  return trimmed
+}
+
+function UserCommandBubble({ text }: { text: string }) {
+  const body = stripLeading(text, '/')
+  return (
+    <box flexDirection="column" paddingX={1} marginBottom={1} width="100%">
+      <box
+        flexDirection="row"
+        width="100%"
+        backgroundColor={c.userBubbleBg}
+        paddingLeft={1}
+        paddingRight={1}
+        selectable
+      >
+        <text fg={c.dim} bg={c.userBubbleBg}>{'\u276F '}</text>
+        <text fg={c.text} bg={c.userBubbleBg}>/{body}</text>
+      </box>
+    </box>
+  )
+}
+
+function UserBashBubble({ text }: { text: string }) {
+  const body = stripLeading(text, '!')
+  return (
+    <box flexDirection="column" paddingX={1} marginBottom={1} width="100%">
+      <box
+        flexDirection="row"
+        width="100%"
+        backgroundColor={c.userBubbleBg}
+        paddingLeft={1}
+        paddingRight={1}
+        selectable
+      >
+        <text fg={c.warning} bg={c.userBubbleBg}>{'! '}</text>
+        <text fg={c.text} bg={c.userBubbleBg}>{body}</text>
+      </box>
+    </box>
+  )
+}
+
+function UserMemoryBubble({ text }: { text: string }) {
+  const body = stripLeading(text, '#')
+  return (
+    <box flexDirection="column" paddingX={1} marginBottom={1} width="100%">
+      <box
+        flexDirection="row"
+        width="100%"
+        backgroundColor={c.userBubbleBg}
+        paddingLeft={1}
+        paddingRight={1}
+        selectable
+      >
+        <text fg={c.accent} bg={c.userBubbleBg}>{'# '}</text>
+        <text fg={c.text} bg={c.userBubbleBg}>{body}</text>
+      </box>
+    </box>
+  )
+}
+
+function UserPromptBubble({ text }: { text: string }) {
   return (
     <box flexDirection="column" paddingX={1} marginBottom={1} width="100%">
       <box
@@ -26,8 +102,23 @@ export function UserTextMessage({ item }: Props) {
         paddingRight={1}
         selectable
       >
-        <markdown content={item.content} bg={c.userBubbleBg} />
+        <markdown content={text} bg={c.userBubbleBg} />
       </box>
     </box>
   )
+}
+
+export function UserTextMessage({ item }: Props) {
+  const kind = item.kind ?? 'prompt'
+  switch (kind) {
+    case 'command':
+      return <UserCommandBubble text={item.content} />
+    case 'bash':
+      return <UserBashBubble text={item.content} />
+    case 'memory':
+      return <UserMemoryBubble text={item.content} />
+    case 'prompt':
+    default:
+      return <UserPromptBubble text={item.content} />
+  }
 }

--- a/ui/src/components/messages/index.ts
+++ b/ui/src/components/messages/index.ts
@@ -1,5 +1,5 @@
 /**
- * Barrel for the Lite-native message leaf components.
+ * Barrel for the OpenTUI message leaf components.
  *
  * Each leaf renders exactly one discriminant of the pipeline's
  * `RenderItem` shape (from `ui/src/store/message-model.ts`) and consumes
@@ -9,6 +9,7 @@
  * sample tree's monolithic `Message`/`MessageRow` runtime.
  */
 export { AssistantTextMessage } from './AssistantTextMessage.js'
+export { CompactBoundaryMessage } from './CompactBoundaryMessage.js'
 export { FileEditToolPreview, isFileEditToolName } from './FileEditToolPreview.js'
 export { StreamingMessage } from './StreamingMessage.js'
 export { SystemMessage } from './SystemMessage.js'
@@ -17,3 +18,25 @@ export { ToolActivityMessage } from './ToolActivityMessage.js'
 export { ToolGroupMessage } from './ToolGroupMessage.js'
 export { ToolResultOrphanMessage } from './ToolResultOrphanMessage.js'
 export { UserTextMessage } from './UserTextMessage.js'
+
+// ---------------------------------------------------------------------------
+// Intentionally not ported from upstream — require IPC/state data that does
+// not exist in cc-rust today. Reintroduce only with a matching backend signal:
+//
+// - RateLimitMessage / SystemAPIErrorMessage — rate-limit/API errors arrive
+//   as plain system_info text; upgrade once the backend sends structured
+//   error events with code/retry-after.
+// - TaskAssignmentMessage / UserTeammateMessage / UserChannelMessage /
+//   UserAgentNotificationMessage — agent-swarm / KAIROS channel UI; cc-rust
+//   daemon surfaces these but the frontend IPC does not yet expose them.
+// - UserImageMessage / AttachmentMessage — depend on the ImageSource
+//   refs the backend does not yet forward.
+// - PlanApprovalMessage / UserPlanMessage / UserResourceUpdateMessage /
+//   UserLocalCommandOutputMessage / UserBashOutputMessage — need tagged
+//   content (`<bash-stdout>`, `<plan>`, `<mcp-resource-update>`) which
+//   cc-rust strips before IPC.
+// - ShutdownMessage / HookProgressMessage — no hook/shutdown event stream
+//   in the current IPC protocol.
+// - AdvisorMessage / AssistantRedactedThinkingMessage — niche upstream
+//   cases; our redacted-thinking renders via ThinkingPreview already.
+// ---------------------------------------------------------------------------

--- a/ui/src/components/tasks/BackgroundTask.tsx
+++ b/ui/src/components/tasks/BackgroundTask.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import type { BackgroundAgent } from '../../store/app-state.js'
+import { c } from '../../theme.js'
+import {
+  elapsedMs,
+  formatElapsed,
+  getTaskStatusColor,
+  getTaskStatusIcon,
+  statusOf,
+} from './taskStatusUtils.js'
+
+/**
+ * Single-row renderer for a background agent. Adapted from the upstream
+ * `BackgroundTask.tsx` which branched on `task.type` (local_bash, remote_agent,
+ * local_agent, in_process_teammate, local_workflow, monitor_mcp, dream). Our
+ * Rust port only exposes the `BackgroundAgent` shape, so there is a single
+ * rendering path: icon + description + elapsed + terminal-state hint.
+ */
+type Props = {
+  agent: BackgroundAgent
+  now: number
+  maxDescriptionWidth?: number
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text
+  if (max <= 1) return text.slice(0, max)
+  return `${text.slice(0, max - 1)}\u2026`
+}
+
+export function BackgroundTask({ agent, now, maxDescriptionWidth }: Props) {
+  const status = statusOf(agent)
+  const icon = getTaskStatusIcon(status, { hasError: agent.hadError })
+  const color = getTaskStatusColor(status, { hasError: agent.hadError })
+  const elapsed = formatElapsed(elapsedMs(agent, now))
+  const descLimit = maxDescriptionWidth ?? 60
+  const description = truncate(agent.description || agent.agentId, descLimit)
+
+  const stateLabel =
+    status === 'running'
+      ? 'running'
+      : status === 'completed'
+        ? 'done'
+        : status === 'failed'
+          ? 'error'
+          : 'stopped'
+
+  return (
+    <text>
+      <span fg={color}>{icon}</span>
+      <span fg={c.text}> {description}</span>
+      <span fg={c.dim}>
+        {' '}
+        ({stateLabel} · {elapsed})
+      </span>
+    </text>
+  )
+}

--- a/ui/src/components/tasks/BackgroundTaskStatus.tsx
+++ b/ui/src/components/tasks/BackgroundTaskStatus.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { useAppState } from '../../store/app-store.js'
+import type { BackgroundAgent } from '../../store/app-state.js'
+import { BackgroundTask } from './BackgroundTask.js'
+import { statusOf } from './taskStatusUtils.js'
+
+/**
+ * Compact footer-style panel listing current and recently-finished background
+ * agents. Adapted from `ui/examples/upstream-patterns/src/components/tasks/
+ * BackgroundTaskStatus.tsx`, collapsed to match our single data source
+ * (`BackgroundAgent[]`). Running agents are listed first, followed by up to
+ * `MAX_RECENT_FINISHED` finished-but-still-interesting rows.
+ *
+ * Mirrors the visual density of `SubsystemStatus.tsx` (bordered box with a
+ * title, small rows beneath). Hides itself entirely when there are no
+ * agents to show.
+ */
+
+const MAX_RECENT_FINISHED = 3
+const RUNNING_TICK_MS = 1000
+
+export function BackgroundTaskStatus() {
+  const { backgroundAgents } = useAppState()
+  const [now, setNow] = useState(() => Date.now())
+
+  // Sort: running first (oldest first so long-running tasks don't jump to
+  // the end), then recently finished (latest first).
+  const { running, finished } = useMemo(() => {
+    const run: BackgroundAgent[] = []
+    const done: BackgroundAgent[] = []
+    for (const a of backgroundAgents) {
+      if (statusOf(a) === 'running') run.push(a)
+      else done.push(a)
+    }
+    run.sort((a, b) => a.startedAt - b.startedAt)
+    done.sort((a, b) => (b.completedAt ?? 0) - (a.completedAt ?? 0))
+    return {
+      running: run,
+      finished: done.slice(0, MAX_RECENT_FINISHED),
+    }
+  }, [backgroundAgents])
+
+  // Tick every second while something is running so elapsed time updates.
+  useEffect(() => {
+    if (running.length === 0) return
+    const id = setInterval(() => setNow(Date.now()), RUNNING_TICK_MS)
+    return () => clearInterval(id)
+  }, [running.length])
+
+  const totalShown = running.length + finished.length
+  if (totalShown === 0) return null
+
+  const runningCount = running.length
+  const titleParts = [`${runningCount} running`]
+  if (finished.length > 0) titleParts.push(`${finished.length} recent`)
+  const title = `Background tasks (${titleParts.join(', ')})`
+
+  return (
+    <box
+      flexDirection="column"
+      border
+      borderStyle="rounded"
+      borderColor="#45475A"
+      paddingX={1}
+      title={title}
+      titleAlignment="left"
+      gap={0}
+    >
+      {running.map(agent => (
+        <BackgroundTask key={agent.agentId} agent={agent} now={now} />
+      ))}
+      {finished.map(agent => (
+        <BackgroundTask key={agent.agentId} agent={agent} now={now} />
+      ))}
+    </box>
+  )
+}

--- a/ui/src/components/tasks/ShellProgress.tsx
+++ b/ui/src/components/tasks/ShellProgress.tsx
@@ -1,0 +1,116 @@
+import React from 'react'
+import { c } from '../../theme.js'
+import type { ToolActivityRenderItem } from '../../store/message-model.js'
+import {
+  getTaskStatusColor,
+  getTaskStatusIcon,
+  type TaskStatus,
+} from './taskStatusUtils.js'
+
+/**
+ * Helpers for rendering a running shell (Bash tool activity) as a compact
+ * "Running: <cmd>" line. Adapted from `ui/examples/upstream-patterns/src/
+ * components/tasks/ShellProgress.tsx`.
+ *
+ * Upstream had a `LocalShellTaskState` type from the backend task system;
+ * we instead accept either a raw command string or a `ToolActivityRenderItem`
+ * produced by our message model (Bash tool_use entries have `input.command`).
+ */
+
+type TaskStatusTextProps = {
+  status: TaskStatus
+  label?: string
+  suffix?: string
+}
+
+export function TaskStatusText({
+  status,
+  label,
+  suffix,
+}: TaskStatusTextProps) {
+  const displayLabel = label ?? status
+  const color = getTaskStatusColor(status)
+  return (
+    <text>
+      <span fg={color}>(</span>
+      <span fg={color}>{displayLabel}</span>
+      {suffix ? <span fg={color}>{suffix}</span> : null}
+      <span fg={color}>)</span>
+    </text>
+  )
+}
+
+type ShellProgressProps = {
+  command: string
+  status: TaskStatus
+  maxCommandWidth?: number
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text
+  if (max <= 1) return text.slice(0, max)
+  return `${text.slice(0, max - 1)}\u2026`
+}
+
+/**
+ * Compact one-liner like `▶ Running: git status (running)` for a shell
+ * command. Colors follow task-status semantics.
+ */
+export function ShellProgress({
+  command,
+  status,
+  maxCommandWidth,
+}: ShellProgressProps) {
+  const icon = getTaskStatusIcon(status)
+  const color = getTaskStatusColor(status)
+  const trimmed = truncate(command, maxCommandWidth ?? 80)
+  const label =
+    status === 'running'
+      ? 'Running'
+      : status === 'completed'
+        ? 'Done'
+        : status === 'failed'
+          ? 'Failed'
+          : 'Stopped'
+
+  return (
+    <text>
+      <span fg={color}>{icon}</span>
+      <span fg={c.dim}> {label}: </span>
+      <span fg={c.text}>{trimmed}</span>
+    </text>
+  )
+}
+
+/**
+ * Derive the Bash command (if any) from a `ToolActivityRenderItem`.
+ * Returns `undefined` for non-Bash tool activities so callers can fall back
+ * to more generic rendering.
+ */
+export function bashCommandFromActivity(
+  item: ToolActivityRenderItem,
+): string | undefined {
+  if (item.name !== 'Bash') return undefined
+  const cmd = item.input?.command
+  return typeof cmd === 'string' && cmd.length > 0 ? cmd : undefined
+}
+
+/**
+ * Map a `ToolActivityRenderItem.status` onto our `TaskStatus` set.
+ */
+export function toolStatusToTaskStatus(
+  s: ToolActivityRenderItem['status'],
+): TaskStatus {
+  switch (s) {
+    case 'success':
+      return 'completed'
+    case 'error':
+      return 'failed'
+    case 'cancelled':
+      return 'killed'
+    case 'pending':
+    case 'running':
+    default:
+      return 'running'
+  }
+}

--- a/ui/src/components/tasks/index.ts
+++ b/ui/src/components/tasks/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Tasks panel barrel export.
+ *
+ * Adapted subset of the upstream `components/tasks/` folder. Files not
+ * ported (because they require backend task/agent-detail subsystems we
+ * don't have in the Rust port):
+ *   - AsyncAgentDetailDialog, DreamDetailDialog, InProcessTeammateDetailDialog,
+ *     MonitorMcpDetailDialog, RemoteSessionDetailDialog, RemoteSessionProgress,
+ *     ShellDetailDialog, WorkflowDetailDialog, BackgroundTasksDialog
+ */
+export { BackgroundTask } from './BackgroundTask.js'
+export { BackgroundTaskStatus } from './BackgroundTaskStatus.js'
+export {
+  ShellProgress,
+  TaskStatusText,
+  bashCommandFromActivity,
+  toolStatusToTaskStatus,
+} from './ShellProgress.js'
+export { renderToolActivityChip } from './renderToolActivity.js'
+export {
+  elapsedMs,
+  formatElapsed,
+  getTaskStatusColor,
+  getTaskStatusIcon,
+  isTerminalStatus,
+  statusOf,
+  type TaskStatus,
+  type TaskStatusOptions,
+} from './taskStatusUtils.js'

--- a/ui/src/components/tasks/renderToolActivity.tsx
+++ b/ui/src/components/tasks/renderToolActivity.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { c } from '../../theme.js'
+import type { ToolActivityRenderItem } from '../../store/message-model.js'
+import {
+  bashCommandFromActivity,
+  ShellProgress,
+  toolStatusToTaskStatus,
+} from './ShellProgress.js'
+
+/**
+ * Compact status chip for a `ToolActivityRenderItem`, used by the tasks-
+ * related panels (not the main transcript — `ToolActivityMessage` handles
+ * that). Adapted from `ui/examples/upstream-patterns/src/components/tasks/
+ * renderToolActivity.tsx`.
+ *
+ * Upstream pulled a `userFacingName` and `renderToolUseMessage` from a
+ * registered `Tools` object. We don't have that registry in the frontend,
+ * so we fall back to `name` + `inputSummary` for a single-line summary, and
+ * route Bash specifically through `ShellProgress` so shell commands get
+ * the friendlier "Running: cmd" formatting.
+ */
+type Props = {
+  item: ToolActivityRenderItem
+  maxWidth?: number
+}
+
+export function renderToolActivityChip({ item, maxWidth }: Props) {
+  const bashCmd = bashCommandFromActivity(item)
+  if (bashCmd) {
+    return (
+      <ShellProgress
+        command={bashCmd}
+        status={toolStatusToTaskStatus(item.status)}
+        maxCommandWidth={maxWidth}
+      />
+    )
+  }
+
+  const summary = item.inputSummary || item.inputDetail || ''
+  return (
+    <text>
+      <span fg={c.warning}>{item.name}</span>
+      {summary ? <span fg={c.dim}>({summary})</span> : null}
+    </text>
+  )
+}

--- a/ui/src/components/tasks/taskStatusUtils.ts
+++ b/ui/src/components/tasks/taskStatusUtils.ts
@@ -1,0 +1,125 @@
+/**
+ * Shared utilities for displaying task status across different task types.
+ *
+ * Adapted from `ui/examples/upstream-patterns/src/components/tasks/taskStatusUtils.tsx`.
+ * The upstream references a rich `TaskState` union from `src/tasks/types.ts`
+ * that we don't have in the Rust port — here we derive the same status set
+ * from `BackgroundAgent` fields in our store (`app-state.ts`):
+ *
+ *   - completedAt unset                       → 'running'
+ *   - completedAt set && hadError             → 'failed'
+ *   - completedAt set && !hadError            → 'completed'
+ *   - (reserved) explicitly aborted           → 'killed'
+ *
+ * Glyphs are unicode characters rather than the upstream `figures` package,
+ * and colors are pulled from `theme.ts` as hex strings so they can be
+ * consumed directly by OpenTUI `<text fg=...>` attributes.
+ */
+import type { BackgroundAgent } from '../../store/app-state.js'
+import { c } from '../../theme.js'
+
+export type TaskStatus = 'running' | 'completed' | 'failed' | 'killed'
+
+/**
+ * Returns true if the given task status represents a terminal (finished) state.
+ */
+export function isTerminalStatus(status: TaskStatus): boolean {
+  return status === 'completed' || status === 'failed' || status === 'killed'
+}
+
+export interface TaskStatusOptions {
+  isIdle?: boolean
+  awaitingApproval?: boolean
+  hasError?: boolean
+  shutdownRequested?: boolean
+}
+
+/**
+ * Derive a status from a `BackgroundAgent` record.
+ */
+export function statusOf(agent: BackgroundAgent): TaskStatus {
+  if (agent.completedAt == null) return 'running'
+  if (agent.hadError) return 'failed'
+  return 'completed'
+}
+
+/**
+ * Returns the appropriate unicode icon for a task based on status and state flags.
+ */
+export function getTaskStatusIcon(
+  status: TaskStatus,
+  options?: TaskStatusOptions,
+): string {
+  const { isIdle, awaitingApproval, hasError, shutdownRequested } =
+    options ?? {}
+
+  if (hasError) return '\u2717' // ✗
+  if (awaitingApproval) return '?'
+  if (shutdownRequested) return '\u26A0' // ⚠
+
+  if (status === 'running') {
+    if (isIdle) return '\u2026' // …
+    return '\u25B6' // ▶
+  }
+  if (status === 'completed') return '\u2713' // ✓
+  if (status === 'failed' || status === 'killed') return '\u2717' // ✗
+  return '\u25CF' // ●
+}
+
+/**
+ * Returns a hex color for a task based on status and state flags.
+ * Uses the palette from `theme.ts` so colors stay consistent with other panels.
+ */
+export function getTaskStatusColor(
+  status: TaskStatus,
+  options?: TaskStatusOptions,
+): string {
+  const { isIdle, awaitingApproval, hasError, shutdownRequested } =
+    options ?? {}
+
+  if (hasError) return c.error
+  if (awaitingApproval) return c.warning
+  if (shutdownRequested) return c.warning
+  if (isIdle) return c.dim
+
+  if (status === 'completed') return c.success
+  if (status === 'failed') return c.error
+  if (status === 'killed') return c.warning
+  return c.info
+}
+
+/**
+ * Format an elapsed duration in milliseconds as a compact human-readable
+ * string. Examples: `0.4s`, `12s`, `3m 05s`, `1h 02m`.
+ */
+export function formatElapsed(ms: number): string {
+  if (ms < 0) ms = 0
+  if (ms < 1000) {
+    const s = (ms / 1000).toFixed(1)
+    return `${s}s`
+  }
+  const totalSec = Math.floor(ms / 1000)
+  if (totalSec < 60) return `${totalSec}s`
+  const minutes = Math.floor(totalSec / 60)
+  const seconds = totalSec % 60
+  if (minutes < 60) {
+    return `${minutes}m ${seconds.toString().padStart(2, '0')}s`
+  }
+  const hours = Math.floor(minutes / 60)
+  const mins = minutes % 60
+  return `${hours}h ${mins.toString().padStart(2, '0')}m`
+}
+
+/**
+ * Compute the elapsed runtime for an agent, in milliseconds.
+ * Running tasks use `now`; finished tasks use `completedAt` or `durationMs`.
+ */
+export function elapsedMs(agent: BackgroundAgent, now: number): number {
+  if (agent.completedAt != null) {
+    return Math.max(0, agent.completedAt - agent.startedAt)
+  }
+  if (agent.durationMs != null) {
+    return agent.durationMs
+  }
+  return Math.max(0, now - agent.startedAt)
+}

--- a/ui/src/store/message-model.ts
+++ b/ui/src/store/message-model.ts
@@ -33,11 +33,27 @@ export type ToolActivityStatus =
   | 'error'
   | 'cancelled'
 
+/**
+ * Sub-kind for user input messages, inferred from the prompt prefix so the
+ * dispatcher can pick a layout without the backend adding extra metadata.
+ *
+ * - `prompt` — normal user prompt (markdown bubble)
+ * - `command` — slash command (`/foo bar`)
+ * - `bash` — bash shortcut (`!ls -la`)
+ * - `memory` — memory shortcut (`#remember something`)
+ */
+export type UserTextKind = 'prompt' | 'command' | 'bash' | 'memory'
+
 export interface UserTextRenderItem {
   type: 'user_text'
   id: string
   content: string
   timestamp: number
+  /**
+   * Heuristic kind used by `UserTextMessage` to pick a visual style. Older
+   * items produced before this field was added render as `'prompt'`.
+   */
+  kind?: UserTextKind
 }
 
 export interface AssistantTextRenderItem {
@@ -115,6 +131,31 @@ export type RenderItem =
 const GROUPABLE_TOOL_NAMES = new Set(['Read', 'Glob', 'Grep'])
 const MAX_GROUP_PREVIEW_LINES = 3
 
+/**
+ * Heuristic classifier for a user input segment — mirrors the upstream
+ * `UserTextMessage` router which splits by XML tags. Our IPC strips those
+ * tags, so we fall back to the leading character of the trimmed text
+ * (`/foo` → command, `!ls` → bash, `#note` → memory). Matches the prompt
+ * widget's own prefix conventions in `PromptInput.tsx`.
+ */
+export function classifyUserTextKind(text: string): UserTextKind {
+  const trimmed = text.trimStart()
+  if (!trimmed) {
+    return 'prompt'
+  }
+  const first = trimmed[0]
+  if (first === '/') {
+    return 'command'
+  }
+  if (first === '!') {
+    return 'bash'
+  }
+  if (first === '#') {
+    return 'memory'
+  }
+  return 'prompt'
+}
+
 export function conversationToRawMessage(message: ConversationMessage): RawMessage {
   return {
     id: message.id,
@@ -181,6 +222,7 @@ export function buildRenderItems(
       id: `${raw.id}:user:${segmentIndex}`,
       content: text,
       timestamp: raw.timestamp,
+      kind: classifyUserTextKind(text),
     })
   }
 


### PR DESCRIPTION
## Summary

Ports three component areas from `ui/examples/upstream-patterns/` into the live OpenTUI frontend, bringing rendering closer to upstream parity without extending the IPC/store schema.

- **`messages/`** — All 9 leaves upgraded to upstream-style glyphs (`●` dot anchor, `⎿` continuation line, `∴` thinking, `◌/✓/✗/■` status). New `CompactBoundaryMessage` renders `✻ Conversation compacted` for `system_info.level === 'compact_boundary'`. `UserTextMessage` now splits into 4 bubbles (prompt / command / bash / memory) dispatched by a new optional `kind` field + heuristic `classifyUserTextKind()`.
- **`PromptInput/`** — New `PromptInputFooter` (compact vim/busy/queued/shortcut row under the composer), `usePromptInputPlaceholder` (rotating onboarding hints), `useMaybeTruncateInput` (swap `>10k`-char pastes for a placeholder, rehydrate on submit). `QueuedSubmissions` upgraded from one-line summary to numbered list with truncation and overflow marker.
- **`tasks/`** (new directory) — `BackgroundTaskStatus` panel lists running + recently-finished `BackgroundAgent` entries, mounted between `TeamPanel` and `SubsystemStatus`. Adds status glyph/color helpers (`taskStatusUtils`), a per-row `BackgroundTask` renderer, `ShellProgress` for Bash activity, and `renderToolActivityChip`.

## Why

Keeps the native OpenTUI frontend visually aligned with upstream (`ui/examples/upstream-patterns/`) after recent backend changes.

## What reviewers should know

- **No IPC changes.** Only store change is an optional `kind?: UserTextKind` field on `UserTextRenderItem` — older items fall back to `'prompt'`, so this is backward-compatible.
- **Intentional skips** documented in each barrel's `index.ts`: rate-limit / API-error / hook-progress / shutdown (need structured events not yet in IPC), teammate / channel / swarm / remote-session (KAIROS features not yet on frontend), user-image / plan-approval / bash-stdout (depend on XML tags stripped pre-IPC), voice / shimmer / sandbox-hint (no backend stream). Each is re-introducible once the matching backend signal lands.
- Three subagents drafted the three areas in parallel; work was reconciled with no file-level collisions.
- Status-utils and footer use hex colors from `theme.c` (consistent with `SubsystemStatus`/`TeamPanel`).

## Test plan

- [x] `bun test src/store/ src/components/PromptInput/__tests__/ src/adapters/__tests__/` — 66 pass, 2 fail (failures are pre-existing `@opentui/react/jsx-dev-runtime` resolution in a fresh worktree — unrelated to this change)
- [ ] Visual smoke test: run `cc-rust` and verify
  - assistant/user/system messages show new glyphs (`●`, `⎿`, `∴`, `✻`)
  - typing `/`, `!`, `#` prefixes renders the matching bubble variant
  - paste of `>10k` chars shows truncation placeholder, full content restored on submit
  - queued messages render as numbered list, overflow marker appears past 3
  - footer shows vim/busy/queued/shortcut pills appropriately
  - background agent runs show up in `BackgroundTaskStatus` panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)