### PR TITLE
feat(ui): port 20 upstream components into OpenTUI Lite

### DIFF
--- a/ui/src/components/InterruptedByUser.tsx
+++ b/ui/src/components/InterruptedByUser.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { c } from '../theme.js'
+
+/**
+ * OpenTUI port of the upstream `InterruptedByUser`
+ * (`ui/examples/upstream-patterns/src/components/InterruptedByUser.tsx`).
+ *
+ * Upstream branches on `process.env.USER_TYPE === 'ant'` for an internal
+ * `/issue` hint; cc-rust has no internal-user channel so we keep only the
+ * public variant.
+ */
+export function InterruptedByUser() {
+  return (
+    <text fg={c.dim}>
+      Interrupted <span>·</span> What should Claude do instead?
+    </text>
+  )
+}

--- a/ui/src/components/InvalidConfigDialog.tsx
+++ b/ui/src/components/InvalidConfigDialog.tsx
@@ -1,0 +1,102 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../theme.js'
+
+/**
+ * OpenTUI port of upstream `InvalidConfigDialog`
+ * (`ui/examples/upstream-patterns/src/components/InvalidConfigDialog.tsx`).
+ *
+ * Shown when the main config file contains invalid JSON. Upstream uses
+ * Ink's `Dialog` and kicks off its own `render()` at startup before the
+ * normal app boot. Lite does not bootstrap interactive dialogs from the
+ * frontend's own entry; instead this component is meant to be displayed
+ * inside the app when the backend surfaces a parse error (via a future
+ * `config_error` IPC event). The component exposes `onExit` and
+ * `onReset` callbacks so the parent can wire up the actual file-write +
+ * shutdown behaviour.
+ */
+
+type Props = {
+  filePath: string
+  errorDescription: string
+  onExit: () => void
+  onReset: () => void
+}
+
+type Option = { value: 'exit' | 'reset'; label: string }
+
+const OPTIONS: Option[] = [
+  { value: 'exit', label: 'Exit and fix manually' },
+  { value: 'reset', label: 'Reset with default configuration' },
+]
+
+export function InvalidConfigDialog({
+  filePath,
+  errorDescription,
+  onExit,
+  onReset,
+}: Props) {
+  const [index, setIndex] = useState(0)
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    switch (event.name) {
+      case 'up':
+        setIndex(i => (i - 1 + OPTIONS.length) % OPTIONS.length)
+        return
+      case 'down':
+      case 'tab':
+        setIndex(i => (i + 1) % OPTIONS.length)
+        return
+      case 'escape':
+        onExit()
+        return
+      case 'return':
+      case 'enter': {
+        const opt = OPTIONS[index]
+        if (!opt) return
+        if (opt.value === 'exit') onExit()
+        else onReset()
+      }
+    }
+  })
+
+  return (
+    <box
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.error}
+      paddingX={2}
+      paddingY={1}
+      title="Configuration Error"
+      titleAlignment="center"
+    >
+      <box flexDirection="column">
+        <text>
+          The configuration file at <strong>{filePath}</strong> contains invalid JSON.
+        </text>
+        <box marginTop={1}>
+          <text fg={c.error}>{errorDescription}</text>
+        </box>
+      </box>
+      <box flexDirection="column" marginTop={1}>
+        <text>
+          <strong>Choose an option:</strong>
+        </text>
+        <box flexDirection="column" marginTop={1}>
+          {OPTIONS.map((opt, i) => {
+            const selected = i === index
+            return (
+              <text key={opt.value}>
+                <span fg={selected ? c.accent : c.dim}>
+                  {selected ? '\u25B8 ' : '  '}
+                </span>
+                <span fg={selected ? c.textBright : c.text}>{opt.label}</span>
+              </text>
+            )
+          })}
+        </box>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/InvalidSettingsDialog.tsx
+++ b/ui/src/components/InvalidSettingsDialog.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../theme.js'
+import {
+  ValidationErrorsList,
+  type ValidationError,
+} from './ValidationErrorsList.js'
+
+/**
+ * OpenTUI port of upstream `InvalidSettingsDialog`
+ * (`ui/examples/upstream-patterns/src/components/InvalidSettingsDialog.tsx`).
+ *
+ * Shown at startup when settings files fail validation. User picks
+ * between "continue without these settings" and "exit and fix". Upstream
+ * reaches for Ink's `Dialog` + `Select`; Lite composes the same shape
+ * from OpenTUI primitives and an inline arrow-key picker (same pattern
+ * as `agent-settings/wizard/Select.tsx`).
+ */
+
+type Props = {
+  settingsErrors: ValidationError[]
+  onContinue: () => void
+  onExit: () => void
+}
+
+type Option = { value: 'continue' | 'exit'; label: string }
+
+const OPTIONS: Option[] = [
+  { value: 'exit', label: 'Exit and fix manually' },
+  { value: 'continue', label: 'Continue without these settings' },
+]
+
+export function InvalidSettingsDialog({ settingsErrors, onContinue, onExit }: Props) {
+  const [index, setIndex] = useState(0)
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    switch (event.name) {
+      case 'up':
+        setIndex(i => (i - 1 + OPTIONS.length) % OPTIONS.length)
+        return
+      case 'down':
+      case 'tab':
+        setIndex(i => (i + 1) % OPTIONS.length)
+        return
+      case 'escape':
+        onExit()
+        return
+      case 'return':
+      case 'enter': {
+        const opt = OPTIONS[index]
+        if (!opt) return
+        if (opt.value === 'exit') onExit()
+        else onContinue()
+      }
+    }
+  })
+
+  return (
+    <box
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.warning}
+      paddingX={2}
+      paddingY={1}
+      title="Settings Error"
+      titleAlignment="center"
+    >
+      <ValidationErrorsList errors={settingsErrors} />
+      <box marginTop={1}>
+        <text fg={c.dim}>
+          Files with errors are skipped entirely, not just the invalid settings.
+        </text>
+      </box>
+      <box flexDirection="column" marginTop={1}>
+        {OPTIONS.map((opt, i) => {
+          const selected = i === index
+          return (
+            <text key={opt.value}>
+              <span fg={selected ? c.accent : c.dim}>
+                {selected ? '\u25B8 ' : '  '}
+              </span>
+              <span fg={selected ? c.textBright : c.text}>{opt.label}</span>
+            </text>
+          )
+        })}
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/KeybindingWarnings.tsx
+++ b/ui/src/components/KeybindingWarnings.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import { c } from '../theme.js'
+
+/**
+ * OpenTUI port of upstream `KeybindingWarnings`
+ * (`ui/examples/upstream-patterns/src/components/KeybindingWarnings.tsx`).
+ *
+ * Upstream pulls the cached validation list from
+ * `utils/keybindings/loadUserBindings.ts` on the Node side. In cc-rust
+ * the keybinding config is loaded by the Rust backend and streamed to
+ * the frontend through the IPC `ready` event (`keybindings` field). When
+ * the backend later forwards parse / validation warnings via a
+ * dedicated event we can hook them in here — until then this component
+ * accepts an explicit `warnings` prop so callers (e.g. a future
+ * settings view) can feed it directly.
+ */
+
+export type KeybindingWarning = {
+  severity: 'error' | 'warning'
+  message: string
+  suggestion?: string
+}
+
+type Props = {
+  warnings: KeybindingWarning[]
+  path?: string
+}
+
+export function KeybindingWarnings({ warnings, path }: Props) {
+  if (warnings.length === 0) return null
+
+  const errors = warnings.filter(w => w.severity === 'error')
+  const warns = warnings.filter(w => w.severity === 'warning')
+  const headerColor = errors.length > 0 ? c.error : c.warning
+
+  return (
+    <box flexDirection="column" marginTop={1} marginBottom={1}>
+      <text fg={headerColor}>
+        <strong>Keybinding Configuration Issues</strong>
+      </text>
+      {path && (
+        <text fg={c.dim}>Location: {path}</text>
+      )}
+      <box marginLeft={1} flexDirection="column" marginTop={1}>
+        {errors.map((error, i) => (
+          <box key={`err-${i}`} flexDirection="column">
+            <text fg={c.dim}>
+              <span>{'\u2514 '}</span>
+              <span fg={c.error}>[Error]</span>
+              <span>{' '}{error.message}</span>
+            </text>
+            {error.suggestion && (
+              <box marginLeft={3}>
+                <text fg={c.dim}>{'\u2192 '}{error.suggestion}</text>
+              </box>
+            )}
+          </box>
+        ))}
+        {warns.map((warning, i) => (
+          <box key={`warn-${i}`} flexDirection="column">
+            <text fg={c.dim}>
+              <span>{'\u2514 '}</span>
+              <span fg={c.warning}>[Warning]</span>
+              <span>{' '}{warning.message}</span>
+            </text>
+            {warning.suggestion && (
+              <box marginLeft={3}>
+                <text fg={c.dim}>{'\u2192 '}{warning.suggestion}</text>
+              </box>
+            )}
+          </box>
+        ))}
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/LanguagePicker.tsx
+++ b/ui/src/components/LanguagePicker.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../theme.js'
+
+/**
+ * OpenTUI port of upstream `LanguagePicker`
+ * (`ui/examples/upstream-patterns/src/components/LanguagePicker.tsx`).
+ *
+ * Lets the user enter their preferred response / voice language. Upstream
+ * uses Ink's `TextInput`; here we drive a minimal single-line buffer with
+ * `useKeyboard` so the component works without any additional primitives.
+ * Enter confirms, Esc cancels, Backspace deletes the last character.
+ */
+
+type Props = {
+  initialLanguage?: string
+  onComplete: (language: string | undefined) => void
+  onCancel: () => void
+}
+
+export function LanguagePicker({ initialLanguage, onComplete, onCancel }: Props) {
+  const [value, setValue] = useState(initialLanguage ?? '')
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+
+    const name = event.name
+    const sequence = event.sequence
+
+    if (name === 'escape') {
+      onCancel()
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      const trimmed = value.trim()
+      onComplete(trimmed.length > 0 ? trimmed : undefined)
+      return
+    }
+    if (name === 'backspace') {
+      setValue(prev => prev.slice(0, -1))
+      return
+    }
+    if (
+      typeof sequence === 'string' &&
+      sequence.length === 1 &&
+      sequence >= ' ' &&
+      sequence !== '\x7f'
+    ) {
+      setValue(prev => prev + sequence)
+    }
+  })
+
+  const shown = value.length === 0
+    ? <span fg={c.dim}><em>e.g., Japanese, 日本語, Español…</em></span>
+    : <span>{value}</span>
+
+  return (
+    <box flexDirection="column" paddingX={1} paddingY={1}>
+      <text>Enter your preferred response and voice language:</text>
+      <box flexDirection="row" marginTop={1}>
+        <box flexShrink={0} minWidth={2}>
+          <text fg={c.accent}>{'\u276F '}</text>
+        </box>
+        <box flexGrow={1}>
+          <text>{shown}</text>
+        </box>
+      </box>
+      <box marginTop={1}>
+        <text fg={c.dim}>Enter to confirm · Esc to cancel · empty for default (English)</text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/LogSelector.tsx
+++ b/ui/src/components/LogSelector.tsx
@@ -1,0 +1,224 @@
+import React, { useMemo, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../theme.js'
+
+/**
+ * OpenTUI port of upstream `LogSelector`
+ * (`ui/examples/upstream-patterns/src/components/LogSelector.tsx`).
+ *
+ * Upstream is a 1.4K-line screen that powers `claude --resume`:
+ * lists prior sessions, supports fuse.js search + agentic "search with
+ * Claude", branch / worktree / project-scope filtering, fork grouping,
+ * inline rename, and a preview pane that reuses `SessionPreview`. Most
+ * of that machinery relies on Node-side helpers
+ * (`utils/getWorktreePaths`, `utils/sessionStorage`, analytics) and
+ * IPC commands the Lite backend does not expose today (list sessions,
+ * rename, agentic search).
+ *
+ * This re-host keeps upstream's `onSelect` / `onCancel` / `logs`
+ * contract but narrows the UI to what the current backend supports: a
+ * filterable list with search, keyboard navigation, and a selection
+ * callback. Callers receive the full `LogOption` they handed in so they
+ * can dispatch whatever resume command fits their IPC surface.
+ *
+ * Fields like `onAgenticSearch`, `onToggleAllProjects`, branch filter,
+ * inline rename, and the fork tree stay on the prop surface (typed as
+ * optional) so upstream callers compile — they're just inert until
+ * the corresponding backend commands land.
+ */
+
+export type LogOption = {
+  /** Unique identifier — typically the session id. */
+  id: string
+  /** Human-readable summary shown in the list. */
+  summary: string
+  /** Optional dimmed metadata shown on a second line (timestamp, token
+   *  counts, etc.). */
+  metadata?: string
+  /** Optional project-scope label for multi-project views. */
+  projectPath?: string
+  /** Optional marker for sidechain sessions (mirrors upstream). */
+  isSidechain?: boolean
+  /** Optional user tags. */
+  tags?: string[]
+}
+
+export type LogSelectorProps = {
+  logs: LogOption[]
+  maxHeight?: number
+  forceWidth?: number
+  onCancel?: () => void
+  onSelect: (log: LogOption) => void
+  onLogsChanged?: () => void
+  onLoadMore?: (count: number) => void
+  initialSearchQuery?: string
+  showAllProjects?: boolean
+  onToggleAllProjects?: () => void
+  onAgenticSearch?: (
+    query: string,
+    logs: LogOption[],
+    signal?: AbortSignal,
+  ) => Promise<LogOption[]>
+}
+
+const VISIBLE_ROWS_DEFAULT = 12
+
+function matchesQuery(log: LogOption, query: string): boolean {
+  if (!query) return true
+  const q = query.toLowerCase()
+  if (log.summary.toLowerCase().includes(q)) return true
+  if (log.metadata?.toLowerCase().includes(q)) return true
+  if (log.projectPath?.toLowerCase().includes(q)) return true
+  if (log.tags?.some(t => t.toLowerCase().includes(q))) return true
+  return false
+}
+
+export function LogSelector({
+  logs,
+  maxHeight = VISIBLE_ROWS_DEFAULT,
+  onCancel,
+  onSelect,
+  initialSearchQuery = '',
+  showAllProjects,
+  onToggleAllProjects,
+}: LogSelectorProps) {
+  const [query, setQuery] = useState(initialSearchQuery)
+  const [cursor, setCursor] = useState(0)
+
+  const filtered = useMemo(
+    () => logs.filter(log => matchesQuery(log, query)),
+    [logs, query],
+  )
+
+  const safeCursor = Math.max(0, Math.min(cursor, Math.max(filtered.length - 1, 0)))
+  const visible = Math.max(1, Math.min(maxHeight, filtered.length))
+  const firstVisible = Math.max(
+    0,
+    Math.min(safeCursor - Math.floor(visible / 2), filtered.length - visible),
+  )
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const seq = event.sequence
+
+    if (name === 'escape') {
+      onCancel?.()
+      return
+    }
+    if (name === 'up' && filtered.length > 0) {
+      setCursor(i => Math.max(0, i - 1))
+      return
+    }
+    if (name === 'down' && filtered.length > 0) {
+      setCursor(i => Math.min(filtered.length - 1, i + 1))
+      return
+    }
+    if (name === 'pageup' && filtered.length > 0) {
+      setCursor(i => Math.max(0, i - visible))
+      return
+    }
+    if (name === 'pagedown' && filtered.length > 0) {
+      setCursor(i => Math.min(filtered.length - 1, i + visible))
+      return
+    }
+    if (name === 'home') {
+      setCursor(0)
+      return
+    }
+    if (name === 'end') {
+      setCursor(Math.max(0, filtered.length - 1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      const log = filtered[safeCursor]
+      if (log) onSelect(log)
+      return
+    }
+    if (name === 'backspace') {
+      setQuery(q => q.slice(0, -1))
+      setCursor(0)
+      return
+    }
+    if (event.ctrl && (name === 'p' || seq === '\x10')) {
+      onToggleAllProjects?.()
+      return
+    }
+    if (typeof seq === 'string' && seq.length === 1 && seq >= ' ' && seq !== '\x7f') {
+      setQuery(q => q + seq)
+      setCursor(0)
+    }
+  })
+
+  const rows = filtered.slice(firstVisible, firstVisible + visible)
+
+  return (
+    <box
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.accent}
+      paddingX={2}
+      paddingY={1}
+      title="Resume session"
+      titleAlignment="center"
+    >
+      <box flexDirection="row">
+        <text fg={c.dim}>Search: </text>
+        <text fg={c.text}>{query || <em><span fg={c.dim}>type to filter</span></em>}</text>
+      </box>
+      {onToggleAllProjects && (
+        <box marginTop={1}>
+          <text fg={c.dim}>
+            <em>
+              Ctrl+P to {showAllProjects ? 'hide' : 'show'} all projects
+            </em>
+          </text>
+        </box>
+      )}
+
+      {filtered.length === 0 ? (
+        <box marginTop={1}>
+          <text fg={c.dim}>No matching sessions.</text>
+        </box>
+      ) : (
+        <box flexDirection="column" marginTop={1}>
+          {rows.map((log, i) => {
+            const idx = firstVisible + i
+            const isFocused = idx === safeCursor
+            return (
+              <box key={log.id} flexDirection="column" height={log.metadata ? 2 : 1}>
+                <text>
+                  <span fg={isFocused ? c.accent : c.dim}>
+                    {isFocused ? '\u25B8 ' : '  '}
+                  </span>
+                  <span fg={isFocused ? c.textBright : c.text}>{log.summary}</span>
+                  {log.isSidechain && (
+                    <span fg={c.dim}> (sidechain)</span>
+                  )}
+                </text>
+                {log.metadata && (
+                  <text>
+                    <span fg={c.dim}>{'    '}{log.metadata}</span>
+                    {log.projectPath && (
+                      <span fg={c.dim}>{` · ${log.projectPath}`}</span>
+                    )}
+                  </text>
+                )}
+              </box>
+            )
+          })}
+        </box>
+      )}
+
+      <box marginTop={1}>
+        <text fg={c.dim}>
+          <em>
+            {filtered.length > 0
+              ? `${safeCursor + 1} / ${filtered.length} · Enter open · Esc close`
+              : 'Esc close'}
+          </em>
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/MCPServerApprovalDialog.tsx
+++ b/ui/src/components/MCPServerApprovalDialog.tsx
@@ -1,0 +1,115 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { useBackend } from '../ipc/context.js'
+import { c } from '../theme.js'
+import { MCPServerDialogCopy } from './MCPServerDialogCopy.js'
+
+/**
+ * OpenTUI port of upstream `MCPServerApprovalDialog`
+ * (`ui/examples/upstream-patterns/src/components/MCPServerApprovalDialog.tsx`).
+ *
+ * Prompt shown the first time a new `.mcp.json` server is discovered.
+ * Choices drive the backend `toggle_enabled` command so the server's
+ * `disabled` flag lands on disk at project scope.
+ *
+ * Upstream persists `enabledMcpjsonServers` / `disabledMcpjsonServers`
+ * lists in settings; cc-rust folds both states into the per-entry
+ * `disabled` bit, so we map:
+ *  - `yes` / `yes_all` → enable this server (clear `disabled`).
+ *  - `no`              → disable this server.
+ *  - `yes_all`         → emits a follow-up `enable_all_project_mcp`
+ *    hint via `onAutoApproveAll` so the caller can persist that
+ *    preference once the backend grows a dedicated command.
+ */
+
+type Choice = 'yes_all' | 'yes' | 'no'
+
+type Props = {
+  serverName: string
+  onDone: () => void
+  onAutoApproveAll?: () => void
+}
+
+const OPTIONS: Array<{ value: Choice; label: string }> = [
+  { value: 'yes_all', label: 'Use this and all future MCP servers in this project' },
+  { value: 'yes', label: 'Use this MCP server' },
+  { value: 'no', label: 'Continue without using this MCP server' },
+]
+
+export function MCPServerApprovalDialog({
+  serverName,
+  onDone,
+  onAutoApproveAll,
+}: Props) {
+  const backend = useBackend()
+  const [index, setIndex] = useState(0)
+
+  const commit = (choice: Choice) => {
+    if (choice === 'yes' || choice === 'yes_all') {
+      backend.send({
+        type: 'mcp_command',
+        command: { kind: 'toggle_enabled', server_name: serverName },
+      })
+      if (choice === 'yes_all') {
+        onAutoApproveAll?.()
+      }
+    }
+    // `no` deliberately sends nothing — entries default to `disabled: false`
+    // only once explicitly approved. Upstream also tracks an explicit
+    // deny list; when the backend exposes one we can surface it here.
+    onDone()
+  }
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    switch (event.name) {
+      case 'up':
+        setIndex(i => (i - 1 + OPTIONS.length) % OPTIONS.length)
+        return
+      case 'down':
+      case 'tab':
+        setIndex(i => (i + 1) % OPTIONS.length)
+        return
+      case 'escape':
+        commit('no')
+        return
+      case 'return':
+      case 'enter': {
+        const opt = OPTIONS[index]
+        if (opt) commit(opt.value)
+      }
+    }
+  })
+
+  return (
+    <box
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.warning}
+      paddingX={2}
+      paddingY={1}
+      title={`New MCP server found in .mcp.json: ${serverName}`}
+      titleAlignment="center"
+    >
+      <MCPServerDialogCopy />
+      <box flexDirection="column" marginTop={1}>
+        {OPTIONS.map((opt, i) => {
+          const selected = i === index
+          return (
+            <text key={opt.value}>
+              <span fg={selected ? c.accent : c.dim}>
+                {selected ? '\u25B8 ' : '  '}
+              </span>
+              <span fg={selected ? c.textBright : c.text}>{opt.label}</span>
+            </text>
+          )
+        })}
+      </box>
+      <box marginTop={1}>
+        <text fg={c.dim}>
+          <em>↑↓ navigate · Enter confirm · Esc reject</em>
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/MCPServerDesktopImportDialog.tsx
+++ b/ui/src/components/MCPServerDesktopImportDialog.tsx
@@ -1,0 +1,186 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { useBackend } from '../ipc/context.js'
+import { useAppState } from '../store/app-store.js'
+import type {
+  ConfigScope,
+  McpServerConfigEntry,
+} from '../ipc/protocol.js'
+import { c } from '../theme.js'
+
+/**
+ * OpenTUI port of upstream `MCPServerDesktopImportDialog`
+ * (`ui/examples/upstream-patterns/src/components/MCPServerDesktopImportDialog.tsx`).
+ *
+ * Imports a set of MCP server definitions (typically the user's Claude
+ * Desktop config) into the selected scope. Upstream collects the
+ * existing server list up-front with `getAllMcpConfigs()`; Lite reads
+ * the already-mirrored `mcpSettings.entries` slice from the store and
+ * issues one `upsert_config` IPC command per accepted entry.
+ *
+ * Collision handling mirrors upstream: reuse the same name when the
+ * entry does not already exist, otherwise append `_1`, `_2`, … until the
+ * name is free. Pre-selection excludes collisions so the default Enter
+ * press is safe.
+ */
+
+type Props = {
+  /** New servers to offer for import. Record of name → entry (scope is
+   *  assigned fresh from `scope` below when we upsert). */
+  servers: Record<string, Omit<McpServerConfigEntry, 'name' | 'scope'> & Partial<Pick<McpServerConfigEntry, 'scope'>>>
+  scope: ConfigScope
+  onDone: () => void
+}
+
+function nextFreeName(base: string, existing: Set<string>): string {
+  if (!existing.has(base)) return base
+  let counter = 1
+  while (existing.has(`${base}_${counter}`)) counter++
+  return `${base}_${counter}`
+}
+
+export function MCPServerDesktopImportDialog({ servers, scope, onDone }: Props) {
+  const backend = useBackend()
+  const state = useAppState()
+  const existingEntries = state.mcpSettings.entries
+  const existingNames = useMemo(
+    () => new Set<string>(existingEntries.map(entry => entry.name)),
+    [existingEntries],
+  )
+
+  const serverNames = useMemo(() => Object.keys(servers), [servers])
+  const collisions = useMemo(
+    () => new Set<string>(serverNames.filter(name => existingNames.has(name))),
+    [existingNames, serverNames],
+  )
+
+  const [selected, setSelected] = useState<Set<string>>(() => {
+    const initial = new Set<string>()
+    for (const name of serverNames) {
+      if (!collisions.has(name)) initial.add(name)
+    }
+    return initial
+  })
+  const [cursor, setCursor] = useState(0)
+
+  useEffect(() => {
+    // Refresh config list so `existingNames` is authoritative.
+    backend.send({ type: 'mcp_command', command: { kind: 'query_config' } })
+  }, [backend])
+
+  const toggle = (name: string) => {
+    setSelected(prev => {
+      const next = new Set(prev)
+      if (next.has(name)) next.delete(name)
+      else next.add(name)
+      return next
+    })
+  }
+
+  const submit = () => {
+    const taken = new Set(existingNames)
+    for (const name of serverNames) {
+      if (!selected.has(name)) continue
+      const raw = servers[name]
+      if (!raw) continue
+      const finalName = nextFreeName(name, taken)
+      taken.add(finalName)
+      const entry: McpServerConfigEntry = {
+        ...raw,
+        name: finalName,
+        transport: raw.transport,
+        scope,
+      }
+      backend.send({
+        type: 'mcp_command',
+        command: { kind: 'upsert_config', entry },
+      })
+    }
+    onDone()
+  }
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    switch (event.name) {
+      case 'up':
+        setCursor(i => (i - 1 + serverNames.length) % serverNames.length)
+        return
+      case 'down':
+      case 'tab':
+        setCursor(i => (i + 1) % serverNames.length)
+        return
+      case 'space': {
+        const name = serverNames[cursor]
+        if (name) toggle(name)
+        return
+      }
+      case 'escape':
+        onDone()
+        return
+      case 'return':
+      case 'enter':
+        submit()
+        return
+    }
+  })
+
+  if (serverNames.length === 0) {
+    return (
+      <box borderStyle="rounded" borderColor={c.dim} padding={1}>
+        <text>No MCP servers to import.</text>
+      </box>
+    )
+  }
+
+  return (
+    <box
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.success}
+      paddingX={2}
+      paddingY={1}
+      title="Import MCP Servers from Claude Desktop"
+      titleAlignment="center"
+    >
+      <text fg={c.dim}>
+        Found {serverNames.length} MCP server{serverNames.length === 1 ? '' : 's'} in Claude Desktop.
+      </text>
+      {collisions.size > 0 && (
+        <box marginTop={1}>
+          <text fg={c.warning}>
+            Note: Some servers already exist with the same name. If selected, they will be imported with a numbered suffix.
+          </text>
+        </box>
+      )}
+      <box marginTop={1}>
+        <text>Please select the servers you want to import:</text>
+      </box>
+      <box flexDirection="column" marginTop={1}>
+        {serverNames.map((name, i) => {
+          const isSelected = selected.has(name)
+          const collides = collisions.has(name)
+          const atCursor = i === cursor
+          return (
+            <text key={name}>
+              <span fg={atCursor ? c.accent : c.dim}>
+                {atCursor ? '\u25B8 ' : '  '}
+              </span>
+              <span fg={isSelected ? c.success : c.dim}>
+                {isSelected ? '[\u2713] ' : '[ ] '}
+              </span>
+              <span fg={atCursor ? c.textBright : c.text}>{name}</span>
+              {collides && (
+                <span fg={c.warning}> (already exists)</span>
+              )}
+            </text>
+          )
+        })}
+      </box>
+      <box marginTop={1}>
+        <text fg={c.dim}>
+          <em>Space toggle · Enter import · Esc cancel</em>
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/MCPServerDialogCopy.tsx
+++ b/ui/src/components/MCPServerDialogCopy.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { c } from '../theme.js'
+
+/**
+ * Standard copy block shown above the MCP-server approval / multiselect
+ * dialogs. OpenTUI port of upstream's `MCPServerDialogCopy`
+ * (`ui/examples/upstream-patterns/src/components/MCPServerDialogCopy.tsx`).
+ *
+ * The upstream version embeds a clickable `<Link>` hyperlink; our OpenTUI
+ * primitive set currently has no link element, so we render the URL inline
+ * and dim it. When an OSC-8 hyperlink element lands in `@opentui/core` we
+ * can swap the `<span>` for a proper link.
+ */
+export function MCPServerDialogCopy() {
+  return (
+    <text>
+      MCP servers may execute code or access system resources. All tool calls
+      require approval. Learn more in the MCP documentation
+      {' '}
+      <span fg={c.dim}>(https://docs.claude.com/en/docs/claude-code/mcp)</span>.
+    </text>
+  )
+}

--- a/ui/src/components/MCPServerMultiselectDialog.tsx
+++ b/ui/src/components/MCPServerMultiselectDialog.tsx
@@ -1,0 +1,119 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { useBackend } from '../ipc/context.js'
+import { c } from '../theme.js'
+import { MCPServerDialogCopy } from './MCPServerDialogCopy.js'
+
+/**
+ * OpenTUI port of upstream `MCPServerMultiselectDialog`
+ * (`ui/examples/upstream-patterns/src/components/MCPServerMultiselectDialog.tsx`).
+ *
+ * Shown when several newly-seen `.mcp.json` servers arrive at once.
+ * Space toggles each server, Enter commits, Esc rejects all. For every
+ * approved server we issue a `toggle_enabled` IPC command to clear the
+ * per-entry `disabled` flag on the backend — same shape used by the
+ * `/mcp` panel's enable/disable button.
+ */
+
+type Props = {
+  serverNames: string[]
+  onDone: () => void
+}
+
+export function MCPServerMultiselectDialog({ serverNames, onDone }: Props) {
+  const backend = useBackend()
+  const [selected, setSelected] = useState<Set<string>>(() => new Set(serverNames))
+  const [cursor, setCursor] = useState(0)
+
+  const toggle = (name: string) => {
+    setSelected(prev => {
+      const next = new Set(prev)
+      if (next.has(name)) next.delete(name)
+      else next.add(name)
+      return next
+    })
+  }
+
+  const commit = () => {
+    for (const name of serverNames) {
+      if (selected.has(name)) {
+        backend.send({
+          type: 'mcp_command',
+          command: { kind: 'toggle_enabled', server_name: name },
+        })
+      }
+    }
+    onDone()
+  }
+
+  const rejectAll = () => {
+    // No backend round-trip today — entries default to disabled until
+    // explicitly enabled. When a structured "deny list" command lands we
+    // can forward each rejected name through it.
+    onDone()
+  }
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    switch (event.name) {
+      case 'up':
+        setCursor(i => (i - 1 + serverNames.length) % serverNames.length)
+        return
+      case 'down':
+      case 'tab':
+        setCursor(i => (i + 1) % serverNames.length)
+        return
+      case 'space': {
+        const name = serverNames[cursor]
+        if (name) toggle(name)
+        return
+      }
+      case 'escape':
+        rejectAll()
+        return
+      case 'return':
+      case 'enter':
+        commit()
+        return
+    }
+  })
+
+  return (
+    <box
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.warning}
+      paddingX={2}
+      paddingY={1}
+      title={`${serverNames.length} new MCP servers found in .mcp.json`}
+      titleAlignment="center"
+    >
+      <MCPServerDialogCopy />
+      <box marginTop={1}>
+        <text>Select any you wish to enable.</text>
+      </box>
+      <box flexDirection="column" marginTop={1}>
+        {serverNames.map((name, i) => {
+          const isSelected = selected.has(name)
+          const atCursor = i === cursor
+          return (
+            <text key={name}>
+              <span fg={atCursor ? c.accent : c.dim}>
+                {atCursor ? '\u25B8 ' : '  '}
+              </span>
+              <span fg={isSelected ? c.success : c.dim}>
+                {isSelected ? '[\u2713] ' : '[ ] '}
+              </span>
+              <span fg={atCursor ? c.textBright : c.text}>{name}</span>
+            </text>
+          )
+        })}
+      </box>
+      <box marginTop={1}>
+        <text fg={c.dim}>
+          <em>Space toggle · Enter confirm · Esc reject all</em>
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/Markdown.tsx
+++ b/ui/src/components/Markdown.tsx
@@ -1,0 +1,83 @@
+import React, { useRef } from 'react'
+import { c } from '../theme.js'
+
+/**
+ * OpenTUI port of upstream `Markdown` / `StreamingMarkdown`
+ * (`ui/examples/upstream-patterns/src/components/Markdown.tsx`).
+ *
+ * Upstream walks `marked.lexer(...)` tokens, formats them with
+ * `formatToken` into ANSI, and splices a React-rendered `MarkdownTable`
+ * between plain-text chunks. OpenTUI ships a `<markdown>` intrinsic that
+ * already handles headings, lists, links, inline code, code fences, and
+ * paragraphs. To avoid bundling `marked` on the frontend we lean on that
+ * primitive for the common case and keep the upstream component's public
+ * shape (`children` as the markdown source + optional `dimColor`).
+ *
+ * The module-level token cache, `stripPromptXMLTags`, and cli-highlight
+ * suspense-boundary trickery are skipped here because OpenTUI handles
+ * the rendering. If a future need arises (e.g. tables rendered
+ * differently, or a ctrl+o "expand" toggle) they can be re-introduced.
+ */
+
+type Props = {
+  children: string
+  /** When true, render the markdown with dim foreground color. */
+  dimColor?: boolean
+}
+
+function stripPromptXMLTags(input: string): string {
+  // Mirror of upstream's `stripPromptXMLTags` — strips any leading
+  // `<system-reminder>…</system-reminder>` wrappers so the markdown
+  // body renders without the transport envelope. Kept intentionally
+  // minimal — the full upstream helper strips several tag families we
+  // don't currently surface.
+  const CLOSE = '</system-reminder>'
+  let text = input.trimStart()
+  while (text.startsWith('<system-reminder>')) {
+    const end = text.indexOf(CLOSE)
+    if (end < 0) break
+    text = text.slice(end + CLOSE.length).trimStart()
+  }
+  return text
+}
+
+export function Markdown({ children, dimColor }: Props) {
+  const body = stripPromptXMLTags(children)
+  if (!body.trim()) return null
+
+  return (
+    <box flexDirection="column" width="100%">
+      <markdown
+        content={body}
+        bg={c.bg}
+        {...(dimColor ? { fg: c.dim } : {})}
+      />
+    </box>
+  )
+}
+
+/**
+ * Streaming variant — upstream splits at the last top-level block
+ * boundary so the stable prefix is memoized and never re-parsed. The
+ * OpenTUI `<markdown>` element diffs internally per frame, so we just
+ * forward the whole content. The monotonically-advancing ref is kept so
+ * external callers that rely on the `StreamingMarkdown` identity still
+ * receive the same interface.
+ */
+export function StreamingMarkdown({ children }: { children: string }) {
+  const stablePrefixRef = useRef('')
+  const stripped = stripPromptXMLTags(children)
+  if (!stripped.startsWith(stablePrefixRef.current)) {
+    stablePrefixRef.current = ''
+  }
+  const lastBlockIdx = stripped.lastIndexOf('\n\n')
+  if (lastBlockIdx > stablePrefixRef.current.length) {
+    stablePrefixRef.current = stripped.slice(0, lastBlockIdx)
+  }
+  if (!stripped.trim()) return null
+  return (
+    <box flexDirection="column" width="100%">
+      <markdown content={stripped} bg={c.bg} />
+    </box>
+  )
+}

--- a/ui/src/components/MarkdownTable.tsx
+++ b/ui/src/components/MarkdownTable.tsx
@@ -1,0 +1,286 @@
+import React from 'react'
+import { useTerminalDimensions } from '@opentui/react'
+import { c } from '../theme.js'
+
+/**
+ * OpenTUI port of upstream `MarkdownTable`
+ * (`ui/examples/upstream-patterns/src/components/MarkdownTable.tsx`).
+ *
+ * Upstream receives a `marked.Tokens.Table` token with pre-parsed header
+ * + rows and renders a fully-bordered table, switching to a vertical
+ * key-value layout for narrow widths. Lite does not import `marked`
+ * (see `./Markdown.tsx` for the rationale), so this component takes a
+ * plain `{ header: string[]; rows: string[][] }` shape and builds the
+ * same horizontal / vertical fallback using OpenTUI's `<box>` primitives
+ * for borders. The algorithm for column-width distribution follows
+ * upstream:
+ *  1. each column gets at least its longest-word width,
+ *  2. extra space is distributed proportionally to each column's ideal
+ *     width,
+ *  3. if the table still does not fit, fall back to vertical key/value
+ *     rendering.
+ */
+
+export type MarkdownTableToken = {
+  header: string[]
+  rows: string[][]
+  /** Optional per-column alignment — matches `Tokens.Table['align']`. */
+  align?: Array<'left' | 'center' | 'right' | null>
+}
+
+type Props = {
+  token: MarkdownTableToken
+  /** Override width (used by tests). */
+  forceWidth?: number
+}
+
+const MIN_COLUMN_WIDTH = 3
+const SAFETY_MARGIN = 4
+const MAX_ROW_LINES = 4
+
+function stringWidth(s: string): number {
+  // Simple code-point width. Upstream uses `stringWidth` from @anthropic/ink
+  // which handles East-Asian full-width glyphs; the Lite bundle does not
+  // carry that helper, so we approximate with code-point count. For plain
+  // ASCII (the common case) this matches exactly.
+  return [...s].length
+}
+
+function padAligned(text: string, width: number, align: 'left' | 'center' | 'right'): string {
+  const textWidth = stringWidth(text)
+  const pad = Math.max(0, width - textWidth)
+  if (pad === 0) return text
+  if (align === 'right') return ' '.repeat(pad) + text
+  if (align === 'center') {
+    const left = Math.floor(pad / 2)
+    return ' '.repeat(left) + text + ' '.repeat(pad - left)
+  }
+  return text + ' '.repeat(pad)
+}
+
+function wrapText(text: string, width: number, hard: boolean): string[] {
+  if (width <= 0) return [text]
+  const words = text.split(/\s+/).filter(Boolean)
+  const lines: string[] = []
+  let current = ''
+  for (const word of words) {
+    if (!current) {
+      if (stringWidth(word) <= width) {
+        current = word
+      } else if (hard) {
+        const chars = [...word]
+        while (chars.length > 0) {
+          lines.push(chars.splice(0, width).join(''))
+        }
+      } else {
+        lines.push(word)
+      }
+      continue
+    }
+    if (stringWidth(current) + 1 + stringWidth(word) <= width) {
+      current += ' ' + word
+    } else {
+      lines.push(current)
+      if (stringWidth(word) <= width) {
+        current = word
+      } else if (hard) {
+        const chars = [...word]
+        while (chars.length > 0) {
+          lines.push(chars.splice(0, width).join(''))
+        }
+        current = ''
+      } else {
+        current = word
+      }
+    }
+  }
+  if (current) lines.push(current)
+  return lines.length > 0 ? lines : ['']
+}
+
+function getMinWidth(text: string): number {
+  const words = text.split(/\s+/).filter(Boolean)
+  if (words.length === 0) return MIN_COLUMN_WIDTH
+  return Math.max(MIN_COLUMN_WIDTH, ...words.map(w => stringWidth(w)))
+}
+
+function getIdealWidth(text: string): number {
+  return Math.max(MIN_COLUMN_WIDTH, stringWidth(text))
+}
+
+export function MarkdownTable({ token, forceWidth }: Props) {
+  const { width: actualWidth } = useTerminalDimensions()
+  const terminalWidth = forceWidth ?? actualWidth
+
+  const numCols = token.header.length
+  if (numCols === 0) return null
+
+  const minWidths = token.header.map((header, col) => {
+    let max = getMinWidth(header)
+    for (const row of token.rows) {
+      max = Math.max(max, getMinWidth(row[col] ?? ''))
+    }
+    return max
+  })
+
+  const idealWidths = token.header.map((header, col) => {
+    let max = getIdealWidth(header)
+    for (const row of token.rows) {
+      max = Math.max(max, getIdealWidth(row[col] ?? ''))
+    }
+    return max
+  })
+
+  const borderOverhead = 1 + numCols * 3
+  const availableWidth = Math.max(
+    terminalWidth - borderOverhead - SAFETY_MARGIN,
+    numCols * MIN_COLUMN_WIDTH,
+  )
+  const totalMin = minWidths.reduce((a, b) => a + b, 0)
+  const totalIdeal = idealWidths.reduce((a, b) => a + b, 0)
+
+  let columnWidths: number[]
+  let needsHardWrap = false
+  if (totalIdeal <= availableWidth) {
+    columnWidths = idealWidths
+  } else if (totalMin <= availableWidth) {
+    const extra = availableWidth - totalMin
+    const overflow = idealWidths.map((ideal, i) => ideal - minWidths[i]!)
+    const overflowSum = overflow.reduce((a, b) => a + b, 0)
+    columnWidths = minWidths.map((min, i) => {
+      if (overflowSum === 0) return min
+      return min + Math.floor((overflow[i]! / overflowSum) * extra)
+    })
+  } else {
+    needsHardWrap = true
+    const scale = availableWidth / totalMin
+    columnWidths = minWidths.map(m => Math.max(MIN_COLUMN_WIDTH, Math.floor(m * scale)))
+  }
+
+  const rowLines = (cells: string[], isHeader: boolean) => {
+    const wrapped = cells.map((cell, col) =>
+      wrapText(cell, columnWidths[col]!, needsHardWrap),
+    )
+    const maxLines = Math.max(1, ...wrapped.map(lines => lines.length))
+    const offsets = wrapped.map(lines => Math.floor((maxLines - lines.length) / 2))
+    const output: string[] = []
+    for (let lineIdx = 0; lineIdx < maxLines; lineIdx++) {
+      let line = '\u2502'
+      for (let col = 0; col < cells.length; col++) {
+        const contentIdx = lineIdx - offsets[col]!
+        const lines = wrapped[col]!
+        const text = contentIdx >= 0 && contentIdx < lines.length ? lines[contentIdx]! : ''
+        const width = columnWidths[col]!
+        const align = isHeader ? 'center' : (token.align?.[col] ?? 'left') || 'left'
+        line += ' ' + padAligned(text, width, align) + ' \u2502'
+      }
+      output.push(line)
+    }
+    return output
+  }
+
+  const maxRowLines = (() => {
+    let max = 1
+    for (let col = 0; col < token.header.length; col++) {
+      max = Math.max(max, wrapText(token.header[col] ?? '', columnWidths[col]!, needsHardWrap).length)
+    }
+    for (const row of token.rows) {
+      for (let col = 0; col < row.length; col++) {
+        max = Math.max(max, wrapText(row[col] ?? '', columnWidths[col]!, needsHardWrap).length)
+      }
+    }
+    return max
+  })()
+
+  const useVertical = maxRowLines > MAX_ROW_LINES
+
+  if (useVertical) {
+    return <VerticalTable token={token} terminalWidth={terminalWidth} />
+  }
+
+  const border = (kind: 'top' | 'mid' | 'bot') => {
+    const parts: Record<'top' | 'mid' | 'bot', [string, string, string, string]> = {
+      top: ['\u250C', '\u2500', '\u252C', '\u2510'],
+      mid: ['\u251C', '\u2500', '\u253C', '\u2524'],
+      bot: ['\u2514', '\u2500', '\u2534', '\u2518'],
+    }
+    const [left, mid, cross, right] = parts[kind]
+    let line = left
+    columnWidths.forEach((w, i) => {
+      line += mid.repeat(w + 2)
+      line += i < columnWidths.length - 1 ? cross : right
+    })
+    return line
+  }
+
+  const lines: string[] = []
+  lines.push(border('top'))
+  lines.push(...rowLines(token.header, true))
+  lines.push(border('mid'))
+  token.rows.forEach((row, i) => {
+    lines.push(...rowLines(row, false))
+    if (i < token.rows.length - 1) lines.push(border('mid'))
+  })
+  lines.push(border('bot'))
+
+  // Safety fallback — same logic as upstream.
+  const maxLineWidth = Math.max(...lines.map(l => stringWidth(l)))
+  if (maxLineWidth > terminalWidth - SAFETY_MARGIN) {
+    return <VerticalTable token={token} terminalWidth={terminalWidth} />
+  }
+
+  return (
+    <box flexDirection="column">
+      {lines.map((line, i) => (
+        <text key={i} fg={c.text}>{line}</text>
+      ))}
+    </box>
+  )
+}
+
+function VerticalTable({ token, terminalWidth }: { token: MarkdownTableToken; terminalWidth: number }) {
+  const separatorWidth = Math.min(terminalWidth - 1, 40)
+  const separator = '\u2500'.repeat(separatorWidth)
+  const wrapIndent = '  '
+
+  const items: React.ReactNode[] = []
+  token.rows.forEach((row, rowIdx) => {
+    if (rowIdx > 0) {
+      items.push(
+        <text key={`sep-${rowIdx}`} fg={c.dim}>{separator}</text>,
+      )
+    }
+    row.forEach((cell, colIdx) => {
+      const label = token.header[colIdx] ?? `Column ${colIdx + 1}`
+      const value = cell.replace(/\s+/g, ' ').trim()
+      const firstWidth = terminalWidth - stringWidth(label) - 3
+      const restWidth = terminalWidth - wrapIndent.length - 1
+      const first = wrapText(value, Math.max(firstWidth, 10), false)
+      const firstLine = first[0] ?? ''
+      let wrapped: string[]
+      if (first.length <= 1 || restWidth <= firstWidth) {
+        wrapped = first
+      } else {
+        const remaining = first.slice(1).map(l => l.trim()).join(' ')
+        const rest = wrapText(remaining, restWidth, false)
+        wrapped = [firstLine, ...rest]
+      }
+      items.push(
+        <text key={`row-${rowIdx}-col-${colIdx}-first`}>
+          <strong>{label}:</strong> {wrapped[0] ?? ''}
+        </text>,
+      )
+      for (let i = 1; i < wrapped.length; i++) {
+        const line = wrapped[i]
+        if (!line || !line.trim()) continue
+        items.push(
+          <text key={`row-${rowIdx}-col-${colIdx}-cont-${i}`} fg={c.text}>
+            {wrapIndent}{line}
+          </text>,
+        )
+      }
+    })
+  })
+
+  return <box flexDirection="column">{items}</box>
+}

--- a/ui/src/components/MemoryUsageIndicator.tsx
+++ b/ui/src/components/MemoryUsageIndicator.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from 'react'
+import { c } from '../theme.js'
+
+/**
+ * OpenTUI port of upstream `MemoryUsageIndicator`
+ * (`ui/examples/upstream-patterns/src/components/MemoryUsageIndicator.tsx`).
+ *
+ * Polls Node/Bun's heap metrics on a 10-second cadence and surfaces a
+ * warning line when heap usage crosses the "high"/"critical" thresholds
+ * upstream uses. Upstream gates the entire widget behind
+ * `USER_TYPE === 'ant'` (internal-only). cc-rust has no equivalent flag,
+ * so we expose the check via the `CC_RUST_MEMORY_INDICATOR` env var so
+ * operators can opt in without rebuilding.
+ */
+
+const HIGH_THRESHOLD = 0.75
+const CRITICAL_THRESHOLD = 0.9
+const POLL_INTERVAL_MS = 10_000
+
+type Status = 'normal' | 'high' | 'critical'
+
+interface MemoryUsage {
+  heapUsed: number
+  status: Status
+}
+
+function formatFileSize(bytes: number): string {
+  const units = ['B', 'KB', 'MB', 'GB']
+  let value = bytes
+  let unit = 0
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024
+    unit++
+  }
+  return `${value.toFixed(1)} ${units[unit]}`
+}
+
+function readMemoryUsage(): MemoryUsage | null {
+  if (typeof process === 'undefined' || typeof process.memoryUsage !== 'function') {
+    return null
+  }
+  try {
+    const mu = process.memoryUsage()
+    const total = mu.heapTotal || 1
+    const ratio = mu.heapUsed / total
+    let status: Status = 'normal'
+    if (ratio >= CRITICAL_THRESHOLD) status = 'critical'
+    else if (ratio >= HIGH_THRESHOLD) status = 'high'
+    return { heapUsed: mu.heapUsed, status }
+  } catch {
+    return null
+  }
+}
+
+export function MemoryUsageIndicator() {
+  const enabled =
+    typeof process !== 'undefined' &&
+    process.env?.CC_RUST_MEMORY_INDICATOR === '1'
+  const [usage, setUsage] = useState<MemoryUsage | null>(null)
+
+  useEffect(() => {
+    if (!enabled) return
+    const tick = () => setUsage(readMemoryUsage())
+    tick()
+    const id = setInterval(tick, POLL_INTERVAL_MS)
+    return () => clearInterval(id)
+  }, [enabled])
+
+  if (!enabled || !usage || usage.status === 'normal') {
+    return null
+  }
+
+  const color = usage.status === 'critical' ? c.error : c.warning
+  return (
+    <box>
+      <text fg={color}>
+        High memory usage ({formatFileSize(usage.heapUsed)})
+      </text>
+    </box>
+  )
+}

--- a/ui/src/components/Message.tsx
+++ b/ui/src/components/Message.tsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import type { ViewMode } from '../keybindings.js'
+import type { RenderItem } from '../store/message-model.js'
+import { MessageBubble } from './MessageBubble.js'
+
+/**
+ * OpenTUI port of upstream `Message`
+ * (`ui/examples/upstream-patterns/src/components/Message.tsx`).
+ *
+ * Upstream's `Message` takes a `NormalizedUserMessage | AssistantMessage |
+ * AttachmentMessage | SystemMessage | GroupedToolUseMessage |
+ * CollapsedReadSearchGroup`, walks its content blocks, and dispatches to
+ * per-type leaves under `./messages/*`. Lite does the same work through
+ * `store/message-model.ts` (`RawMessage` → `RenderItem` via
+ * `buildRenderItems`) and `MessageBubble` (one leaf per `RenderItem`
+ * discriminant).
+ *
+ * Re-hosting `Message` as a thin adapter on top of that pipeline gives
+ * callers that reference `Message.tsx` a working component without
+ * pulling in upstream's Ink-specific state graph. The props shape is
+ * reduced to what Lite actually has access to — `RenderItem` plus
+ * `viewMode` — because Lite's upstream-style `NormalizedMessage` types
+ * are not surfaced through IPC today.
+ *
+ * Upstream's niceties that require data not present in Lite's IPC
+ * surface (per-message `model`, `timestamp` header on transcript-only
+ * rows, CompactBoundary, AdvisorMessage, OffscreenFreeze cache) are
+ * deliberately skipped; the per-type leaves under `./messages/` handle
+ * what's exposed by `RenderItem`.
+ */
+
+export type MessageProps = {
+  item: RenderItem
+  viewMode: ViewMode
+  /** Upstream parameters preserved for API compatibility — currently
+   *  ignored because the Lite leaves consume them via the store. */
+  addMargin?: boolean
+  verbose?: boolean
+  isTranscriptMode?: boolean
+  isStatic?: boolean
+}
+
+function MessageImpl({ item, viewMode }: MessageProps) {
+  return <MessageBubble item={item} viewMode={viewMode} />
+}
+
+export const Message = React.memo(MessageImpl, (prev, next) => {
+  return (
+    prev.item === next.item &&
+    prev.viewMode === next.viewMode &&
+    prev.verbose === next.verbose &&
+    prev.isTranscriptMode === next.isTranscriptMode &&
+    prev.isStatic === next.isStatic
+  )
+})
+
+/**
+ * Porting of upstream's `hasThinkingContent` helper. Works against any
+ * object shaped like `RenderItem`, `RawMessage`, or upstream's
+ * `NormalizedMessage`. Returns true if the object exposes either
+ * thinking text or a `thinking` / `redacted_thinking` content block.
+ */
+export function hasThinkingContent(m: {
+  type?: string
+  role?: string
+  thinking?: string
+  message?: { content: Array<{ type: string }> }
+  contentBlocks?: Array<{ type: string }>
+}): boolean {
+  if (typeof m.thinking === 'string' && m.thinking.trim().length > 0) {
+    return true
+  }
+  const blocks = m.contentBlocks ?? m.message?.content
+  if (!Array.isArray(blocks)) return false
+  return blocks.some(
+    block => block.type === 'thinking' || block.type === 'redacted_thinking',
+  )
+}
+
+/**
+ * Porting of upstream's `areMessagePropsEqual` for tests / direct memo
+ * consumers. Matches the default `React.memo` comparator above.
+ */
+export function areMessagePropsEqual(prev: MessageProps, next: MessageProps): boolean {
+  return (
+    prev.item === next.item &&
+    prev.viewMode === next.viewMode &&
+    prev.verbose === next.verbose &&
+    prev.isTranscriptMode === next.isTranscriptMode &&
+    prev.isStatic === next.isStatic
+  )
+}

--- a/ui/src/components/MessageModel.tsx
+++ b/ui/src/components/MessageModel.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { c } from '../theme.js'
+import type { RawMessage } from '../store/message-model.js'
+import type { ViewMode } from '../keybindings.js'
+
+/**
+ * OpenTUI port of upstream `MessageModel`
+ * (`ui/examples/upstream-patterns/src/components/MessageModel.tsx`).
+ *
+ * Displays the assistant model name next to a message when the caller is
+ * in transcript mode. Lite's `RawMessage` carries `role` + `content` (plus
+ * `contentBlocks`) but does not expose the upstream per-message `model`
+ * field yet; when the backend adds it the component will render without
+ * further changes. Until then it hides gracefully.
+ */
+
+type Props = {
+  message: RawMessage & { model?: string }
+  viewMode: ViewMode
+}
+
+export function MessageModel({ message, viewMode }: Props) {
+  if (viewMode !== 'transcript') {
+    return null
+  }
+  if (message.role !== 'assistant') {
+    return null
+  }
+  const hasText =
+    (message.contentBlocks?.some(block => block.type === 'text') ?? false) ||
+    (typeof message.content === 'string' && message.content.trim().length > 0)
+  if (!hasText) {
+    return null
+  }
+  const model = message.model
+  if (!model) {
+    return null
+  }
+  return (
+    <box minWidth={model.length + 2}>
+      <text fg={c.dim}>{model}</text>
+    </box>
+  )
+}

--- a/ui/src/components/MessageResponse.tsx
+++ b/ui/src/components/MessageResponse.tsx
@@ -1,0 +1,44 @@
+import React, { createContext, useContext, type ReactNode } from 'react'
+import { c } from '../theme.js'
+
+/**
+ * OpenTUI port of upstream `MessageResponse`
+ * (`ui/examples/upstream-patterns/src/components/MessageResponse.tsx`).
+ *
+ * Renders the `  ⎿ ` continuation connector used by tool-result /
+ * assistant-response follow-up rows. The nested-context trick matches
+ * upstream: inner MessageResponse calls return `children` raw to avoid
+ * stacking extra `⎿` prefixes.
+ *
+ * Upstream's `<Ratchet lock="offscreen">` and `<NoSelect>` wrappers are
+ * OpenTUI primitives we don't mirror today; we get "freeze while offscreen"
+ * from `scrollbox` clipping and we don't have a NoSelect equivalent — the
+ * prefix is still copied but it's the same as most other decorations here.
+ */
+
+const MessageResponseContext = createContext(false)
+
+type Props = {
+  children: ReactNode
+  height?: number
+}
+
+export function MessageResponse({ children, height }: Props) {
+  const isNested = useContext(MessageResponseContext)
+  if (isNested) {
+    return <>{children}</>
+  }
+
+  return (
+    <MessageResponseContext.Provider value={true}>
+      <box flexDirection="row" height={height} width="100%">
+        <box flexShrink={0} minWidth={5}>
+          <text fg={c.dim}>{'  \u23BF  '}</text>
+        </box>
+        <box flexShrink={1} flexGrow={1}>
+          {children}
+        </box>
+      </box>
+    </MessageResponseContext.Provider>
+  )
+}

--- a/ui/src/components/MessageRow.tsx
+++ b/ui/src/components/MessageRow.tsx
@@ -1,0 +1,97 @@
+import React from 'react'
+import type { ViewMode } from '../keybindings.js'
+import type { RenderItem } from '../store/message-model.js'
+import { c } from '../theme.js'
+import { Message, hasThinkingContent } from './Message.js'
+import { MessageModel } from './MessageModel.js'
+
+/**
+ * OpenTUI port of upstream `MessageRow`
+ * (`ui/examples/upstream-patterns/src/components/MessageRow.tsx`).
+ *
+ * Upstream wraps `Message` with:
+ *   1. Optional transcript-mode metadata row (timestamp + model pill).
+ *   2. An `OffscreenFreeze` to cache the rendered element once it has
+ *      scrolled out of the viewport.
+ *
+ * Lite's `MessageList` drives the conversation through the `RenderItem`
+ * pipeline and delegates leaves to `MessageBubble`. `MessageRow` re-hosts
+ * that shape for callers that want the upstream API: it renders the
+ * optional metadata row above `Message` and delegates body rendering to
+ * the existing bubble pipeline. The OffscreenFreeze optimisation is
+ * skipped because OpenTUI's `scrollbox` already clips off-screen
+ * content, so revisiting a message does not re-run layout.
+ */
+
+export type MessageRowProps = {
+  item: RenderItem
+  viewMode: ViewMode
+  /** Optional per-message model name — populated once the backend
+   *  exposes it on `RawMessage`. Until then the metadata row only shows
+   *  a timestamp when the item supplies one. */
+  model?: string
+  columns?: number
+}
+
+function formatTimestamp(ts: number): string {
+  try {
+    return new Date(ts).toLocaleString()
+  } catch {
+    return ''
+  }
+}
+
+function MessageRowImpl({ item, viewMode, model, columns }: MessageRowProps) {
+  const isTranscript = viewMode === 'transcript'
+  const isAssistant = item.type === 'assistant_text' || item.type === 'streaming'
+  const hasMetadata =
+    isTranscript && isAssistant && (model || item.timestamp) && (item.type === 'assistant_text' || item.type === 'streaming')
+
+  if (!hasMetadata) {
+    return <Message item={item} viewMode={viewMode} />
+  }
+
+  return (
+    <box flexDirection="column" width={columns ?? '100%'}>
+      <box flexDirection="row" justifyContent="flex-end" marginTop={1}>
+        {item.timestamp && (
+          <box marginRight={1}>
+            <text fg={c.dim}>{formatTimestamp(item.timestamp)}</text>
+          </box>
+        )}
+        {model && (
+          <MessageModel
+            message={{
+              id: item.id,
+              role: 'assistant',
+              content:
+                item.type === 'assistant_text' || item.type === 'streaming'
+                  ? item.content
+                  : '',
+              timestamp: item.timestamp,
+              model,
+            }}
+            viewMode={viewMode}
+          />
+        )}
+      </box>
+      <Message item={item} viewMode={viewMode} />
+    </box>
+  )
+}
+
+export const MessageRow = React.memo(MessageRowImpl, (prev, next) => {
+  if (prev.item !== next.item) return false
+  if (prev.viewMode !== next.viewMode) return false
+  if (prev.model !== next.model) return false
+  if (prev.columns !== next.columns) return false
+  return true
+})
+
+/**
+ * Helper exported upstream for transcripts that hide all but the latest
+ * thinking block. Preserved for API compatibility.
+ */
+export function shouldShowThinking(item: RenderItem): boolean {
+  return hasThinkingContent(item)
+}

--- a/ui/src/components/MessageSelector.tsx
+++ b/ui/src/components/MessageSelector.tsx
@@ -1,0 +1,327 @@
+import React, { useCallback, useMemo, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { RawMessage } from '../store/message-model.js'
+import { c } from '../theme.js'
+import { Spinner } from './Spinner.js'
+
+/**
+ * OpenTUI port of upstream `MessageSelector`
+ * (`ui/examples/upstream-patterns/src/components/MessageSelector.tsx`).
+ *
+ * Upstream powers the "Rewind to…" pop-up — a list of prior user turns
+ * the operator can restore (conversation only / code only / both / or
+ * summarize from). It depends on several pieces that Lite does not have
+ * surfaced through IPC yet:
+ *   - `fileHistoryCanRestore` / `fileHistoryGetDiffStats` (rust-side
+ *     file snapshot store),
+ *   - `onSummarize` + compaction direction commands,
+ *   - analytics / telemetry events.
+ *
+ * The re-host keeps the same public call surface (`messages` + callback
+ * props) so the upstream rewind flow can be wired to the backend when
+ * the commands land. Today the UI:
+ *   - paginates user messages with ↑ / ↓ / home / end,
+ *   - shows a focused "restore options" step once a message is picked,
+ *   - invokes the appropriate callback on confirm.
+ *
+ * The `onRestoreCode` / `onSummarize` callbacks are optional — when the
+ * parent does not provide them, the corresponding options are hidden.
+ */
+
+export type PartialCompactDirection = 'from' | 'up_to'
+
+export type MessageSelectorProps = {
+  messages: RawMessage[]
+  onPreRestore?: () => void
+  onRestoreMessage: (message: RawMessage) => Promise<void> | void
+  onRestoreCode?: (message: RawMessage) => Promise<void> | void
+  onSummarize?: (
+    message: RawMessage,
+    feedback?: string,
+    direction?: PartialCompactDirection,
+  ) => Promise<void> | void
+  onClose: () => void
+  /** Skip the pick-list and jump straight to the confirm step. */
+  preselectedMessage?: RawMessage
+}
+
+type RestoreOption =
+  | 'both'
+  | 'conversation'
+  | 'code'
+  | 'summarize'
+  | 'nevermind'
+
+const MAX_VISIBLE = 7
+
+function userMessageSelectable(m: RawMessage): boolean {
+  if (m.role !== 'user') return false
+  if (!m.content?.trim()) return false
+  // Hide XML-wrapped system echoes (command expansions, bash stdout, …).
+  return !m.content.trimStart().startsWith('<')
+}
+
+function shortTitle(message: RawMessage, maxWidth = 80): string {
+  const compact = message.content.replace(/\s+/g, ' ').trim()
+  if (compact.length <= maxWidth) return compact
+  return compact.slice(0, maxWidth - 1) + '\u2026'
+}
+
+export function MessageSelector({
+  messages,
+  onPreRestore,
+  onRestoreMessage,
+  onRestoreCode,
+  onSummarize,
+  onClose,
+  preselectedMessage,
+}: MessageSelectorProps) {
+  const candidates = useMemo(
+    () => messages.filter(userMessageSelectable),
+    [messages],
+  )
+  const [selectedIndex, setSelectedIndex] = useState(
+    Math.max(0, candidates.length - 1),
+  )
+  const [messageToRestore, setMessageToRestore] = useState<
+    RawMessage | undefined
+  >(preselectedMessage)
+  const [isRestoring, setIsRestoring] = useState(false)
+  const [error, setError] = useState<string | undefined>()
+  const [restoreOption, setRestoreOption] = useState<RestoreOption>('both')
+
+  const availableOptions = useMemo<Array<{ value: RestoreOption; label: string }>>(
+    () => {
+      const list: Array<{ value: RestoreOption; label: string }> = []
+      if (onRestoreCode) {
+        list.push({ value: 'both', label: 'Restore code and conversation' })
+        list.push({ value: 'conversation', label: 'Restore conversation' })
+        list.push({ value: 'code', label: 'Restore code' })
+      } else {
+        list.push({ value: 'conversation', label: 'Restore conversation' })
+      }
+      if (onSummarize) {
+        list.push({ value: 'summarize', label: 'Summarize from here' })
+      }
+      list.push({ value: 'nevermind', label: 'Never mind' })
+      return list
+    },
+    [onRestoreCode, onSummarize],
+  )
+  const [optionIndex, setOptionIndex] = useState(0)
+
+  const firstVisible = Math.max(
+    0,
+    Math.min(
+      selectedIndex - Math.floor(MAX_VISIBLE / 2),
+      candidates.length - MAX_VISIBLE,
+    ),
+  )
+
+  const runRestore = useCallback(
+    async (message: RawMessage, option: RestoreOption) => {
+      if (option === 'nevermind') {
+        if (preselectedMessage) onClose()
+        else setMessageToRestore(undefined)
+        return
+      }
+      onPreRestore?.()
+      setIsRestoring(true)
+      setError(undefined)
+      try {
+        if (option === 'summarize' && onSummarize) {
+          await onSummarize(message)
+        } else {
+          if ((option === 'code' || option === 'both') && onRestoreCode) {
+            await onRestoreCode(message)
+          }
+          if (option === 'conversation' || option === 'both') {
+            await onRestoreMessage(message)
+          }
+        }
+        onClose()
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err))
+      } finally {
+        setIsRestoring(false)
+      }
+    },
+    [
+      onClose,
+      onPreRestore,
+      onRestoreCode,
+      onRestoreMessage,
+      onSummarize,
+      preselectedMessage,
+    ],
+  )
+
+  useKeyboard(event => {
+    if (event.eventType === 'release' || isRestoring) return
+    const key = event.name
+
+    if (messageToRestore) {
+      if (key === 'escape') {
+        if (preselectedMessage) onClose()
+        else setMessageToRestore(undefined)
+        return
+      }
+      if (key === 'up') {
+        setOptionIndex(i => (i - 1 + availableOptions.length) % availableOptions.length)
+        return
+      }
+      if (key === 'down' || key === 'tab') {
+        setOptionIndex(i => (i + 1) % availableOptions.length)
+        return
+      }
+      if (key === 'return' || key === 'enter') {
+        const opt = availableOptions[optionIndex]
+        if (opt) {
+          setRestoreOption(opt.value)
+          void runRestore(messageToRestore, opt.value)
+        }
+      }
+      return
+    }
+
+    if (key === 'escape') {
+      onClose()
+      return
+    }
+    if (candidates.length === 0) return
+    if (key === 'up') {
+      setSelectedIndex(i => Math.max(0, i - 1))
+      return
+    }
+    if (key === 'down') {
+      setSelectedIndex(i => Math.min(candidates.length - 1, i + 1))
+      return
+    }
+    if (key === 'home') {
+      setSelectedIndex(0)
+      return
+    }
+    if (key === 'end') {
+      setSelectedIndex(candidates.length - 1)
+      return
+    }
+    if (key === 'return' || key === 'enter') {
+      const chosen = candidates[selectedIndex]
+      if (chosen) {
+        setMessageToRestore(chosen)
+        setOptionIndex(0)
+      }
+    }
+  })
+
+  if (candidates.length === 0 && !preselectedMessage) {
+    return (
+      <box
+        flexDirection="column"
+        borderStyle="rounded"
+        borderColor={c.accent}
+        paddingX={2}
+        paddingY={1}
+        title="Rewind"
+        titleAlignment="center"
+      >
+        <text>Nothing to rewind to yet.</text>
+      </box>
+    )
+  }
+
+  return (
+    <box
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.accent}
+      paddingX={2}
+      paddingY={1}
+      title="Rewind"
+      titleAlignment="center"
+    >
+      {error && (
+        <box marginBottom={1}>
+          <text fg={c.error}>Error: {error}</text>
+        </box>
+      )}
+
+      {!messageToRestore && (
+        <>
+          <text>
+            {onRestoreCode
+              ? 'Restore the code and/or conversation to the point before…'
+              : 'Restore and fork the conversation to the point before…'}
+          </text>
+          <box flexDirection="column" marginTop={1}>
+            {candidates.slice(firstVisible, firstVisible + MAX_VISIBLE).map((msg, i) => {
+              const optionIndex = firstVisible + i
+              const isSelected = optionIndex === selectedIndex
+              return (
+                <text key={msg.id}>
+                  <span fg={isSelected ? c.accent : c.dim}>
+                    {isSelected ? '\u25B8 ' : '  '}
+                  </span>
+                  <span fg={isSelected ? c.textBright : c.text}>
+                    {shortTitle(msg)}
+                  </span>
+                </text>
+              )
+            })}
+          </box>
+          <box marginTop={1}>
+            <text fg={c.dim}>
+              <em>↑↓ navigate · Enter pick · Esc close</em>
+            </text>
+          </box>
+        </>
+      )}
+
+      {messageToRestore && (
+        <>
+          <text>
+            Confirm you want to restore the conversation to the point before you sent this message:
+          </text>
+          <box
+            flexDirection="column"
+            marginTop={1}
+            paddingLeft={1}
+            borderStyle="single"
+            border={['left']}
+            borderColor={c.dim}
+          >
+            <text fg={c.text}>{shortTitle(messageToRestore, 120)}</text>
+          </box>
+
+          {isRestoring && restoreOption === 'summarize' ? (
+            <box flexDirection="row" marginTop={1}>
+              <Spinner />
+              <text>{' Summarizing…'}</text>
+            </box>
+          ) : (
+            <box flexDirection="column" marginTop={1}>
+              {availableOptions.map((opt, i) => {
+                const focused = i === optionIndex
+                return (
+                  <text key={opt.value}>
+                    <span fg={focused ? c.accent : c.dim}>
+                      {focused ? '\u25B8 ' : '  '}
+                    </span>
+                    <span fg={focused ? c.textBright : c.text}>
+                      {opt.label}
+                    </span>
+                  </text>
+                )
+              })}
+            </box>
+          )}
+          <box marginTop={1}>
+            <text fg={c.dim}>
+              <em>Enter confirm · Esc back</em>
+            </text>
+          </box>
+        </>
+      )}
+    </box>
+  )
+}

--- a/ui/src/components/Messages.tsx
+++ b/ui/src/components/Messages.tsx
@@ -1,0 +1,95 @@
+import React, { useMemo } from 'react'
+import type { ViewMode } from '../keybindings.js'
+import { buildRenderItems, type RawMessage, type RenderItem } from '../store/message-model.js'
+import { c } from '../theme.js'
+import { MessageRow } from './MessageRow.js'
+
+/**
+ * OpenTUI port of upstream `Messages`
+ * (`ui/examples/upstream-patterns/src/components/Messages.tsx`).
+ *
+ * Upstream is a ~1.1K-line orchestrator that:
+ *  - normalizes the raw conversation buffer (collapse read/search groups,
+ *    group tool uses, filter hidden messages, reorder syn messages), and
+ *  - hands the resulting list to a virtualized list
+ *    (`VirtualMessageList`) that streams ANSI into an Ink `<Static>`
+ *    region.
+ *
+ * Lite already has that pipeline under a different shape:
+ *   - `store/message-model.ts::buildRenderItems` applies the
+ *     normalization + grouping (tool-group collapsing, streaming splice,
+ *     etc.) against `RawMessage[]`.
+ *   - `components/MessageList.tsx` renders the result inside an OpenTUI
+ *     `<scrollbox>`, driven by the app store.
+ *
+ * This re-host provides the upstream call surface (`Messages` taking a
+ * message list + view mode) so callers that reference `Messages.tsx`
+ * receive the normalized list rendered with `MessageRow`. The scroll /
+ * virtualization / logo-header concerns stay in `MessageList.tsx` —
+ * this component is intentionally a composition point, not a runtime
+ * replacement.
+ */
+
+export type MessagesProps = {
+  messages: RawMessage[]
+  viewMode: ViewMode
+  /** Live streaming text for the current turn, if any. */
+  streamingText?: string
+  streamingThinking?: string
+  /** Whether the conversation is currently streaming or waiting. Drives
+   *  the `'running'` state on in-flight tool activities. */
+  isBusy?: boolean
+  /** Optional absolute width for the containing box. */
+  columns?: number
+}
+
+export function Messages({
+  messages,
+  viewMode,
+  streamingText,
+  streamingThinking,
+  isBusy,
+  columns,
+}: MessagesProps) {
+  const items = useMemo(
+    () =>
+      buildRenderItems(messages, {
+        viewMode,
+        isBusy: !!isBusy,
+        streamingText,
+        streamingThinking,
+      }),
+    [isBusy, messages, streamingText, streamingThinking, viewMode],
+  )
+
+  if (items.length === 0) {
+    return null
+  }
+
+  return (
+    <box flexDirection="column" width={columns ?? '100%'} backgroundColor={c.bg}>
+      {items.map(item => (
+        <MessageRow key={item.id} item={item} viewMode={viewMode} columns={typeof columns === 'number' ? columns : undefined} />
+      ))}
+    </box>
+  )
+}
+
+/**
+ * Exported so test code can reuse the static-message heuristic. Mirrors
+ * upstream's `shouldRenderStatically`: anything that has already
+ * resolved (no tool activity still running, no streaming body) is safe
+ * to render into upstream's `<Static>` region. In Lite everything lives
+ * inside `<scrollbox>`, so this is advisory — callers use it when
+ * deciding whether to skip memo bust on transient state changes.
+ */
+export function shouldRenderStatically(item: RenderItem): boolean {
+  if (item.type === 'streaming') return false
+  if (item.type === 'tool_activity') {
+    return item.status !== 'running' && item.status !== 'pending'
+  }
+  if (item.type === 'tool_group') {
+    return item.status !== 'running' && item.status !== 'pending'
+  }
+  return true
+}

--- a/ui/src/components/messageActions.tsx
+++ b/ui/src/components/messageActions.tsx
@@ -1,0 +1,309 @@
+import React, { createContext, useCallback, useMemo, useRef, type RefObject } from 'react'
+import type { RenderItem } from '../store/message-model.js'
+import { c } from '../theme.js'
+
+/**
+ * OpenTUI port of upstream `messageActions.tsx`
+ * (`ui/examples/upstream-patterns/src/components/messageActions.tsx`).
+ *
+ * Upstream wires the scrollback "cursor" bar — the `enter` / `c` / `p`
+ * action row you see when you arrow up from the composer onto a prior
+ * message. It reaches into upstream's `NormalizableMessage` union and a
+ * global keybinding registry that Lite does not have in the same shape.
+ *
+ * Lite drives the transcript through `RenderItem` (pipeline lives in
+ * `store/message-model.ts`). This module re-hosts the upstream surface
+ * against that type:
+ *   - `isNavigableMessage(item)` — decides whether an item is a cursor
+ *     target.
+ *   - `copyTextOf(item)` — plain-text representation for "copy".
+ *   - `toolPrimaryInputOf(item)` — extracts the dominant input field
+ *     (path / command / pattern / url / prompt) for the "copy X" action.
+ *   - `MESSAGE_ACTIONS` — table of actions + eligibility predicates.
+ *   - `useMessageActions()` — React hook returning keyboard handlers
+ *     the caller can feed into a custom keybinding dispatcher.
+ *   - `MessageActionsBar` — the footer row rendering the active action
+ *     hints.
+ *
+ * Lite does not yet mount this bar inside `MessageList.tsx`; the module
+ * is provided as the ready-made integration point for when the
+ * navigation mode lands.
+ */
+
+export const NAVIGABLE_TYPES = [
+  'user_text',
+  'assistant_text',
+  'tool_activity',
+  'tool_group',
+  'tool_result_orphan',
+  'system_text',
+] as const
+export type NavigableType = (typeof NAVIGABLE_TYPES)[number]
+
+export type NavigableItem = RenderItem
+
+export function isNavigableMessage(item: NavigableItem): boolean {
+  if (!NAVIGABLE_TYPES.includes(item.type as NavigableType)) return false
+  if (item.type === 'system_text') {
+    // Empty system messages add nothing to the cursor — skip them.
+    return !!item.content.trim()
+  }
+  if (item.type === 'user_text' || item.type === 'assistant_text') {
+    return !!item.content.trim()
+  }
+  if (item.type === 'tool_activity') {
+    return !!item.name && !!(item.inputDetail || item.inputSummary || item.output)
+  }
+  if (item.type === 'tool_group') {
+    return item.activities.length > 0
+  }
+  return true
+}
+
+type PrimaryInput = { label: string; extract: (input: any) => string | undefined }
+
+const pickString = (key: string) => (input: any): string | undefined => {
+  if (!input || typeof input !== 'object') return undefined
+  const value = input[key]
+  return typeof value === 'string' && value.trim() ? value : undefined
+}
+
+/** Mirror of upstream's `PRIMARY_INPUT`. */
+export const PRIMARY_INPUT: Record<string, PrimaryInput> = {
+  Read: { label: 'path', extract: pickString('file_path') },
+  Edit: { label: 'path', extract: pickString('file_path') },
+  Write: { label: 'path', extract: pickString('file_path') },
+  NotebookEdit: { label: 'path', extract: pickString('notebook_path') },
+  Bash: { label: 'command', extract: pickString('command') },
+  Grep: { label: 'pattern', extract: pickString('pattern') },
+  Glob: { label: 'pattern', extract: pickString('pattern') },
+  WebFetch: { label: 'url', extract: pickString('url') },
+  WebSearch: { label: 'query', extract: pickString('query') },
+  Task: { label: 'prompt', extract: pickString('prompt') },
+  Agent: { label: 'prompt', extract: pickString('prompt') },
+}
+
+export function toolPrimaryInputOf(
+  item: NavigableItem,
+): { name: string; label: string; value: string } | undefined {
+  if (item.type !== 'tool_activity' && item.type !== 'tool_group') return undefined
+  if (item.type === 'tool_activity') {
+    const spec = PRIMARY_INPUT[item.name]
+    const value = spec?.extract(item.input)
+    if (!spec || !value) return undefined
+    return { name: item.name, label: spec.label, value }
+  }
+  const first = item.activities[0]
+  if (!first) return undefined
+  const spec = PRIMARY_INPUT[first.name]
+  const value = spec?.extract(first.input)
+  if (!spec || !value) return undefined
+  return { name: first.name, label: spec.label, value }
+}
+
+export function copyTextOf(item: NavigableItem): string {
+  switch (item.type) {
+    case 'user_text':
+    case 'assistant_text':
+    case 'streaming':
+      return item.content
+    case 'system_text':
+      return item.content
+    case 'tool_activity':
+      return item.output ?? item.inputDetail ?? item.inputSummary ?? ''
+    case 'tool_group':
+      return item.activities
+        .map(a => a.output ?? a.inputDetail ?? a.inputSummary ?? '')
+        .filter(Boolean)
+        .join('\n\n')
+    case 'tool_result_orphan':
+      return item.output
+    default:
+      return ''
+  }
+}
+
+export type MessageActionCaps = {
+  copy: (text: string) => void
+}
+
+export type MessageActionsState = {
+  id: string
+  itemType: NavigableType
+  expanded: boolean
+  /** Dominant tool name when the cursor sits on a tool activity / group. */
+  toolName?: string
+}
+
+export type MessageActionsNav = {
+  enterCursor: () => void
+  navigatePrev: () => void
+  navigateNext: () => void
+  navigateTop: () => void
+  navigateBottom: () => void
+  getSelected: () => NavigableItem | null
+}
+
+export const MessageActionsSelectedContext = createContext(false)
+export const InVirtualListContext = createContext(false)
+
+/** Selected-row background colour helper — matches upstream API. */
+export function useSelectedMessageBg(): string | undefined {
+  return undefined
+}
+
+type Action = {
+  key: string
+  label: string | ((state: MessageActionsState) => string)
+  types: readonly NavigableType[]
+  applies?: (state: MessageActionsState) => boolean
+  stays?: true
+  run: (item: NavigableItem, caps: MessageActionCaps) => void
+}
+
+export const MESSAGE_ACTIONS: Action[] = [
+  {
+    key: 'enter',
+    label: state => (state.expanded ? 'collapse' : 'expand'),
+    types: ['tool_activity', 'tool_group', 'system_text'],
+    stays: true,
+    run: () => {},
+  },
+  {
+    key: 'c',
+    label: 'copy',
+    types: NAVIGABLE_TYPES,
+    run: (item, caps) => caps.copy(copyTextOf(item)),
+  },
+  {
+    key: 'p',
+    label: state =>
+      state.toolName && state.toolName in PRIMARY_INPUT
+        ? `copy ${PRIMARY_INPUT[state.toolName]!.label}`
+        : 'copy',
+    types: ['tool_activity', 'tool_group'],
+    applies: state => !!state.toolName && state.toolName in PRIMARY_INPUT,
+    run: (item, caps) => {
+      const primary = toolPrimaryInputOf(item)
+      if (primary) caps.copy(primary.value)
+    },
+  },
+]
+
+function isApplicable(action: Action, state: MessageActionsState): boolean {
+  if (!action.types.includes(state.itemType)) return false
+  return !action.applies || action.applies(state)
+}
+
+/**
+ * Returns a map of keyboard-handler closures keyed by shortcut action.
+ * Callers register these with the app's keybinding dispatcher. The
+ * hook is context-agnostic: no internal dependency on a specific
+ * keybinding surface.
+ */
+export function useMessageActions(
+  cursor: MessageActionsState | null,
+  setCursor: React.Dispatch<React.SetStateAction<MessageActionsState | null>>,
+  navRef: RefObject<MessageActionsNav | null>,
+  caps: MessageActionCaps,
+): {
+  enter: () => void
+  handlers: Record<string, () => void>
+} {
+  const cursorRef = useRef(cursor)
+  cursorRef.current = cursor
+  const capsRef = useRef(caps)
+  capsRef.current = caps
+
+  const handlers = useMemo(() => {
+    const h: Record<string, () => void> = {
+      'messageActions:prev': () => navRef.current?.navigatePrev(),
+      'messageActions:next': () => navRef.current?.navigateNext(),
+      'messageActions:top': () => navRef.current?.navigateTop(),
+      'messageActions:bottom': () => navRef.current?.navigateBottom(),
+      'messageActions:escape': () =>
+        setCursor(c => (c?.expanded ? { ...c, expanded: false } : null)),
+      'messageActions:ctrlc': () => setCursor(null),
+    }
+    const keys = new Set(MESSAGE_ACTIONS.map(a => a.key))
+    for (const key of keys) {
+      h[`messageActions:${key}`] = () => {
+        const current = cursorRef.current
+        if (!current) return
+        const action = MESSAGE_ACTIONS.find(
+          a => a.key === key && isApplicable(a, current),
+        )
+        if (!action) return
+        if (action.stays) {
+          setCursor(c => (c ? { ...c, expanded: !c.expanded } : null))
+          return
+        }
+        const item = navRef.current?.getSelected()
+        if (!item) return
+        action.run(item, capsRef.current)
+        setCursor(null)
+      }
+    }
+    return h
+  }, [navRef, setCursor])
+
+  const enter = useCallback(() => {
+    navRef.current?.enterCursor()
+  }, [navRef])
+
+  return { enter, handlers }
+}
+
+export function MessageActionsBar({
+  cursor,
+}: {
+  cursor: MessageActionsState
+}) {
+  const applicable = MESSAGE_ACTIONS.filter(a => isApplicable(a, cursor))
+  return (
+    <box flexDirection="column" flexShrink={0} paddingY={1}>
+      <box
+        borderStyle="single"
+        border={['top']}
+        borderColor={c.dim}
+      />
+      <box paddingX={2} paddingY={1} flexDirection="row">
+        {applicable.map((action, i) => {
+          const label =
+            typeof action.label === 'function' ? action.label(cursor) : action.label
+          return (
+            <React.Fragment key={action.key}>
+              {i > 0 && <text fg={c.dim}> · </text>}
+              <text>
+                <strong>{action.key}</strong>
+                <span fg={c.dim}> {label}</span>
+              </text>
+            </React.Fragment>
+          )
+        })}
+        <text fg={c.dim}> · </text>
+        <text>
+          <strong>\u2191\u2193</strong>
+          <span fg={c.dim}> navigate</span>
+        </text>
+        <text fg={c.dim}> · </text>
+        <text>
+          <strong>esc</strong>
+          <span fg={c.dim}> back</span>
+        </text>
+      </box>
+    </box>
+  )
+}
+
+/** Upstream's XML-trim helper. Re-exported so consumers can reuse it. */
+export function stripSystemReminders(text: string): string {
+  const CLOSE = '</system-reminder>'
+  let t = text.trimStart()
+  while (t.startsWith('<system-reminder>')) {
+    const end = t.indexOf(CLOSE)
+    if (end < 0) break
+    t = t.slice(end + CLOSE.length).trimStart()
+  }
+  return t
+}


### PR DESCRIPTION
## Summary

Ports the remaining 20 components from `ui/examples/upstream-patterns/src/components/` into the active Lite tree under `ui/src/components/`, adapting each to the existing OpenTUI primitives, theme palette (`c.*`), store, and IPC surface.

### What landed

- **Atoms** — `InterruptedByUser`, `MCPServerDialogCopy`, `MessageResponse`, `MessageModel`, `MemoryUsageIndicator`, `KeybindingWarnings`.
- **Dialogs** — `LanguagePicker`, `InvalidSettingsDialog`, `InvalidConfigDialog`, `MCPServerApprovalDialog`, `MCPServerMultiselectDialog`, `MCPServerDesktopImportDialog`. The three MCP dialogs are wired to the existing `mcp_command` IPC (`toggle_enabled` / `upsert_config`) — **no new backend commands introduced**.
- **Markdown stack** — `Markdown` / `MarkdownTable` lean on the OpenTUI `<markdown>` intrinsic instead of bundling `marked`; the table variant reimplements upstream's column-distribution + vertical-fallback algorithm against OpenTUI primitives.
- **Message pipeline adapters** — `Message`, `MessageRow`, `Messages`, `messageActions` re-host the upstream API as thin wrappers over Lite's existing `RenderItem` + `MessageBubble` pipeline in `store/message-model.ts`. The sample tree's `NormalizedMessage` machinery is intentionally not re-introduced.
- **Selectors** — `MessageSelector` (rewind) and `LogSelector` (resume) preserve upstream's callback-shaped prop contract; restore / session-listing IPC is left to callers because those commands do not exist in the current Lite protocol.

### Reviewer notes

- Every new file includes a header comment documenting what was ported verbatim, what was skipped, and the corresponding backend prerequisite (where applicable). That's the right place to look when wiring these into runtime call sites.
- Type-checked locally: the only remaining TS errors under the new files are the pre-existing `syntaxStyle` omission that is already accepted across the other four `<markdown>` call sites (`AssistantTextMessage`, `StreamingMessage`, `UserTextMessage`, `ToolActivityMessage`). No new categories of error introduced.
- Pattern/style matches the existing `permissions/`, `panels/`, `messages/` modules — primitives (`<box>`, `<text>`, `<markdown>`, `border={['left']}`), `useAppState()` / `useBackend()` / `useAppDispatch()`, `useKeyboard` for navigation, theme colours from `c.*`.

## Test plan

- [ ] `bun run dev` launches without regressions; existing components still render.
- [ ] Wire the ported dialogs into their intended call sites (future PRs) — this PR only adds the files; none of them are referenced from `App.tsx` yet.
- [ ] Spot-check `<markdown>` rendering inside the new `Markdown` component against the existing message leaves.
- [ ] Verify the MCP dialogs emit the expected `mcp_command` payloads when enabled from a settings flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)