### PR TITLE
feat(shell): live Bash progress + OpenTUI shell output components

### DIFF
--- a/crates/claude-code-rs/src/engine/lifecycle/deps.rs
+++ b/crates/claude-code-rs/src/engine/lifecycle/deps.rs
@@ -45,6 +45,13 @@ pub(crate) struct QueryEngineDeps {
     pub(crate) permission_callback: Option<crate::types::tool::PermissionCallback>,
     /// Background agent sender — forwarded into ToolUseContext.
     pub(crate) bg_agent_tx: Option<crate::ipc::agent_channel::AgentSender>,
+    /// Optional callback that receives every `ToolProgress` emitted by a
+    /// tool. The query loop pulls this via `tool_progress_callback()` and
+    /// hands it to `execute_tool_calls`. Tests can leave it unset; in
+    /// headless mode the engine installs a closure that forwards each
+    /// progress event to `FrontendSink`.
+    pub(crate) tool_progress_callback:
+        Option<Arc<dyn Fn(ToolProgress) + Send + Sync>>,
     /// Shared buffer of completed background agents.
     pub(crate) pending_bg_results: cc_types::background_agents::PendingBackgroundResults,
     /// Hook runner — used via the `HookRunner` trait from `cc-types::hooks` so
@@ -57,6 +64,12 @@ pub(crate) struct QueryEngineDeps {
 
 #[async_trait::async_trait]
 impl QueryDeps for QueryEngineDeps {
+    fn tool_progress_callback(
+        &self,
+    ) -> Option<Arc<dyn Fn(ToolProgress) + Send + Sync>> {
+        self.tool_progress_callback.clone()
+    }
+
     async fn call_model(&self, mut params: ModelCallParams) -> Result<ModelResponse> {
         let client = self.api_client.as_ref().ok_or_else(|| {
             anyhow::anyhow!(
@@ -337,7 +350,7 @@ impl QueryDeps for QueryEngineDeps {
         request: ToolExecRequest,
         tools: &Tools,
         parent_message: &crate::types::message::AssistantMessage,
-        _on_progress: Option<Arc<dyn Fn(ToolProgress) + Send + Sync>>,
+        on_progress: Option<Arc<dyn Fn(ToolProgress) + Send + Sync>>,
     ) -> Result<ToolExecResult> {
         use cc_types::hooks::{PermissionOverride, PostToolHookResult, PreToolHookResult};
         use crate::types::tool::PermissionResult;
@@ -769,8 +782,30 @@ impl QueryDeps for QueryEngineDeps {
         }
         let tool_start = std::time::Instant::now();
 
+        // Adapt the `Arc` from `QueryDeps::execute_tool` into the `Box`
+        // the `Tool::call` contract expects. The wrapper also stamps the
+        // current `request.tool_use_id` onto each `ToolProgress` so
+        // downstream tools don't need to know it themselves.
+        let tool_use_id_for_progress = request.tool_use_id.clone();
+        let boxed_progress: Option<Box<dyn Fn(ToolProgress) + Send + Sync>> =
+            on_progress.as_ref().map(|arc| {
+                let arc = arc.clone();
+                let tool_use_id = tool_use_id_for_progress.clone();
+                Box::new(move |mut p: ToolProgress| {
+                    if p.tool_use_id.is_empty() {
+                        p.tool_use_id = tool_use_id.clone();
+                    }
+                    arc(p)
+                }) as Box<dyn Fn(ToolProgress) + Send + Sync>
+            });
+
         match tool
-            .call(effective_input.clone(), &ctx, parent_message, None)
+            .call(
+                effective_input.clone(),
+                &ctx,
+                parent_message,
+                boxed_progress,
+            )
             .await
         {
             Ok(result) => {

--- a/crates/claude-code-rs/src/engine/lifecycle/mod.rs
+++ b/crates/claude-code-rs/src/engine/lifecycle/mod.rs
@@ -75,6 +75,12 @@ pub(crate) struct QueryEngineState {
     /// Sender for background agent completion channel.
     /// Set by headless/TUI mode; cloned into ToolUseContext.
     pub(crate) bg_agent_tx: Option<crate::ipc::agent_channel::AgentSender>,
+    /// Callback invoked on every [`ToolProgress`] emitted by a tool.
+    /// Set by headless/TUI mode; read by `QueryEngineDeps::tool_progress_callback`
+    /// and plumbed down to `execute_tool_calls` so tools (notably Bash) can
+    /// surface live output back to the frontend.
+    pub(crate) tool_progress_callback:
+        Option<Arc<dyn Fn(crate::types::tool::ToolProgress) + Send + Sync>>,
     /// If set, the engine is "sleeping" until this instant.
     /// The proactive tick loop skips ticks while `Instant::now() < sleep_until`.
     /// Cleared by `wake_up()` on user messages or external events.
@@ -161,6 +167,7 @@ impl QueryEngine {
                 permission_callback: None,
                 ask_user_callback: None,
                 bg_agent_tx: None,
+                tool_progress_callback: None,
                 sleep_until: None,
                 session_memory,
                 audit_ctx: AuditContext::noop("pending"),
@@ -220,6 +227,19 @@ impl QueryEngine {
     /// Set the background agent sender (called by headless/TUI at startup).
     pub fn set_bg_agent_tx(&self, tx: crate::ipc::agent_channel::AgentSender) {
         self.state.write().bg_agent_tx = Some(tx);
+    }
+
+    /// Install a `ToolProgress` callback.
+    ///
+    /// Headless/TUI mode wires this to a closure that serializes the
+    /// progress event into a `BackendMessage::ToolProgress` and sends it
+    /// through [`FrontendSink`]. The query loop reads the callback via
+    /// [`QueryEngineDeps::tool_progress_callback`] on every tool batch.
+    pub fn set_tool_progress_callback(
+        &self,
+        cb: Arc<dyn Fn(crate::types::tool::ToolProgress) + Send + Sync>,
+    ) {
+        self.state.write().tool_progress_callback = Some(cb);
     }
 
     // -- Sleep control -------------------------------------------------------

--- a/crates/claude-code-rs/src/engine/lifecycle/submit_message.rs
+++ b/crates/claude-code-rs/src/engine/lifecycle/submit_message.rs
@@ -349,6 +349,7 @@ impl QueryEngine {
             // Create deps for the inner query loop
             let permission_callback = state_ref.read().permission_callback.clone();
             let bg_agent_tx = state_ref.read().bg_agent_tx.clone();
+            let tool_progress_callback = state_ref.read().tool_progress_callback.clone();
             let submit_audit_ctx = state_ref.read().audit_ctx.with_submit();
             let deps = Arc::new(QueryEngineDeps {
                 aborted: aborted_ref.clone(),
@@ -359,6 +360,7 @@ impl QueryEngine {
                 agent_context: config.agent_context.clone(),
                 permission_callback,
                 bg_agent_tx,
+                tool_progress_callback,
                 pending_bg_results: pending_bg_results.clone(),
                 hook_runner: hook_runner.clone(),
                 command_dispatcher: command_dispatcher.clone(),

--- a/crates/claude-code-rs/src/ipc/callbacks.rs
+++ b/crates/claude-code-rs/src/ipc/callbacks.rs
@@ -58,6 +58,52 @@ pub fn install_permission_callback(
     engine.set_permission_callback(callback);
 }
 
+/// Install the `ToolProgress` callback on the engine.
+///
+/// Whenever a tool emits a [`ToolProgress`](crate::types::tool::ToolProgress)
+/// event — typically the Bash tool streaming its stdout tail — the callback
+/// pulls the relevant fields out of the attached `data` JSON and sends a
+/// [`BackendMessage::ToolProgress`] to the frontend.
+///
+/// Missing fields are tolerated: only `tool_use_id` is required to drive UI
+/// routing; everything else is optional and the frontend falls back to its
+/// empty-state rendering.
+pub fn install_tool_progress_callback(engine: &QueryEngine, sink: FrontendSink) {
+    let callback = Arc::new(
+        move |progress: crate::types::tool::ToolProgress| {
+            let data = &progress.data;
+            let tool = data
+                .get("tool")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let output = data
+                .get("output")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let elapsed_seconds = data
+                .get("elapsed_seconds")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let total_lines = data.get("total_lines").and_then(|v| v.as_u64());
+            let total_bytes = data.get("total_bytes").and_then(|v| v.as_u64());
+            let timeout_ms = data.get("timeout_ms").and_then(|v| v.as_u64());
+
+            let _ = sink.send(&BackendMessage::ToolProgress {
+                tool_use_id: progress.tool_use_id,
+                tool,
+                output,
+                elapsed_seconds,
+                total_lines,
+                total_bytes,
+                timeout_ms,
+            });
+        },
+    );
+    engine.set_tool_progress_callback(callback);
+}
+
 /// Install the AskUserQuestion callback on the engine.
 ///
 /// When the engine asks a question, a `QuestionRequest` message is sent to the

--- a/crates/claude-code-rs/src/ipc/protocol/mod.rs
+++ b/crates/claude-code-rs/src/ipc/protocol/mod.rs
@@ -151,6 +151,33 @@ pub enum BackendMessage {
         #[serde(skip_serializing_if = "Option::is_none")]
         content_blocks: Option<Vec<ToolResultContentInfo>>,
     },
+    /// Intermediate progress report from a long-running tool invocation.
+    ///
+    /// Primarily emitted by the Bash tool so the frontend can render a
+    /// live "Running… (12s)" indicator plus a tail of recent output.
+    /// `output` holds the tail-capped snapshot the UI should display;
+    /// `total_lines` / `total_bytes` are the full-stream counters so the
+    /// UI can show `+N lines` / `~N lines` and total bytes; `timeout_ms`
+    /// surfaces the configured timeout.
+    ToolProgress {
+        tool_use_id: String,
+        /// Tool name (e.g. `"Bash"`) — lets UI-side routing pick the
+        /// right progress renderer without a second lookup.
+        tool: String,
+        /// Tail-capped snapshot suitable for display.
+        output: String,
+        /// Whole-seconds elapsed since the tool started.
+        elapsed_seconds: u64,
+        /// Total output lines observed so far.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        total_lines: Option<u64>,
+        /// Total output bytes observed so far.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        total_bytes: Option<u64>,
+        /// Configured tool timeout in milliseconds (if any).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        timeout_ms: Option<u64>,
+    },
     /// Ask the UI to show a permission dialog for a tool call.
     PermissionRequest {
         tool_use_id: String,

--- a/crates/claude-code-rs/src/ipc/runtime.rs
+++ b/crates/claude-code-rs/src/ipc/runtime.rs
@@ -62,6 +62,7 @@ impl HeadlessRuntime {
             self.pending_questions.clone(),
             self.sink.clone(),
         );
+        super::callbacks::install_tool_progress_callback(&self.engine, self.sink.clone());
 
         // ── 1b. Background agent channel ─────────────────────────────
         let (agent_tx, mut agent_rx) = crate::ipc::agent_channel::agent_channel();

--- a/crates/claude-code-rs/src/query/deps.rs
+++ b/crates/claude-code-rs/src/query/deps.rs
@@ -127,6 +127,17 @@ pub trait QueryDeps: Send + Sync {
         on_progress: Option<Arc<dyn Fn(ToolProgress) + Send + Sync>>,
     ) -> Result<ToolExecResult>;
 
+    /// Optional progress callback passed to each `execute_tool` call.
+    /// Default: `None` so tests and lightweight impls stay unchanged.
+    /// Production impls that have a route to the frontend (e.g. the
+    /// engine when it was created with a sink) return `Some(…)` so the
+    /// Bash tool can emit `ToolProgress` updates while running.
+    fn tool_progress_callback(
+        &self,
+    ) -> Option<Arc<dyn Fn(ToolProgress) + Send + Sync>> {
+        None
+    }
+
     /// 获取当前 app state
     fn get_app_state(&self) -> AppState;
 

--- a/crates/claude-code-rs/src/query/loop_helpers.rs
+++ b/crates/claude-code-rs/src/query/loop_helpers.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 
 use crate::types::message::{AssistantMessage, ContentBlock, Message, MessageContent, UserMessage};
 use crate::types::state::QueryLoopState;
+use crate::types::tool::ToolProgress;
 use crate::types::transitions::{Continue, Terminal};
 
 use super::deps::{QueryDeps, ToolExecRequest, ToolExecResult};
@@ -110,6 +111,7 @@ pub(crate) async fn execute_tool_calls(
     tool_uses: &[(String, String, serde_json::Value)],
     tools: &crate::types::tool::Tools,
     parent_message: &AssistantMessage,
+    on_progress: Option<Arc<dyn Fn(ToolProgress) + Send + Sync>>,
 ) -> Vec<ToolExecResult> {
     let mut results = Vec::new();
 
@@ -157,6 +159,7 @@ pub(crate) async fn execute_tool_calls(
                 let parent = parent_message.clone();
                 let tools = tools.clone();
                 let batch_span = batch_span.clone();
+                let on_progress_clone = on_progress.clone();
                 let handle = tokio::spawn(async move {
                     let req = ToolExecRequest {
                         tool_use_id: id,
@@ -164,7 +167,7 @@ pub(crate) async fn execute_tool_calls(
                         input,
                         langfuse_batch_span: batch_span,
                     };
-                    deps.execute_tool(req, &tools, &parent, None).await
+                    deps.execute_tool(req, &tools, &parent, on_progress_clone).await
                 });
                 handles.push(handle);
             }
@@ -199,7 +202,10 @@ pub(crate) async fn execute_tool_calls(
                     input,
                     langfuse_batch_span: None,
                 };
-                match deps.execute_tool(req, tools, parent_message, None).await {
+                match deps
+                    .execute_tool(req, tools, parent_message, on_progress.clone())
+                    .await
+                {
                     Ok(result) => results.push(result),
                     Err(e) => {
                         warn!(error = %e, "tool execution error");

--- a/crates/claude-code-rs/src/query/loop_impl.rs
+++ b/crates/claude-code-rs/src/query/loop_impl.rs
@@ -538,6 +538,7 @@ pub fn query(params: QueryParams, deps: Arc<dyn QueryDeps>) -> impl Stream<Item 
                     &tool_uses,
                     &tools,
                     &assistant_message,
+                    deps.tool_progress_callback(),
                 )
                 .await;
 

--- a/crates/claude-code-rs/src/tools/exec/bash.rs
+++ b/crates/claude-code-rs/src/tools/exec/bash.rs
@@ -1,6 +1,11 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
 use anyhow::Result;
 use async_trait::async_trait;
+use parking_lot::Mutex;
 use serde_json::{json, Value};
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
 use crate::permissions::dangerous::is_dangerous_command;
@@ -71,6 +76,54 @@ pub(crate) fn truncate_output(output: &str, max_chars: usize) -> String {
 
         // Reduce head_lines by half each iteration
         head_lines /= 2;
+    }
+}
+
+/// Snapshot for `ToolProgress::output` — carries the tail-capped
+/// rendering of the current stdout/stderr buffers plus whole-stream
+/// counters (lines/bytes) so the frontend can show `+N lines` / total
+/// bytes even when the output itself is truncated.
+struct ProgressSnapshot {
+    output: String,
+    total_lines: u64,
+    total_bytes: u64,
+}
+
+/// Build a `ProgressSnapshot` from the live stdout/stderr buffers.
+///
+/// The merge rule matches `call`'s final `combined` output: `stdout`
+/// first, then a separator newline, then `stderr`. Counters always
+/// reflect the full (pre-truncation) streams so the UI can show an
+/// accurate `~N lines`.
+fn build_progress_snapshot(
+    stdout_buf: &Arc<Mutex<String>>,
+    stderr_buf: &Arc<Mutex<String>>,
+    max_chars: usize,
+) -> ProgressSnapshot {
+    let stdout = stdout_buf.lock().clone();
+    let stderr = stderr_buf.lock().clone();
+
+    let mut combined = String::new();
+    if !stdout.is_empty() {
+        combined.push_str(&stdout);
+    }
+    if !stderr.is_empty() {
+        if !combined.is_empty() {
+            combined.push('\n');
+        }
+        combined.push_str(&stderr);
+    }
+
+    let total_bytes = combined.len() as u64;
+    let total_lines =
+        combined.lines().count() as u64 + if combined.ends_with('\n') { 0 } else { 0 };
+
+    let truncated = truncate_output(&combined, max_chars);
+
+    ProgressSnapshot {
+        output: truncated,
+        total_lines,
+        total_bytes,
     }
 }
 
@@ -242,7 +295,7 @@ impl Tool for BashTool {
         input: Value,
         ctx: &ToolUseContext,
         _parent_message: &AssistantMessage,
-        _on_progress: Option<Box<dyn Fn(ToolProgress) + Send + Sync>>,
+        on_progress: Option<Box<dyn Fn(ToolProgress) + Send + Sync>>,
     ) -> Result<ToolResult> {
         let (command, timeout_ms, _description) = Self::parse_input(&input);
 
@@ -357,14 +410,143 @@ impl Tool for BashTool {
         tracing::debug!(sandbox = %sandbox_description, "bash tool exec");
 
         let timeout_duration = resolve_timeout(timeout_ms);
+        let timeout_millis = timeout_duration.as_millis() as u64;
 
-        let result = tokio::time::timeout(timeout_duration, cmd.output()).await;
+        // Ensure stdio is piped even on the unwrapped path so we can stream.
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+        cmd.kill_on_drop(true);
 
-        match result {
-            Ok(Ok(output)) => {
-                let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-                let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-                let exit_code = output.status.code().unwrap_or(-1);
+        // Spawn the child so we can stream stdout/stderr back as the
+        // command runs. The upstream Ink UI renders a "Running… (Xs)"
+        // ticker plus a tail of recent output driven by `ToolProgress`
+        // events — we emit those here via `on_progress`.
+        let mut child = match cmd.spawn() {
+            Ok(c) => c,
+            Err(e) => {
+                return Ok(ToolResult {
+                    data: json!({
+                        "error": format!("Failed to spawn command: {}", e)
+                    }),
+                    new_messages: vec![],
+                    ..Default::default()
+                });
+            }
+        };
+
+        let stdout_pipe = child.stdout.take();
+        let stderr_pipe = child.stderr.take();
+        let stdout_buf: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
+        let stderr_buf: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
+
+        let stdout_task = stdout_pipe.map(|pipe| {
+            let buf = stdout_buf.clone();
+            tokio::spawn(async move {
+                let mut reader = BufReader::new(pipe).lines();
+                while let Ok(Some(line)) = reader.next_line().await {
+                    let mut b = buf.lock();
+                    b.push_str(&line);
+                    b.push('\n');
+                }
+            })
+        });
+
+        let stderr_task = stderr_pipe.map(|pipe| {
+            let buf = stderr_buf.clone();
+            tokio::spawn(async move {
+                let mut reader = BufReader::new(pipe).lines();
+                while let Ok(Some(line)) = reader.next_line().await {
+                    let mut b = buf.lock();
+                    b.push_str(&line);
+                    b.push('\n');
+                }
+            })
+        });
+
+        // The outer `QueryEngineDeps::execute_tool` wrapper stamps the
+        // real `tool_use_id` onto every `ToolProgress` we emit, so the
+        // tool itself only needs to fill in `data`.
+        let start = Instant::now();
+        let progress_interval = Duration::from_millis(1000);
+        let max_chars = self.max_result_size_chars();
+
+        // Move the box into a shared `Arc` so both the tick task (below)
+        // and the post-exit emit reuse the same callback without raw
+        // pointer gymnastics.
+        let on_progress_arc: Option<
+            Arc<dyn Fn(ToolProgress) + Send + Sync>,
+        > = on_progress.map(Arc::from);
+
+        // Fire a ticker on a background task so the frontend sees
+        // `ToolProgress` updates roughly once a second while the command
+        // runs. The task is aborted as soon as the child exits.
+        let progress_handle = on_progress_arc.as_ref().map(|cb| {
+            let cb = cb.clone();
+            let stdout_buf = stdout_buf.clone();
+            let stderr_buf = stderr_buf.clone();
+            let start = start;
+            let timeout_ms = timeout_millis;
+            tokio::spawn(async move {
+                let mut ticker = tokio::time::interval(progress_interval);
+                ticker.set_missed_tick_behavior(
+                    tokio::time::MissedTickBehavior::Skip,
+                );
+                // Skip the immediate tick so we don't fire at t=0.
+                ticker.tick().await;
+                loop {
+                    ticker.tick().await;
+                    let elapsed_seconds = start.elapsed().as_secs();
+                    let snapshot = build_progress_snapshot(
+                        &stdout_buf,
+                        &stderr_buf,
+                        max_chars,
+                    );
+                    cb(ToolProgress {
+                        tool_use_id: String::new(),
+                        data: json!({
+                            "tool": "Bash",
+                            "output": snapshot.output,
+                            "elapsed_seconds": elapsed_seconds,
+                            "total_lines": snapshot.total_lines,
+                            "total_bytes": snapshot.total_bytes,
+                            "timeout_ms": timeout_ms,
+                        }),
+                    });
+                }
+            })
+        });
+
+        let exit_status =
+            match tokio::time::timeout(timeout_duration, child.wait()).await {
+                Ok(status) => status,
+                Err(_) => {
+                    let _ = child.start_kill();
+                    Err(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "timeout",
+                    ))
+                }
+            };
+
+        if let Some(handle) = progress_handle {
+            handle.abort();
+        }
+
+        // Ensure the reader tasks drain whatever was left after the child
+        // exited before we snapshot the buffers for the final result.
+        if let Some(handle) = stdout_task {
+            let _ = handle.await;
+        }
+        if let Some(handle) = stderr_task {
+            let _ = handle.await;
+        }
+
+        let stdout = stdout_buf.lock().clone();
+        let stderr = stderr_buf.lock().clone();
+
+        match exit_status {
+            Ok(status) => {
+                let exit_code = status.code().unwrap_or(-1);
 
                 let mut combined = String::new();
                 if !stdout.is_empty() {
@@ -377,9 +559,29 @@ impl Tool for BashTool {
                     combined.push_str(&stderr);
                 }
 
-                // Truncate if too large using head+tail strategy
-                let max_chars = self.max_result_size_chars();
                 combined = truncate_output(&combined, max_chars);
+
+                // Final progress tick — lets the UI flip from
+                // "Running…" to "Done" with the complete tail.
+                if let Some(ref cb) = on_progress_arc {
+                    let elapsed_seconds = start.elapsed().as_secs();
+                    let snapshot = build_progress_snapshot(
+                        &stdout_buf,
+                        &stderr_buf,
+                        max_chars,
+                    );
+                    cb(ToolProgress {
+                        tool_use_id: String::new(),
+                        data: json!({
+                            "tool": "Bash",
+                            "output": snapshot.output,
+                            "elapsed_seconds": elapsed_seconds,
+                            "total_lines": snapshot.total_lines,
+                            "total_bytes": snapshot.total_bytes,
+                            "timeout_ms": timeout_millis,
+                        }),
+                    });
+                }
 
                 Ok(ToolResult {
                     data: json!({
@@ -392,13 +594,18 @@ impl Tool for BashTool {
                     ..Default::default()
                 })
             }
-            Ok(Err(e)) => Ok(ToolResult {
-                data: json!({ "error": format!("Failed to execute command: {}", e) }),
+            Err(e) if e.kind() == std::io::ErrorKind::TimedOut => Ok(ToolResult {
+                data: json!({
+                    "error": format!(
+                        "Command timed out after {}ms",
+                        timeout_duration.as_millis()
+                    )
+                }),
                 new_messages: vec![],
                 ..Default::default()
             }),
-            Err(_) => Ok(ToolResult {
-                data: json!({ "error": format!("Command timed out after {}ms", timeout_duration.as_millis()) }),
+            Err(e) => Ok(ToolResult {
+                data: json!({ "error": format!("Failed to execute command: {}", e) }),
                 new_messages: vec![],
                 ..Default::default()
             }),

--- a/ui/src/components/App.tsx
+++ b/ui/src/components/App.tsx
@@ -153,6 +153,18 @@ export function App() {
           }
           break
         }
+        case 'tool_progress':
+          dispatch({
+            type: 'TOOL_PROGRESS',
+            toolUseId: msg.tool_use_id,
+            tool: msg.tool,
+            output: msg.output,
+            elapsedSeconds: msg.elapsed_seconds,
+            totalLines: msg.total_lines,
+            totalBytes: msg.total_bytes,
+            timeoutMs: msg.timeout_ms,
+          })
+          break
         case 'permission_request':
           dispatch({
             type: 'PERMISSION_REQUEST',

--- a/ui/src/components/messages/ToolActivityMessage.tsx
+++ b/ui/src/components/messages/ToolActivityMessage.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import type { ViewMode } from '../../keybindings.js'
+import { useAppState } from '../../store/app-store.js'
 import { c } from '../../theme.js'
 import type { ToolActivityRenderItem } from '../../store/message-model.js'
 import type { ToolStatus } from '../../view-model/types.js'
+import { ShellProgressMessage } from '../shell/index.js'
 import { FileEditToolPreview, isFileEditToolName } from './FileEditToolPreview.js'
 
 /**
@@ -70,6 +72,10 @@ export function ToolActivityMessage({ item, viewMode }: Props) {
   const status = STATUS_STYLES[item.status]
   const question = extractAskUserQuestion(item)
   const showEditPreview = isFileEditToolName(item.name)
+  const { shellProgress } = useAppState()
+  const bashProgress =
+    item.name === 'Bash' ? shellProgress[item.toolUseId] : undefined
+  const showShellProgress = Boolean(bashProgress)
 
   if (viewMode === 'prompt') {
     return (
@@ -87,7 +93,20 @@ export function ToolActivityMessage({ item, viewMode }: Props) {
             </text>
           )}
         </box>
-        {item.outputSummary && !question && !showEditPreview && (
+        {showShellProgress && bashProgress && (
+          <box paddingLeft={3} width="100%">
+            <ShellProgressMessage
+              output={bashProgress.output}
+              fullOutput={bashProgress.fullOutput}
+              elapsedTimeSeconds={bashProgress.elapsedSeconds}
+              totalLines={bashProgress.totalLines}
+              totalBytes={bashProgress.totalBytes}
+              timeoutMs={bashProgress.timeoutMs}
+              verbose={false}
+            />
+          </box>
+        )}
+        {item.outputSummary && !question && !showEditPreview && !showShellProgress && (
           <box paddingLeft={3} width="100%" flexDirection="row">
             <text fg={c.dim}>{'\u23BF '}</text>
             <text selectable fg={item.isError ? c.error : c.dim}>
@@ -138,10 +157,27 @@ export function ToolActivityMessage({ item, viewMode }: Props) {
           {showEditPreview && (
             <FileEditToolPreview toolName={item.name} input={item.input} />
           )}
-          <text fg={c.dim}>Result</text>
-          <text selectable fg={item.isError ? c.error : c.text}>
-            {item.outputSummary || '(waiting for result)'}
-          </text>
+          {showShellProgress && bashProgress ? (
+            <>
+              <text fg={c.dim}>Progress</text>
+              <ShellProgressMessage
+                output={bashProgress.output}
+                fullOutput={bashProgress.fullOutput}
+                elapsedTimeSeconds={bashProgress.elapsedSeconds}
+                totalLines={bashProgress.totalLines}
+                totalBytes={bashProgress.totalBytes}
+                timeoutMs={bashProgress.timeoutMs}
+                verbose={true}
+              />
+            </>
+          ) : (
+            <>
+              <text fg={c.dim}>Result</text>
+              <text selectable fg={item.isError ? c.error : c.text}>
+                {item.outputSummary || '(waiting for result)'}
+              </text>
+            </>
+          )}
         </box>
       </box>
     </box>

--- a/ui/src/components/shell/ExpandShellOutputContext.tsx
+++ b/ui/src/components/shell/ExpandShellOutputContext.tsx
@@ -1,0 +1,33 @@
+import React, { createContext, useContext } from 'react'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/shell/ExpandShellOutputContext.tsx`.
+ *
+ * Context flag that children can read to decide whether to render shell
+ * output in full or truncated form. Used to auto-expand the latest
+ * user `!<cmd>` output in the transcript while keeping older entries
+ * compact.
+ */
+
+const ExpandShellOutputContext = createContext(false)
+
+export function ExpandShellOutputProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <ExpandShellOutputContext.Provider value={true}>
+      {children}
+    </ExpandShellOutputContext.Provider>
+  )
+}
+
+/**
+ * Returns true if rendered inside an `ExpandShellOutputProvider`. Consumers
+ * (`OutputLine`, `ShellProgressMessage`) use this to bypass truncation.
+ */
+export function useExpandShellOutput(): boolean {
+  return useContext(ExpandShellOutputContext)
+}

--- a/ui/src/components/shell/OutputLine.tsx
+++ b/ui/src/components/shell/OutputLine.tsx
@@ -1,0 +1,99 @@
+import React, { useMemo } from 'react'
+import { c } from '../../theme.js'
+import { stripAnsi } from './format.js'
+import { useExpandShellOutput } from './ExpandShellOutputContext.js'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/shell/OutputLine.tsx`.
+ *
+ * Differences from upstream:
+ * - No Ink `<Ansi>`: OpenTUI `<text>` renders literal characters, so we
+ *   strip ANSI with `stripAnsi` rather than colorising inline.
+ * - No `MessageResponse` wrapper: the shell components that consume this
+ *   own the `⎿` gutter. `OutputLine` is purely the body text.
+ * - No upstream `renderTruncatedContent`: when truncation is required we
+ *   keep the last `maxLines` lines as a tail — matches the behaviour of
+ *   the upstream `ShellProgressMessage` tail-preview.
+ */
+
+const MAX_JSON_FORMAT_LENGTH = 10_000
+const DEFAULT_MAX_LINES = 8
+
+type Props = {
+  content: string
+  /** If true, render the full (stripped) content. */
+  verbose: boolean
+  isError?: boolean
+  isWarning?: boolean
+  /**
+   * Max lines to show when `verbose` is false. Ignored while expanded via
+   * `ExpandShellOutputContext`.
+   */
+  maxLines?: number
+}
+
+export function tryFormatJson(line: string): string {
+  try {
+    const parsed = JSON.parse(line)
+    const stringified = JSON.stringify(parsed)
+
+    // Precision loss guard — large 64-bit ints lose precision through
+    // JSON.parse/stringify. Normalise both strings for comparison.
+    const normalizedOriginal = line.replace(/\\\//g, '/').replace(/\s+/g, '')
+    const normalizedStringified = stringified.replace(/\s+/g, '')
+
+    if (normalizedOriginal !== normalizedStringified) {
+      return line
+    }
+
+    return JSON.stringify(parsed, null, 2)
+  } catch {
+    return line
+  }
+}
+
+export function tryJsonFormatContent(content: string): string {
+  if (content.length > MAX_JSON_FORMAT_LENGTH) {
+    return content
+  }
+  const lines = content.split('\n')
+  return lines.map(tryFormatJson).join('\n')
+}
+
+function truncateToTail(content: string, maxLines: number): string {
+  const lines = content.split('\n')
+  if (lines.length <= maxLines) {
+    return content
+  }
+  const omitted = lines.length - maxLines
+  const tail = lines.slice(-maxLines).join('\n')
+  return `... (${omitted} earlier lines omitted)\n${tail}`
+}
+
+export function OutputLine({
+  content,
+  verbose,
+  isError,
+  isWarning,
+  maxLines = DEFAULT_MAX_LINES,
+}: Props) {
+  const expandShellOutput = useExpandShellOutput()
+  const shouldShowFull = verbose || expandShellOutput
+
+  const formatted = useMemo(() => {
+    const stripped = stripAnsi(tryJsonFormatContent(content))
+    if (shouldShowFull) {
+      return stripped
+    }
+    return truncateToTail(stripped, maxLines)
+  }, [content, shouldShowFull, maxLines])
+
+  const color = isError ? c.error : isWarning ? c.warning : c.text
+
+  return (
+    <text selectable fg={color}>
+      {formatted}
+    </text>
+  )
+}

--- a/ui/src/components/shell/ShellProgressMessage.tsx
+++ b/ui/src/components/shell/ShellProgressMessage.tsx
@@ -1,0 +1,103 @@
+import React from 'react'
+import { c } from '../../theme.js'
+import { formatFileSize, stripAnsi } from './format.js'
+import { ShellTimeDisplay } from './ShellTimeDisplay.js'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/shell/ShellProgressMessage.tsx`.
+ *
+ * Renders the live/trailing view of a shell (Bash) command as it runs:
+ * - While there is no output yet: dim "Running…" line + elapsed/timeout.
+ * - Once output starts flowing: dim tail (last 5 lines by default) plus
+ *   a status row with `+N lines`, elapsed, and total bytes.
+ * - In verbose mode the full output is shown with no tail cap.
+ *
+ * Backing data comes from a `tool_progress` IPC event emitted by the
+ * Rust `BashTool` (see `crates/claude-code-rs/src/tools/exec/bash.rs`).
+ * The upstream component wraps itself in `OffscreenFreeze` to avoid
+ * terminal resets when the progress line scrolls into scrollback —
+ * OpenTUI does its own diffing so we don't need the same guard here.
+ */
+
+type Props = {
+  /** Most-recent output (may already be tail-capped by the backend). */
+  output: string
+  /** Full accumulated output — used in verbose mode. */
+  fullOutput: string
+  /** Whole-seconds the command has been running. */
+  elapsedTimeSeconds?: number
+  /** Total stdout+stderr line count (including tail-capped portion). */
+  totalLines?: number
+  /** Total stdout+stderr byte count. */
+  totalBytes?: number
+  /** Configured timeout in milliseconds. */
+  timeoutMs?: number
+  /** Show every output line instead of a 5-line tail. */
+  verbose: boolean
+  /** Max tail lines when not verbose. Upstream uses 5. */
+  tailLines?: number
+}
+
+export function ShellProgressMessage({
+  output,
+  fullOutput,
+  elapsedTimeSeconds,
+  totalLines,
+  totalBytes,
+  timeoutMs,
+  verbose,
+  tailLines = 5,
+}: Props) {
+  const strippedFullOutput = stripAnsi(fullOutput.trim())
+  const strippedOutput = stripAnsi(output.trim())
+  const lines = strippedOutput.split('\n').filter(line => line)
+  const displayLines = verbose
+    ? strippedFullOutput
+    : lines.slice(-tailLines).join('\n')
+
+  if (!lines.length) {
+    return (
+      <box flexDirection="row" gap={1}>
+        <text fg={c.dim}>{'Running\u2026'}</text>
+        <ShellTimeDisplay
+          elapsedTimeSeconds={elapsedTimeSeconds}
+          timeoutMs={timeoutMs}
+        />
+      </box>
+    )
+  }
+
+  // Upstream rules:
+  //  - Truncated tail (backend capped): `~<totalLines> lines`
+  //  - Not truncated but more lines than shown: `+<extra> lines`
+  const extraLines = totalLines ? Math.max(0, totalLines - tailLines) : 0
+  let lineStatus = ''
+  if (!verbose && totalBytes && totalLines) {
+    lineStatus = `~${totalLines} lines`
+  } else if (!verbose && extraLines > 0) {
+    lineStatus = `+${extraLines} lines`
+  }
+
+  return (
+    <box flexDirection="column">
+      <box
+        flexDirection="column"
+        height={verbose ? undefined : Math.min(tailLines, lines.length)}
+        overflow="hidden"
+      >
+        <text fg={c.dim}>{displayLines}</text>
+      </box>
+      <box flexDirection="row" gap={1}>
+        {lineStatus ? <text fg={c.dim}>{lineStatus}</text> : null}
+        <ShellTimeDisplay
+          elapsedTimeSeconds={elapsedTimeSeconds}
+          timeoutMs={timeoutMs}
+        />
+        {totalBytes ? (
+          <text fg={c.dim}>{formatFileSize(totalBytes)}</text>
+        ) : null}
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/shell/ShellTimeDisplay.tsx
+++ b/ui/src/components/shell/ShellTimeDisplay.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { c } from '../../theme.js'
+import { formatDuration } from './format.js'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/shell/ShellTimeDisplay.tsx`.
+ *
+ * Renders a compact "(1s)", "(1s · timeout 30s)", or "(timeout 30s)"
+ * annotation for a shell run — kept next to the progress/output block so
+ * the user knows how long the command has been running and when it will
+ * be killed.
+ */
+
+type Props = {
+  elapsedTimeSeconds?: number
+  timeoutMs?: number
+}
+
+export function ShellTimeDisplay({ elapsedTimeSeconds, timeoutMs }: Props) {
+  if (elapsedTimeSeconds === undefined && !timeoutMs) {
+    return null
+  }
+
+  const timeout = timeoutMs
+    ? formatDuration(timeoutMs, { hideTrailingZeros: true })
+    : undefined
+
+  if (elapsedTimeSeconds === undefined) {
+    return <text fg={c.dim}>{`(timeout ${timeout})`}</text>
+  }
+
+  const elapsed = formatDuration(elapsedTimeSeconds * 1000)
+  if (timeout) {
+    return <text fg={c.dim}>{`(${elapsed} · timeout ${timeout})`}</text>
+  }
+  return <text fg={c.dim}>{`(${elapsed})`}</text>
+}

--- a/ui/src/components/shell/format.ts
+++ b/ui/src/components/shell/format.ts
@@ -1,0 +1,82 @@
+/**
+ * Formatting helpers for shell UI — localized here so the shell components
+ * don't pull in a utility surface that doesn't exist in the OpenTUI port.
+ *
+ * - `formatDuration`: same semantics as the upstream `utils/format.ts`
+ *   helper — produces `0.4s`, `12s`, `3m 5s`, `1h 2m`, etc.
+ * - `formatFileSize`: short byte count like `128B`, `4.2KB`, `1.8MB`.
+ * - `stripAnsi`: minimal ANSI escape stripper for terminal output we
+ *   want to render as plain text (OpenTUI `<text>` does not interpret
+ *   ANSI control sequences).
+ */
+
+export interface FormatDurationOptions {
+  /** Drop trailing `0s`/`0m` segments from compound outputs. */
+  hideTrailingZeros?: boolean
+}
+
+export function formatDuration(
+  ms: number,
+  options: FormatDurationOptions = {},
+): string {
+  if (!Number.isFinite(ms) || ms < 0) {
+    return '0s'
+  }
+
+  const { hideTrailingZeros = false } = options
+
+  if (ms < 1000) {
+    return `${(ms / 1000).toFixed(1)}s`
+  }
+
+  const totalSeconds = Math.floor(ms / 1000)
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`
+  }
+
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  if (minutes < 60) {
+    if (hideTrailingZeros && seconds === 0) {
+      return `${minutes}m`
+    }
+    return `${minutes}m ${seconds}s`
+  }
+
+  const hours = Math.floor(minutes / 60)
+  const remMinutes = minutes % 60
+  if (hideTrailingZeros && remMinutes === 0) {
+    return `${hours}h`
+  }
+  return `${hours}h ${remMinutes}m`
+}
+
+export function formatFileSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) {
+    return '0B'
+  }
+  if (bytes < 1024) {
+    return `${bytes}B`
+  }
+  const kb = bytes / 1024
+  if (kb < 1024) {
+    return `${kb < 10 ? kb.toFixed(1) : Math.round(kb)}KB`
+  }
+  const mb = kb / 1024
+  if (mb < 1024) {
+    return `${mb < 10 ? mb.toFixed(1) : Math.round(mb)}MB`
+  }
+  const gb = mb / 1024
+  return `${gb < 10 ? gb.toFixed(1) : Math.round(gb)}GB`
+}
+
+// eslint-disable-next-line no-control-regex
+const ANSI_PATTERN = /\u001b\[[0-9;?]*[A-Za-z]|\u001b\]([^\u0007\u001b]*)(?:\u0007|\u001b\\)/g
+
+/**
+ * Strip CSI/OSC ANSI escape sequences from `value` so the result can be
+ * rendered by plain OpenTUI `<text>` nodes.
+ */
+export function stripAnsi(value: string): string {
+  return value.replace(ANSI_PATTERN, '')
+}

--- a/ui/src/components/shell/index.ts
+++ b/ui/src/components/shell/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Barrel for shell output UI components.
+ *
+ * Mirrors the upstream `ui/examples/upstream-patterns/src/components/shell/`
+ * layout:
+ *   - `ExpandShellOutputContext` — context flag for full vs truncated output
+ *   - `OutputLine`               — JSON-aware, ANSI-stripped output renderer
+ *   - `ShellProgressMessage`     — running/completed shell tail view
+ *   - `ShellTimeDisplay`         — elapsed/timeout annotation
+ */
+
+export {
+  ExpandShellOutputProvider,
+  useExpandShellOutput,
+} from './ExpandShellOutputContext.js'
+export { OutputLine, tryFormatJson, tryJsonFormatContent } from './OutputLine.js'
+export { ShellProgressMessage } from './ShellProgressMessage.js'
+export { ShellTimeDisplay } from './ShellTimeDisplay.js'
+export { formatDuration, formatFileSize, stripAnsi } from './format.js'

--- a/ui/src/ipc/protocol.ts
+++ b/ui/src/ipc/protocol.ts
@@ -501,6 +501,22 @@ export type BackendMessage =
        */
       content_blocks?: ToolResultContentInfo[]
     }
+  /**
+   * Intermediate progress report for a long-running tool (typically Bash).
+   * Mirrors Rust `BackendMessage::ToolProgress`. Used by the shell UI to
+   * drive `ShellProgressMessage` — `output` is the tail-capped snapshot,
+   * `total_lines` / `total_bytes` are whole-stream counters.
+   */
+  | {
+      type: 'tool_progress'
+      tool_use_id: string
+      tool: string
+      output: string
+      elapsed_seconds: number
+      total_lines?: number
+      total_bytes?: number
+      timeout_ms?: number
+    }
   | { type: 'permission_request'; tool_use_id: string; tool: string; command: string; options: string[] }
   | { type: 'question_request'; id: string; text: string }
   | { type: 'system_info'; text: string; level: string }

--- a/ui/src/store/app-state.ts
+++ b/ui/src/store/app-state.ts
@@ -37,6 +37,30 @@ export interface BackgroundAgent {
   durationMs?: number
 }
 
+/**
+ * Live-shell progress state for a Bash tool invocation. Populated by the
+ * `tool_progress` IPC event the Rust backend emits while a `BashTool`
+ * runs — see `crates/claude-code-rs/src/tools/exec/bash.rs`. Used by the
+ * `ShellProgressMessage` component to render a "Running… (12s)" tail
+ * view while the command is in-flight and the final output preview once
+ * it finishes.
+ */
+export interface ShellProgressState {
+  toolUseId: string
+  tool: string
+  /** Most-recent tail-capped output snapshot. */
+  output: string
+  /** Accumulated full output (what the UI shows in verbose mode). */
+  fullOutput: string
+  elapsedSeconds: number
+  totalLines?: number
+  totalBytes?: number
+  timeoutMs?: number
+  /** `true` once the corresponding `tool_result` arrives. */
+  completed: boolean
+  updatedAt: number
+}
+
 export interface PendingQuestion {
   id: string
   text: string
@@ -139,6 +163,7 @@ export interface AppState {
   vimMode: string
   keybindingConfig: KeybindingConfig | null
   backgroundAgents: BackgroundAgent[]
+  shellProgress: Record<string, ShellProgressState>
   queuedSubmissions: QueuedSubmission[]
   viewMode: ViewMode
   agentTree: AgentNode[]
@@ -171,6 +196,7 @@ export const initialState: AppState = {
   vimMode: 'NORMAL',
   keybindingConfig: null,
   backgroundAgents: [],
+  shellProgress: {},
   queuedSubmissions: [],
   viewMode: 'prompt',
   agentTree: [],
@@ -229,6 +255,16 @@ export type CoreAction =
 export type ToolActivityAction =
   | { type: 'TOOL_USE'; id: string; name: string; input: any }
   | { type: 'TOOL_RESULT'; toolUseId: string; output: string; isError: boolean }
+  | {
+      type: 'TOOL_PROGRESS'
+      toolUseId: string
+      tool: string
+      output: string
+      elapsedSeconds: number
+      totalLines?: number
+      totalBytes?: number
+      timeoutMs?: number
+    }
 
 export type BackgroundAgentAction =
   | { type: 'BG_AGENT_STARTED'; agentId: string; description: string }

--- a/ui/src/store/app-store.tsx
+++ b/ui/src/store/app-store.tsx
@@ -22,6 +22,7 @@ export type {
   PendingQuestion,
   PermissionRequest,
   QueuedSubmission,
+  ShellProgressState,
   SubsystemState,
   TeamState,
   Usage,
@@ -51,6 +52,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
 
     case 'TOOL_USE':
     case 'TOOL_RESULT':
+    case 'TOOL_PROGRESS':
       return reduceToolActivity(state, action)
 
     case 'BG_AGENT_STARTED':

--- a/ui/src/store/reducers/tool-activity.ts
+++ b/ui/src/store/reducers/tool-activity.ts
@@ -1,4 +1,4 @@
-import type { AppState, ToolActivityAction } from '../app-state.js'
+import type { AppState, ShellProgressState, ToolActivityAction } from '../app-state.js'
 
 export function reduceToolActivity(state: AppState, action: ToolActivityAction): AppState {
   switch (action.type) {
@@ -16,17 +16,62 @@ export function reduceToolActivity(state: AppState, action: ToolActivityAction):
         }],
       }
 
-    case 'TOOL_RESULT':
+    case 'TOOL_RESULT': {
+      const nextMessages = [...state.messages, {
+        id: `result-${action.toolUseId}-${Date.now()}`,
+        role: 'tool_result' as const,
+        content: action.output,
+        timestamp: Date.now(),
+        toolUseId: action.toolUseId,
+        isError: action.isError,
+      }]
+
+      const existingProgress = state.shellProgress[action.toolUseId]
+      if (!existingProgress) {
+        return { ...state, messages: nextMessages }
+      }
+      // Mark the progress entry as completed so the UI can swap the
+      // live tail for the final result summary without losing the
+      // "Running → Done" transition.
       return {
         ...state,
-        messages: [...state.messages, {
-          id: `result-${action.toolUseId}-${Date.now()}`,
-          role: 'tool_result',
-          content: action.output,
-          timestamp: Date.now(),
-          toolUseId: action.toolUseId,
-          isError: action.isError,
-        }],
+        messages: nextMessages,
+        shellProgress: {
+          ...state.shellProgress,
+          [action.toolUseId]: { ...existingProgress, completed: true, updatedAt: Date.now() },
+        },
       }
+    }
+
+    case 'TOOL_PROGRESS': {
+      const existing = state.shellProgress[action.toolUseId]
+      const fullOutput = existing ? mergeFullOutput(existing.fullOutput, action.output) : action.output
+      const next: ShellProgressState = {
+        toolUseId: action.toolUseId,
+        tool: action.tool,
+        output: action.output,
+        fullOutput,
+        elapsedSeconds: action.elapsedSeconds,
+        totalLines: action.totalLines,
+        totalBytes: action.totalBytes,
+        timeoutMs: action.timeoutMs,
+        completed: false,
+        updatedAt: Date.now(),
+      }
+      return {
+        ...state,
+        shellProgress: { ...state.shellProgress, [action.toolUseId]: next },
+      }
+    }
   }
+}
+
+/**
+ * The backend's `output` is already a tail-capped snapshot. Each tick
+ * replaces the snapshot rather than appending, but we keep the longest
+ * observed version as `fullOutput` so verbose mode retains earlier
+ * content when the backend starts truncating newer ticks.
+ */
+function mergeFullOutput(previous: string, next: string): string {
+  return next.length >= previous.length ? next : previous
 }


### PR DESCRIPTION
## Summary

- Port [ui/examples/upstream-patterns/src/components/shell/](ui/examples/upstream-patterns/src/components/shell/) into the active `ui/src/components/shell/` tree (`ExpandShellOutputContext`, `OutputLine`, `ShellProgressMessage`, `ShellTimeDisplay`, shared `format.ts`).
- Add a new `BackendMessage::ToolProgress` IPC event and plumb an `on_progress` callback through `QueryDeps` → `execute_tool_calls` → `Tool::call`; the engine deps wrapper stamps the current `tool_use_id` onto every progress event.
- Rewrite `BashTool::call` to `spawn()` the child, stream stdout/stderr into shared buffers, fire progress ticks on a 1s cadence plus a final tick after exit (preserving sandbox wrapping, timeout handling, and truncation).
- Frontend stores per-`tool_use_id` `ShellProgressState` and `ToolActivityMessage` renders `ShellProgressMessage` (tail view in prompt mode, full verbose view in transcript mode) whenever a Bash activity has matching progress.

## Why

The upstream shell UI shows a live "Running… (Xs)" indicator with a tail of recent output while a Bash command runs; cc-rust previously had no progress channel and showed nothing until the command finished. This brings the OpenTUI port in line with upstream behaviour (per the full-build mandate in `CLAUDE.md`) without changing tool contracts or permission semantics.

## Reviewer notes

- `ToolProgress` is emitted as a `BackendMessage::ToolProgress`; the frontend consumes it via a new `TOOL_PROGRESS` action in `reduceToolActivity` and keeps the progress entry alive past `TOOL_RESULT` (marking `completed: true`) so the "Running → Done" transition is visible.
- Bash streaming uses `tokio::io::BufReader::lines()` on piped stdout/stderr; `kill_on_drop(true)` + explicit `start_kill()` on timeout keeps runaway children from lingering.
- The progress callback is wrapped at the `QueryEngineDeps` layer so tools never need to know their own `tool_use_id` — they emit `tool_use_id: String::new()` and the deps layer fills it in.
- Test doubles in `query/loop_tests.rs` are unaffected because `QueryDeps::tool_progress_callback()` has a default `None` impl.
- Verified with `cargo check --workspace` (clean except for 2 pre-existing `dead_code` warnings in `web/handlers.rs`) and `bun build --no-bundle` on each new/modified TS file.

## Test plan

- [ ] Run a long Bash command (e.g. `sleep 3 && echo ok`) via the tool and confirm the UI shows the "Running… (Xs)" indicator that updates each second and switches to the final output on exit.
- [ ] Run a command that produces >5 lines of output and confirm the tail shows the last 5 plus a `+N lines` hint.
- [ ] Run a command that times out and confirm the UI receives a final progress tick and the tool result still reports `Command timed out after Xms`.
- [ ] Toggle transcript view while a Bash command is running and confirm `ShellProgressMessage` switches to the verbose full-output mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)