### PR TITLE
feat(ui): port 20 upstream components to OpenTUI Lite

### DIFF
--- a/ui/src/components/MessageTimestamp.tsx
+++ b/ui/src/components/MessageTimestamp.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import { c } from '../theme.js'
+import type { RawMessage } from '../store/message-model.js'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/MessageTimestamp.tsx`.
+ *
+ * Shows a dim `hh:mm am/pm` timestamp next to assistant text in
+ * transcript mode. Returns `null` in prompt mode or when the message
+ * has no timestamp / text payload — matching the upstream gate.
+ */
+
+type Props = {
+  message: RawMessage
+  isTranscriptMode: boolean
+}
+
+function hasText(message: RawMessage): boolean {
+  if (message.content && message.content.length > 0) return true
+  if (!message.contentBlocks) return false
+  return message.contentBlocks.some(block => block.type === 'text')
+}
+
+export function MessageTimestamp({ message, isTranscriptMode }: Props) {
+  const shouldShow =
+    isTranscriptMode &&
+    !!message.timestamp &&
+    message.role === 'assistant' &&
+    hasText(message)
+
+  if (!shouldShow) {
+    return null
+  }
+
+  const formatted = new Date(message.timestamp).toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: true,
+  })
+
+  return (
+    <box minWidth={formatted.length}>
+      <text fg={c.dim}>{formatted}</text>
+    </box>
+  )
+}

--- a/ui/src/components/ModelPicker.tsx
+++ b/ui/src/components/ModelPicker.tsx
@@ -1,0 +1,334 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../theme.js'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/ModelPicker.tsx`.
+ *
+ * Upstream couples the picker to the full model catalog, effort
+ * cycling, Fast Mode, and `[1m]` context toggling — all of which live
+ * behind the Ink app state. The Lite port keeps the visible chrome
+ * (header, option list, effort row, 1M row, Fast Mode notice) and the
+ * selection flow; consumers pass the option list + effort state and
+ * receive the resulting `(model, effort)` pair on submit.
+ */
+
+export type EffortLevel = 'low' | 'medium' | 'high' | 'max'
+
+export type ModelPickerOption = {
+  value: string
+  label: string
+  description?: string
+  /** When true, `[1m]` 1M-context toggle is offered for this model. */
+  supports1M?: boolean
+  /** When true, the effort row is enabled for this model. */
+  supportsEffort?: boolean
+  /** When true, the `max` effort level is exposed. */
+  supportsMaxEffort?: boolean
+  defaultEffort?: EffortLevel
+}
+
+const NO_PREFERENCE = '__NO_PREFERENCE__'
+
+type Props = {
+  initial: string | null
+  sessionModel?: string
+  options: ModelPickerOption[]
+  currentEffort?: EffortLevel
+  /** Overrides the dim header line below "Select model". */
+  headerText?: string
+  /** Renders the "Fast mode" banner when the caller decides it's
+   *  appropriate (feature gated in upstream). */
+  showFastModeNotice?: boolean
+  fastModeModelDisplay?: string
+  fastModeOn?: boolean
+  /** Standalone renders the picker inside a bordered dialog pane. */
+  isStandaloneCommand?: boolean
+  onSelect: (model: string | null, effort: EffortLevel | undefined) => void
+  onCancel?: () => void
+}
+
+function effortSymbol(effort: EffortLevel | undefined): string {
+  switch (effort) {
+    case 'max':
+      return '\u25C6\u25C6\u25C6\u25C6'
+    case 'high':
+      return '\u25C6\u25C6\u25C6'
+    case 'medium':
+      return '\u25C6\u25C6'
+    case 'low':
+      return '\u25C6'
+    default:
+      return '\u25C7'
+  }
+}
+
+function cycleEffort(
+  current: EffortLevel,
+  direction: 'left' | 'right',
+  includeMax: boolean,
+): EffortLevel {
+  const levels: EffortLevel[] = includeMax
+    ? ['low', 'medium', 'high', 'max']
+    : ['low', 'medium', 'high']
+  const idx = levels.indexOf(current)
+  const resolved = idx >= 0 ? idx : levels.indexOf('high')
+  if (direction === 'right') {
+    return levels[(resolved + 1) % levels.length]!
+  }
+  return levels[(resolved - 1 + levels.length) % levels.length]!
+}
+
+function capitalize(s: string): string {
+  return s.length === 0 ? s : s[0]!.toUpperCase() + s.slice(1)
+}
+
+export function ModelPicker({
+  initial,
+  sessionModel,
+  options,
+  currentEffort,
+  headerText,
+  showFastModeNotice = false,
+  fastModeModelDisplay,
+  fastModeOn = false,
+  isStandaloneCommand = false,
+  onSelect,
+  onCancel,
+}: Props) {
+  const allOptions = useMemo<ModelPickerOption[]>(() => {
+    const withNoPref = options.slice()
+    if (!withNoPref.some(o => o.value === NO_PREFERENCE)) {
+      withNoPref.unshift({
+        value: NO_PREFERENCE,
+        label: 'No preference',
+        description: 'Use the default model for this session.',
+      })
+    }
+    return withNoPref
+  }, [options])
+
+  const initialValue = initial === null ? NO_PREFERENCE : initial
+  const initialIdx = Math.max(
+    0,
+    allOptions.findIndex(o => o.value === initialValue),
+  )
+  const [selected, setSelected] = useState(initialIdx)
+  const [effort, setEffort] = useState<EffortLevel | undefined>(currentEffort)
+  const [toggled1M, setToggled1M] = useState<Set<string>>(() => {
+    const set = new Set<string>()
+    if (initial && /\[1m\]/i.test(initial)) {
+      set.add(initial.replace(/\[1m\]/i, ''))
+    }
+    return set
+  })
+  const [hasToggledEffort, setHasToggledEffort] = useState(false)
+
+  useEffect(() => {
+    const next = Math.max(
+      0,
+      allOptions.findIndex(o => o.value === initialValue),
+    )
+    setSelected(next)
+  }, [allOptions, initialValue])
+
+  const focused = allOptions[selected]
+
+  const focusedSupportsEffort = !!focused?.supportsEffort
+  const focusedSupportsMax = !!focused?.supportsMaxEffort
+  const focusedDefault: EffortLevel = focused?.defaultEffort ?? 'high'
+  const displayEffort =
+    effort === 'max' && !focusedSupportsMax ? 'high' : effort ?? focusedDefault
+  const is1MMarked =
+    focused != null &&
+    focused.value !== NO_PREFERENCE &&
+    toggled1M.has(focused.value)
+
+  const handleCycle = useCallback(
+    (direction: 'left' | 'right') => {
+      if (!focusedSupportsEffort) return
+      setEffort(prev =>
+        cycleEffort(prev ?? focusedDefault, direction, focusedSupportsMax),
+      )
+      setHasToggledEffort(true)
+    },
+    [focusedSupportsEffort, focusedSupportsMax, focusedDefault],
+  )
+
+  const handleToggle1M = useCallback(() => {
+    if (!focused || focused.value === NO_PREFERENCE || !focused.supports1M) return
+    setToggled1M(prev => {
+      const next = new Set(prev)
+      if (next.has(focused.value)) next.delete(focused.value)
+      else next.add(focused.value)
+      return next
+    })
+  }, [focused])
+
+  const commit = useCallback(
+    (idx: number) => {
+      const opt = allOptions[idx]
+      if (!opt) return
+      const effortToSend =
+        hasToggledEffort && opt.supportsEffort ? effort : undefined
+      if (opt.value === NO_PREFERENCE) {
+        onSelect(null, effortToSend)
+        return
+      }
+      const wants1M = toggled1M.has(opt.value)
+      const base = opt.value.replace(/\[1m\]/i, '')
+      onSelect(wants1M ? `${base}[1m]` : base, effortToSend)
+    },
+    [allOptions, effort, hasToggledEffort, toggled1M, onSelect],
+  )
+
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const seq = event.sequence?.length === 1 ? event.sequence : undefined
+    const key = (seq ?? name ?? '').toLowerCase()
+
+    if (name === 'escape') {
+      onCancel?.()
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      commit(selected)
+      return
+    }
+    if (name === 'up' || key === 'k') {
+      setSelected(idx => Math.max(0, idx - 1))
+      return
+    }
+    if (name === 'down' || key === 'j') {
+      setSelected(idx => Math.min(allOptions.length - 1, idx + 1))
+      return
+    }
+    if (name === 'left') {
+      handleCycle('left')
+      return
+    }
+    if (name === 'right') {
+      handleCycle('right')
+      return
+    }
+    if (key === ' ') {
+      handleToggle1M()
+    }
+  })
+
+  const visibleCount = Math.min(10, allOptions.length)
+  const hiddenCount = Math.max(0, allOptions.length - visibleCount)
+  const slice = allOptions.slice(0, visibleCount)
+
+  const body = (
+    <box flexDirection="column">
+      <box flexDirection="column" marginBottom={1}>
+        <strong>
+          <text fg={c.accent}>Select model</text>
+        </strong>
+        <text fg={c.dim}>
+          {headerText ??
+            'Switch between Claude models. Applies to this session and future Claude Code sessions.'}
+        </text>
+        {sessionModel && (
+          <text fg={c.dim}>
+            Currently using {sessionModel} for this session. Selecting a model
+            will undo this.
+          </text>
+        )}
+      </box>
+
+      <box flexDirection="column" marginBottom={1}>
+        {slice.map((opt, i) => {
+          const isSelected = i === selected
+          return (
+            <box key={opt.value} flexDirection="column">
+              <box flexDirection="row">
+                <text fg={isSelected ? c.bg : undefined} bg={isSelected ? c.textBright : undefined}>
+                  <strong>{` ${opt.label} `}</strong>
+                </text>
+              </box>
+              {opt.description && isSelected && (
+                <box paddingLeft={3}>
+                  <text fg={c.dim}>{opt.description}</text>
+                </box>
+              )}
+            </box>
+          )
+        })}
+        {hiddenCount > 0 && (
+          <box paddingLeft={3}>
+            <text fg={c.dim}>and {hiddenCount} more…</text>
+          </box>
+        )}
+      </box>
+
+      <box flexDirection="column" marginBottom={1}>
+        {focusedSupportsEffort ? (
+          <text fg={c.dim}>
+            <span fg={c.accent}>{effortSymbol(displayEffort)}</span>{' '}
+            {capitalize(displayEffort)} effort
+            {displayEffort === focusedDefault ? ' (default)' : ''}{' '}
+            <span fg={c.muted}>\u2190 \u2192 to adjust</span>
+          </text>
+        ) : (
+          <text fg={c.muted}>
+            {effortSymbol(undefined)} Effort not supported
+            {focused?.label ? ` for ${focused.label}` : ''}
+          </text>
+        )}
+        {focused?.supports1M && is1MMarked ? (
+          <text fg={c.dim}>
+            <span fg={c.accent}>{effortSymbol('high')}</span> 1M context on
+            <span fg={c.muted}> · Space to toggle</span>
+          </text>
+        ) : (
+          <text fg={c.muted}>
+            {effortSymbol(undefined)} 1M context off
+            {focused?.label ? ` for ${focused.label}` : ''}
+          </text>
+        )}
+      </box>
+
+      {showFastModeNotice && fastModeModelDisplay && (
+        <box marginBottom={1}>
+          {fastModeOn ? (
+            <text fg={c.dim}>
+              Fast mode is <strong>ON</strong> and available with{' '}
+              {fastModeModelDisplay} only (/fast). Switching to other models
+              turns off fast mode.
+            </text>
+          ) : (
+            <text fg={c.dim}>
+              Use <strong>/fast</strong> to turn on Fast mode (
+              {fastModeModelDisplay} only).
+            </text>
+          )}
+        </box>
+      )}
+
+      <text fg={c.dim}>Enter to confirm · Esc to cancel</text>
+    </box>
+  )
+
+  if (!isStandaloneCommand) return body
+
+  return (
+    <box
+      position="absolute"
+      bottom={3}
+      left={1}
+      right={1}
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.accent}
+      paddingX={2}
+      paddingY={1}
+    >
+      {body}
+    </box>
+  )
+}

--- a/ui/src/components/NativeAutoUpdater.tsx
+++ b/ui/src/components/NativeAutoUpdater.tsx
@@ -1,0 +1,91 @@
+import React from 'react'
+import { c } from '../theme.js'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/NativeAutoUpdater.tsx`.
+ *
+ * The upstream component owns the full check→install lifecycle — it
+ * polls GCS, downloads the native installer, and reports progress. In
+ * Lite that work lives on the Rust side; the frontend only has to
+ * render whatever status the backend reports via
+ * `AutoUpdaterResult`. Parent passes the current snapshot; this
+ * component decides what (if anything) to show.
+ */
+
+export type AutoUpdaterResult = {
+  version: string | null
+  status: 'success' | 'install_failed' | 'checking' | 'up_to_date'
+}
+
+type Props = {
+  isUpdating: boolean
+  autoUpdaterResult: AutoUpdaterResult | null
+  /** Optional channel + current/latest version info surfaced only when
+   *  `verbose` is true, matching upstream's dev-mode display. */
+  verbose?: boolean
+  currentVersion?: string
+  latestVersion?: string
+  channel?: string
+  /** When true and the result is success, render the install banner. */
+  showSuccessMessage?: boolean
+  /** Optional max-version warning (shown to Anthropic-internal users
+   *  upstream). Passed through as-is here. */
+  maxVersionIssue?: string | null
+  showMaxVersionIssue?: boolean
+}
+
+export function NativeAutoUpdater({
+  isUpdating,
+  autoUpdaterResult,
+  verbose = false,
+  currentVersion,
+  latestVersion,
+  channel = 'latest',
+  showSuccessMessage = true,
+  maxVersionIssue = null,
+  showMaxVersionIssue = false,
+}: Props) {
+  const hasResult = !!autoUpdaterResult?.version
+  const hasVersionInfo = !!currentVersion && !!latestVersion
+  const shouldRender =
+    !!maxVersionIssue || hasResult || (isUpdating && hasVersionInfo)
+
+  if (!shouldRender) {
+    return null
+  }
+
+  return (
+    <box flexDirection="row" gap={1}>
+      {verbose && hasVersionInfo && (
+        <text fg={c.dim}>
+          current: {currentVersion} · {channel}: {latestVersion}
+        </text>
+      )}
+
+      {isUpdating && <text fg={c.dim}>Checking for updates</text>}
+
+      {!isUpdating &&
+        autoUpdaterResult?.status === 'success' &&
+        showSuccessMessage &&
+        autoUpdaterResult.version && (
+          <text fg={c.success}>
+            \u2713 Update installed · Restart to update
+          </text>
+        )}
+
+      {autoUpdaterResult?.status === 'install_failed' && (
+        <text fg={c.error}>
+          \u2717 Auto-update failed · Try <strong>/status</strong>
+        </text>
+      )}
+
+      {maxVersionIssue && showMaxVersionIssue && (
+        <text fg={c.warning}>
+          \u26A0 Known issue: {maxVersionIssue} · Run{' '}
+          <strong>claude rollback --safe</strong> to downgrade
+        </text>
+      )}
+    </box>
+  )
+}

--- a/ui/src/components/NotebookEditToolUseRejectedMessage.tsx
+++ b/ui/src/components/NotebookEditToolUseRejectedMessage.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { c } from '../theme.js'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/NotebookEditToolUseRejectedMessage.tsx`.
+ *
+ * Rendered when the user rejects a NotebookEdit tool invocation. The
+ * upstream uses `HighlightedCode` to show the (would-have-been-inserted)
+ * cell source; OpenTUI's `<code>` primitive provides the equivalent
+ * syntax-highlighted block.
+ */
+
+type EditMode = 'replace' | 'insert' | 'delete'
+type CellType = 'code' | 'markdown'
+
+type Props = {
+  notebookPath: string
+  cellId?: string
+  newSource: string
+  cellType?: CellType
+  editMode?: EditMode
+  /** When true, render the full path instead of a cwd-relative form. */
+  verbose?: boolean
+  /** Optional cwd used to relativise `notebookPath` when `!verbose`. */
+  cwd?: string
+}
+
+function relativePath(from: string | undefined, to: string): string {
+  if (!from) return to
+  if (to.startsWith(from)) {
+    const rest = to.slice(from.length)
+    return rest.replace(/^[\\/]+/, '') || to
+  }
+  return to
+}
+
+function cellLanguage(cellType: CellType | undefined): string {
+  return cellType === 'markdown' ? 'markdown' : 'python'
+}
+
+export function NotebookEditToolUseRejectedMessage({
+  notebookPath,
+  cellId,
+  newSource,
+  cellType,
+  editMode = 'replace',
+  verbose = false,
+  cwd,
+}: Props) {
+  const operation = editMode === 'delete' ? 'delete' : `${editMode} cell in`
+  const displayPath = verbose ? notebookPath : relativePath(cwd, notebookPath)
+
+  return (
+    <box flexDirection="column" paddingX={1} marginBottom={1}>
+      <box flexDirection="row">
+        <text fg={c.dim}>User rejected {operation} </text>
+        <strong>
+          <text fg={c.dim}>{displayPath}</text>
+        </strong>
+        {cellId && <text fg={c.dim}> at cell {cellId}</text>}
+      </box>
+      {editMode !== 'delete' && newSource.length > 0 && (
+        <box marginTop={1} flexDirection="column">
+          <code code={newSource} language={cellLanguage(cellType)} />
+        </box>
+      )}
+    </box>
+  )
+}

--- a/ui/src/components/OffscreenFreeze.tsx
+++ b/ui/src/components/OffscreenFreeze.tsx
@@ -1,0 +1,30 @@
+import React, { useRef } from 'react'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/OffscreenFreeze.tsx`.
+ *
+ * Upstream freezes a subtree when it scrolls above the viewport so
+ * timer-driven spinners don't force the Ink log-updater into a full
+ * terminal reset on every tick.
+ *
+ * OpenTUI's scrollbox clips inside the viewport (no terminal scrollback
+ * to freeze against), so the visibility hook upstream uses
+ * (`useTerminalViewport`) has no analogue here. The component becomes a
+ * passthrough — the cache is retained as a best-effort `ref` so the
+ * shape of the component matches upstream in case a future OpenTUI
+ * viewport hook is wired in.
+ */
+
+type Props = {
+  children: React.ReactNode
+}
+
+export function OffscreenFreeze({ children }: Props) {
+  // Keep the last rendered children in a ref so the shape matches the
+  // upstream cache-and-return contract, even though OpenTUI renders
+  // every tick inside the scrollbox viewport.
+  const cached = useRef(children)
+  cached.current = children
+  return <box>{cached.current}</box>
+}

--- a/ui/src/components/Onboarding.tsx
+++ b/ui/src/components/Onboarding.tsx
@@ -1,0 +1,151 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../theme.js'
+import { OrderedList } from './OrderedList.js'
+import { PressEnterToContinue } from './PressEnterToContinue.js'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/Onboarding.tsx`.
+ *
+ * Upstream sequences preflight / theme / OAuth / API-key / security /
+ * terminal-setup steps behind a stack of Ink dialogs. The Lite frontend
+ * doesn't ship those dependencies (the Rust backend owns OAuth, theme
+ * persistence, and terminal setup), so this port retains the step
+ * machinery and renders:
+ *   - a welcome banner,
+ *   - an injected theme step if the caller provides one,
+ *   - the fixed security step,
+ *   - a press-Enter-to-finish gate.
+ *
+ * Additional steps are passed through `extraSteps` so projects can
+ * compose OAuth / terminal prompts without bloating the Lite build.
+ */
+
+export type OnboardingStep = {
+  id: string
+  render: (ctx: { next: () => void; exit: () => void }) => React.ReactNode
+}
+
+type Props = {
+  onDone: () => void
+  /** Steps inserted between the theme step and the security step. */
+  extraSteps?: OnboardingStep[]
+  /** Custom theme step (usually a `<ThemePicker onSelect>` wrapper).
+   *  When omitted, the theme step is skipped. */
+  themeStep?: OnboardingStep
+  /** Shown in the banner; defaults to the Claude Code ASCII logo. */
+  banner?: React.ReactNode
+}
+
+const DEFAULT_BANNER = (
+  <box flexDirection="column" alignItems="center">
+    <strong>
+      <text fg={c.accent}>Welcome to Claude Code</text>
+    </strong>
+    <text fg={c.dim}>Terminal-native coding assistant</text>
+  </box>
+)
+
+export function Onboarding({ onDone, extraSteps = [], themeStep, banner }: Props) {
+  const steps = useMemo<OnboardingStep[]>(() => {
+    const list: OnboardingStep[] = []
+    if (themeStep) list.push(themeStep)
+    list.push(...extraSteps)
+    list.push({ id: 'security', render: ({ next }) => <SecurityStep onContinue={next} /> })
+    return list
+  }, [themeStep, extraSteps])
+
+  const [current, setCurrent] = useState(0)
+
+  const next = useCallback(() => {
+    setCurrent(idx => {
+      if (idx + 1 >= steps.length) {
+        onDone()
+        return idx
+      }
+      return idx + 1
+    })
+  }, [steps.length, onDone])
+
+  const exit = useCallback(() => {
+    onDone()
+  }, [onDone])
+
+  const step = steps[current]
+
+  return (
+    <box flexDirection="column">
+      {banner ?? DEFAULT_BANNER}
+      <box flexDirection="column" marginTop={1}>
+        {step?.render({ next, exit })}
+      </box>
+    </box>
+  )
+}
+
+function SecurityStep({ onContinue }: { onContinue: () => void }) {
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    const id = setTimeout(() => setReady(true), 0)
+    return () => clearTimeout(id)
+  }, [])
+
+  useKeyboard((event: KeyEvent) => {
+    if (!ready || event.eventType === 'release') return
+    if (event.name === 'return' || event.name === 'enter') {
+      onContinue()
+    }
+  })
+
+  return (
+    <box flexDirection="column" gap={1} paddingLeft={1}>
+      <strong>
+        <text>Security notes:</text>
+      </strong>
+      <box flexDirection="column" width={70}>
+        <OrderedList>
+          <OrderedList.Item>
+            <text>Claude can make mistakes</text>
+            <text fg={c.dim}>
+              You should always review Claude&apos;s responses, especially when
+              running code.
+            </text>
+          </OrderedList.Item>
+          <OrderedList.Item>
+            <text>
+              Due to prompt injection risks, only use it with code you trust
+            </text>
+            <text fg={c.dim}>
+              For more details see the Claude Code security docs.
+            </text>
+          </OrderedList.Item>
+        </OrderedList>
+      </box>
+      <PressEnterToContinue />
+    </box>
+  )
+}
+
+/**
+ * Optional wrapper that skips a step when `skip` flips true — matches
+ * the upstream `SkippableStep` helper so call sites composing
+ * `extraSteps` can pipe existing logic through.
+ */
+export function SkippableStep({
+  skip,
+  onSkip,
+  children,
+}: {
+  skip: boolean
+  onSkip: () => void
+  children: React.ReactNode
+}) {
+  useEffect(() => {
+    if (skip) onSkip()
+  }, [skip, onSkip])
+  if (skip) return null
+  return <>{children}</>
+}

--- a/ui/src/components/OutputStylePicker.tsx
+++ b/ui/src/components/OutputStylePicker.tsx
@@ -1,0 +1,138 @@
+import React, { useEffect, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../theme.js'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/OutputStylePicker.tsx`.
+ *
+ * Upstream loads output styles via `getAllOutputStyles(getCwd())` which
+ * reaches into `src/constants/outputStyles` — not compiled into the
+ * Lite frontend. Consumers pass the available styles directly; the
+ * component renders the picker chrome and routes the selection.
+ */
+
+export type OutputStyleOption = {
+  value: string
+  label: string
+  description?: string
+}
+
+type Props = {
+  initialStyle: string
+  options?: OutputStyleOption[]
+  isLoading?: boolean
+  onComplete: (style: string) => void
+  onCancel: () => void
+  isStandaloneCommand?: boolean
+}
+
+const DEFAULT_OPTIONS: OutputStyleOption[] = [
+  {
+    value: 'default',
+    label: 'Default',
+    description:
+      'Claude completes coding tasks efficiently and provides concise responses',
+  },
+]
+
+export function OutputStylePicker({
+  initialStyle,
+  options = DEFAULT_OPTIONS,
+  isLoading = false,
+  onComplete,
+  onCancel,
+  isStandaloneCommand = false,
+}: Props) {
+  const list = options.length > 0 ? options : DEFAULT_OPTIONS
+  const initialIndex = Math.max(
+    0,
+    list.findIndex(o => o.value === initialStyle),
+  )
+  const [selected, setSelected] = useState(initialIndex)
+
+  useEffect(() => {
+    const next = Math.max(0, list.findIndex(o => o.value === initialStyle))
+    setSelected(next)
+  }, [initialStyle, list])
+
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release' || isLoading) return
+    const name = event.name
+    const seq = event.sequence?.length === 1 ? event.sequence : undefined
+    const key = (seq ?? name ?? '').toLowerCase()
+
+    if (name === 'escape') {
+      onCancel()
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      const opt = list[selected]
+      if (opt) onComplete(opt.value)
+      return
+    }
+    if (name === 'up' || key === 'k') {
+      setSelected(idx => Math.max(0, idx - 1))
+      return
+    }
+    if (name === 'down' || key === 'j') {
+      setSelected(idx => Math.min(list.length - 1, idx + 1))
+    }
+  })
+
+  const chrome = (
+    <box flexDirection="column" gap={1}>
+      <strong>
+        <text fg={c.accent}>Preferred output style</text>
+      </strong>
+      <text fg={c.dim}>
+        This changes how Claude Code communicates with you
+      </text>
+      {isLoading ? (
+        <text fg={c.dim}>Loading output styles…</text>
+      ) : (
+        <box flexDirection="column">
+          {list.map((opt, i) => {
+            const isSelected = i === selected
+            return (
+              <box key={opt.value} flexDirection="column">
+                <box flexDirection="row">
+                  <text fg={isSelected ? c.bg : undefined} bg={isSelected ? c.textBright : undefined}>
+                    <strong>{` ${opt.label} `}</strong>
+                  </text>
+                </box>
+                {opt.description && (
+                  <box paddingLeft={3}>
+                    <text fg={c.dim}>{opt.description}</text>
+                  </box>
+                )}
+              </box>
+            )
+          })}
+        </box>
+      )}
+      <text fg={c.dim}>Enter to confirm · Esc to cancel</text>
+    </box>
+  )
+
+  if (!isStandaloneCommand) {
+    return chrome
+  }
+
+  return (
+    <box
+      position="absolute"
+      bottom={3}
+      left={1}
+      right={1}
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.accent}
+      paddingX={2}
+      paddingY={1}
+    >
+      {chrome}
+    </box>
+  )
+}

--- a/ui/src/components/PackageManagerAutoUpdater.tsx
+++ b/ui/src/components/PackageManagerAutoUpdater.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import { c } from '../theme.js'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/PackageManagerAutoUpdater.tsx`.
+ *
+ * Upstream polls GCS every 30 min and shows a "Run `brew upgrade …`"
+ * nudge when a newer version is available. The Lite frontend has no
+ * auto-update plumbing (the Rust side handles distribution), so the
+ * component is purely declarative — the parent passes the detected
+ * package manager + new version and the nudge renders. When no update
+ * is pending the component renders `null`, matching upstream.
+ */
+
+export type PackageManager =
+  | 'homebrew'
+  | 'winget'
+  | 'apk'
+  | 'unknown'
+  | 'npm'
+  | 'pnpm'
+  | 'yarn'
+  | 'bun'
+
+type Props = {
+  /** When unset / false no nudge renders. */
+  updateAvailable?: boolean
+  packageManager?: PackageManager
+  /** Currently-installed version (shown when `verbose`). */
+  currentVersion?: string
+  latestVersion?: string
+  verbose?: boolean
+}
+
+function updateCommand(pm: PackageManager | undefined): string {
+  switch (pm) {
+    case 'homebrew':
+      return 'brew upgrade claude-code'
+    case 'winget':
+      return 'winget upgrade Anthropic.ClaudeCode'
+    case 'apk':
+      return 'apk upgrade claude-code'
+    case 'npm':
+      return 'npm install -g @anthropic-ai/claude-code'
+    case 'pnpm':
+      return 'pnpm up -g @anthropic-ai/claude-code'
+    case 'yarn':
+      return 'yarn global upgrade @anthropic-ai/claude-code'
+    case 'bun':
+      return 'bun update -g @anthropic-ai/claude-code'
+    default:
+      return 'your package manager update command'
+  }
+}
+
+export function PackageManagerAutoUpdater({
+  updateAvailable,
+  packageManager,
+  currentVersion,
+  latestVersion,
+  verbose = false,
+}: Props) {
+  if (!updateAvailable) {
+    return null
+  }
+
+  return (
+    <box flexDirection="row" gap={1}>
+      {verbose && currentVersion && (
+        <text fg={c.dim}>
+          currentVersion: {currentVersion}
+          {latestVersion ? ` \u2192 ${latestVersion}` : ''}
+        </text>
+      )}
+      <text fg={c.warning}>
+        Update available! Run:{' '}
+        <strong>{updateCommand(packageManager)}</strong>
+      </text>
+    </box>
+  )
+}

--- a/ui/src/components/PrBadge.tsx
+++ b/ui/src/components/PrBadge.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { c } from '../theme.js'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/PrBadge.tsx`.
+ *
+ * Renders a `PR #123` label colour-coded by review state. Upstream's
+ * `Link` (OSC 8 hyperlink) is reproduced with the same escape sequence
+ * used by `FilePathLink` — terminals that don't support OSC 8 still get
+ * the styled text.
+ */
+
+export type PrReviewState =
+  | 'approved'
+  | 'changes_requested'
+  | 'pending'
+  | 'merged'
+
+type Props = {
+  number: number
+  url: string
+  reviewState?: PrReviewState
+  bold?: boolean
+}
+
+const COLOR_FOR_STATE: Record<PrReviewState, string> = {
+  approved: c.success,
+  changes_requested: c.error,
+  pending: c.warning,
+  merged: c.accent,
+}
+
+function osc8(url: string, text: string): string {
+  return `\x1b]8;;${url}\x1b\\${text}\x1b]8;;\x1b\\`
+}
+
+export function PrBadge({ number, url, reviewState, bold }: Props) {
+  const stateColor = reviewState ? COLOR_FOR_STATE[reviewState] : undefined
+  const labelColor = stateColor ?? (bold ? c.text : c.dim)
+  const prefixColor = bold ? c.text : c.dim
+
+  const label = `#${number}`
+  const linked = osc8(url, label)
+
+  return (
+    <text>
+      <span fg={prefixColor}>PR </span>
+      {bold ? (
+        <strong>
+          <span fg={labelColor}>{linked}</span>
+        </strong>
+      ) : (
+        <span fg={labelColor}>{linked}</span>
+      )}
+    </text>
+  )
+}

--- a/ui/src/components/QuickOpenDialog.tsx
+++ b/ui/src/components/QuickOpenDialog.tsx
@@ -1,0 +1,207 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../theme.js'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/QuickOpenDialog.tsx`.
+ *
+ * Upstream depends on `FuzzyPicker` + `generateFileSuggestions` +
+ * `readFileInRange` out of the Ink stack. The Lite frontend delegates
+ * search + preview to the caller through the `search` / `previewFor`
+ * async handlers. The dialog takes care of input, keyboard navigation,
+ * and routing the final `open` / `insert` action — matching the
+ * upstream shortcuts (Enter = open, Tab = mention, Shift+Tab = insert).
+ */
+
+type Result = string
+
+type Props = {
+  onDone: () => void
+  onInsert: (text: string) => void
+  /** Returns a ranked list of paths for the given query. Called on every
+   *  keystroke (debounced by the upstream indexer in production). */
+  search: (query: string) => Promise<Result[]>
+  /** Returns the first N lines of a file for the preview pane. */
+  previewFor: (path: string) => Promise<string>
+  /** Called when the user confirms Enter on a result. Lite forwards to
+   *  an external editor — upstream opens the file in $EDITOR. */
+  onOpen?: (path: string) => void
+  /** Total rows visible in the results pane. */
+  visibleResults?: number
+  /** Lines of preview text shown next to/below the results. */
+  previewLines?: number
+}
+
+const DEFAULT_VISIBLE = 8
+const DEFAULT_PREVIEW_LINES = 20
+
+export function QuickOpenDialog({
+  onDone,
+  onInsert,
+  onOpen,
+  search,
+  previewFor,
+  visibleResults = DEFAULT_VISIBLE,
+  previewLines = DEFAULT_PREVIEW_LINES,
+}: Props) {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<Result[]>([])
+  const [selected, setSelected] = useState(0)
+  const [preview, setPreview] = useState<{ path: string; content: string } | null>(
+    null,
+  )
+  const generationRef = useRef(0)
+
+  useEffect(() => {
+    const gen = ++generationRef.current
+    if (!query.trim()) {
+      setResults([])
+      setSelected(0)
+      return
+    }
+    let cancelled = false
+    void search(query).then(items => {
+      if (cancelled || gen !== generationRef.current) return
+      setResults(items)
+      setSelected(0)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [query, search])
+
+  useEffect(() => {
+    const focused = results[selected]
+    if (!focused) {
+      setPreview(null)
+      return
+    }
+    let cancelled = false
+    void previewFor(focused)
+      .then(content => {
+        if (!cancelled) setPreview({ path: focused, content })
+      })
+      .catch(() => {
+        if (!cancelled) setPreview({ path: focused, content: '(preview unavailable)' })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [results, selected, previewFor])
+
+  const handleOpen = useCallback(
+    (path: string) => {
+      onOpen?.(path)
+      onDone()
+    },
+    [onOpen, onDone],
+  )
+
+  const handleInsert = useCallback(
+    (path: string, mention: boolean) => {
+      onInsert(mention ? `@${path} ` : `${path} `)
+      onDone()
+    },
+    [onInsert, onDone],
+  )
+
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const seq = event.sequence
+    const lower = (seq?.length === 1 ? seq : name ?? '').toLowerCase()
+
+    if (name === 'escape') {
+      onDone()
+      return
+    }
+    if (name === 'up' || (lower === 'p' && event.ctrl)) {
+      setSelected(idx => Math.max(0, idx - 1))
+      return
+    }
+    if (name === 'down' || (lower === 'n' && event.ctrl)) {
+      setSelected(idx => Math.min(Math.max(results.length - 1, 0), idx + 1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      const r = results[selected]
+      if (r) handleOpen(r)
+      return
+    }
+    if (name === 'tab') {
+      const r = results[selected]
+      if (r) handleInsert(r, !event.shift)
+      return
+    }
+    if (name === 'backspace' || name === 'delete') {
+      setQuery(q => q.slice(0, -1))
+      return
+    }
+    if (seq && seq.length === 1 && !event.ctrl && !event.meta) {
+      setQuery(q => q + seq)
+    }
+  })
+
+  const slice = results.slice(0, visibleResults)
+  const previewSlice = preview?.content.split('\n').slice(0, previewLines) ?? []
+  const emptyMessage = query ? 'No matching files' : 'Start typing to search…'
+
+  return (
+    <box
+      position="absolute"
+      bottom={3}
+      left={1}
+      right={1}
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.accent}
+      paddingX={2}
+      paddingY={1}
+    >
+      <strong>
+        <text fg={c.accent}>Quick Open</text>
+      </strong>
+      <box flexDirection="row" marginTop={1}>
+        <text fg={c.dim}>Search: </text>
+        <text>{query}</text>
+        <text fg={c.accent}>{'\u2588'}</text>
+      </box>
+
+      <box flexDirection="column" marginTop={1} paddingLeft={1}>
+        {slice.length === 0 ? (
+          <text fg={c.dim}>{emptyMessage}</text>
+        ) : (
+          slice.map((p, i) => {
+            const isSelected = i === selected
+            return (
+              <box key={p} flexDirection="row">
+                <text fg={isSelected ? c.bg : undefined} bg={isSelected ? c.info : undefined}>
+                  {isSelected ? '\u276F ' : '  '}
+                  {p}
+                </text>
+              </box>
+            )
+          })
+        )}
+      </box>
+
+      {preview && (
+        <box flexDirection="column" marginTop={1} paddingLeft={1}>
+          <text fg={c.dim}>Preview: {preview.path}</text>
+          {previewSlice.map((line, i) => (
+            <text key={i} fg={c.text}>{line}</text>
+          ))}
+        </box>
+      )}
+
+      <box marginTop={1}>
+        <text fg={c.dim}>
+          Enter to open · Tab to mention (@path) · Shift+Tab to insert · Esc to
+          cancel
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/RemoteCallout.tsx
+++ b/ui/src/components/RemoteCallout.tsx
@@ -1,0 +1,137 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../theme.js'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/RemoteCallout.tsx`.
+ *
+ * First-time prompt that asks whether to enable Remote Control (the
+ * claude.ai/code bridge). Upstream also writes `remoteDialogSeen` to
+ * the global config on mount — the Lite build surfaces that side-effect
+ * through the optional `onSeen` callback so the caller can persist.
+ */
+
+export type RemoteCalloutSelection = 'enable' | 'dismiss'
+
+type Option = {
+  value: RemoteCalloutSelection
+  label: string
+  description: string
+  hotkey: string
+}
+
+const OPTIONS: Option[] = [
+  {
+    value: 'enable',
+    label: 'Enable Remote Control for this session',
+    description: 'Opens a secure connection to claude.ai.',
+    hotkey: 'y',
+  },
+  {
+    value: 'dismiss',
+    label: 'Never mind',
+    description: 'You can always enable it later with /remote-control.',
+    hotkey: 'n',
+  },
+]
+
+type Props = {
+  onDone: (selection: RemoteCalloutSelection) => void
+  /** Invoked once when the callout first mounts so the caller can
+   *  persist `remoteDialogSeen` (upstream wrote directly to config). */
+  onSeen?: () => void
+}
+
+export function RemoteCallout({ onDone, onSeen }: Props) {
+  const [selected, setSelected] = useState(0)
+
+  React.useEffect(() => {
+    onSeen?.()
+  }, [onSeen])
+
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const seq = event.sequence?.length === 1 ? event.sequence : undefined
+    const key = (seq ?? name ?? '').toLowerCase()
+
+    if (name === 'escape') {
+      onDone('dismiss')
+      return
+    }
+    if (key) {
+      const hit = OPTIONS.findIndex(o => o.hotkey === key)
+      if (hit >= 0) {
+        onDone(OPTIONS[hit]!.value)
+        return
+      }
+    }
+    if (name === 'up' || key === 'k') {
+      setSelected(idx => Math.max(0, idx - 1))
+      return
+    }
+    if (name === 'down' || key === 'j') {
+      setSelected(idx => Math.min(OPTIONS.length - 1, idx + 1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      onDone(OPTIONS[selected]!.value)
+    }
+  })
+
+  return (
+    <box
+      position="absolute"
+      bottom={3}
+      left={1}
+      right={1}
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.warning}
+      paddingX={2}
+      paddingY={1}
+    >
+      <strong>
+        <text fg={c.warning}>Remote Control</text>
+      </strong>
+
+      <box flexDirection="column" marginTop={1}>
+        <text>
+          Remote Control lets you access this CLI session from the web
+          (claude.ai/code) or the Claude app, so you can pick up where you
+          left off on any device.
+        </text>
+        <text> </text>
+        <text>
+          You can disconnect remote access anytime by running /remote-control
+          again.
+        </text>
+      </box>
+
+      <box flexDirection="column" marginTop={1}>
+        {OPTIONS.map((opt, i) => {
+          const isSelected = i === selected
+          return (
+            <box key={opt.value} flexDirection="column">
+              <box flexDirection="row">
+                <text fg={isSelected ? c.bg : undefined} bg={isSelected ? c.textBright : undefined}>
+                  <strong>{` ${opt.label} `}</strong>
+                </text>
+                <text fg={c.dim}> ({opt.hotkey})</text>
+              </box>
+              <box paddingLeft={3}>
+                <text fg={c.dim}>{opt.description}</text>
+              </box>
+            </box>
+          )
+        })}
+      </box>
+
+      <box marginTop={1}>
+        <text fg={c.dim}>Enter to confirm · Esc to dismiss</text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/RemoteEnvironmentDialog.tsx
+++ b/ui/src/components/RemoteEnvironmentDialog.tsx
@@ -1,0 +1,203 @@
+import React, { useEffect, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../theme.js'
+import { Spinner } from './Spinner.js'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/RemoteEnvironmentDialog.tsx`.
+ *
+ * Shows the list of teleport remote environments, the current
+ * selection, and lets the user pick a new default. Upstream loads the
+ * list through `getEnvironmentSelectionInfo()` and persists via
+ * `updateSettingsForSource`. The Lite port accepts those handlers so
+ * the caller can bind whichever backend IPC route is appropriate.
+ */
+
+export type EnvironmentResource = {
+  environment_id: string
+  name: string
+}
+
+export type EnvironmentSelectionInfo = {
+  availableEnvironments: EnvironmentResource[]
+  selectedEnvironment: EnvironmentResource | null
+  /** Optional source suffix (e.g. "managed settings"), appended when
+   *  the active selection isn't from local settings. */
+  selectedEnvironmentSourceLabel?: string
+}
+
+type Props = {
+  /** Invoked on mount to fetch the environment list. */
+  loader: () => Promise<EnvironmentSelectionInfo>
+  /** Persists the user's selection. */
+  onSelect: (env: EnvironmentResource) => void | Promise<void>
+  /** Called when the user cancels or confirms. `message` is an optional
+   *  status banner the caller can echo (e.g. into the command menu). */
+  onDone: (message?: string) => void
+}
+
+const DIALOG_TITLE = 'Select Remote Environment'
+const SETUP_HINT = 'Configure environments at: claude.ai/code'
+
+export function RemoteEnvironmentDialog({ loader, onSelect, onDone }: Props) {
+  const [state, setState] = useState<
+    | { kind: 'loading' }
+    | { kind: 'ready'; info: EnvironmentSelectionInfo }
+    | { kind: 'error'; message: string }
+    | { kind: 'updating' }
+  >({ kind: 'loading' })
+  const [selectedIdx, setSelectedIdx] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+    void loader()
+      .then(info => {
+        if (cancelled) return
+        const idx = Math.max(
+          0,
+          info.availableEnvironments.findIndex(
+            env => env.environment_id === info.selectedEnvironment?.environment_id,
+          ),
+        )
+        setSelectedIdx(idx)
+        setState({ kind: 'ready', info })
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        setState({
+          kind: 'error',
+          message: err instanceof Error ? err.message : String(err),
+        })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [loader])
+
+  const commit = (env: EnvironmentResource) => {
+    setState({ kind: 'updating' })
+    void Promise.resolve(onSelect(env))
+      .then(() => onDone(`Set default remote environment to ${env.name} (${env.environment_id})`))
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err)
+        onDone(`Error updating environment: ${message}`)
+      })
+  }
+
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const seq = event.sequence?.length === 1 ? event.sequence : undefined
+    const key = (seq ?? name ?? '').toLowerCase()
+
+    if (name === 'escape') {
+      onDone()
+      return
+    }
+    if (state.kind !== 'ready') return
+    const envs = state.info.availableEnvironments
+    if (envs.length === 0) {
+      if (name === 'return' || name === 'enter') onDone()
+      return
+    }
+    if (name === 'up' || key === 'k') {
+      setSelectedIdx(idx => Math.max(0, idx - 1))
+      return
+    }
+    if (name === 'down' || key === 'j') {
+      setSelectedIdx(idx => Math.min(envs.length - 1, idx + 1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      const target = envs[selectedIdx]
+      if (target) commit(target)
+    }
+  })
+
+  const body = (() => {
+    if (state.kind === 'loading') {
+      return <Spinner label="Loading environments…" />
+    }
+    if (state.kind === 'updating') {
+      return <Spinner label="Updating…" />
+    }
+    if (state.kind === 'error') {
+      return <text fg={c.error}>Error: {state.message}</text>
+    }
+    const { info } = state
+    const envs = info.availableEnvironments
+    if (envs.length === 0 || !info.selectedEnvironment) {
+      return <text>No remote environments available.</text>
+    }
+    if (envs.length === 1) {
+      const env = envs[0]!
+      return (
+        <box flexDirection="column">
+          <text>
+            <span fg={c.success}>\u2713</span> Using <strong>{env.name}</strong>{' '}
+            <span fg={c.dim}>({env.environment_id})</span>
+          </text>
+          <box marginTop={1}>
+            <text fg={c.dim}>{SETUP_HINT}</text>
+          </box>
+          <box marginTop={1}>
+            <text fg={c.dim}>Enter to continue · Esc to cancel</text>
+          </box>
+        </box>
+      )
+    }
+    const suffix = info.selectedEnvironmentSourceLabel
+      ? ` (from ${info.selectedEnvironmentSourceLabel} settings)`
+      : ''
+    return (
+      <box flexDirection="column">
+        <text>
+          Currently using: <strong>{info.selectedEnvironment.name}</strong>
+          {suffix}
+        </text>
+        <box marginTop={1}>
+          <text fg={c.dim}>{SETUP_HINT}</text>
+        </box>
+        <box marginTop={1} flexDirection="column">
+          {envs.map((env, i) => {
+            const isSelected = i === selectedIdx
+            return (
+              <box key={env.environment_id} flexDirection="row">
+                <text fg={isSelected ? c.bg : undefined} bg={isSelected ? c.textBright : undefined}>
+                  <strong>{` ${env.name} `}</strong>
+                </text>
+                <text fg={c.dim}> ({env.environment_id})</text>
+              </box>
+            )
+          })}
+        </box>
+        <box marginTop={1}>
+          <text fg={c.dim}>\u2191/\u2193 to select · Enter to confirm · Esc to cancel</text>
+        </box>
+      </box>
+    )
+  })()
+
+  return (
+    <box
+      position="absolute"
+      bottom={3}
+      left={1}
+      right={1}
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.accent}
+      paddingX={2}
+      paddingY={1}
+    >
+      <strong>
+        <text fg={c.accent}>{DIALOG_TITLE}</text>
+      </strong>
+      <box marginTop={1} flexDirection="column">
+        {body}
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/ResumeTask.tsx
+++ b/ui/src/components/ResumeTask.tsx
@@ -1,0 +1,288 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../theme.js'
+import { Spinner } from './Spinner.js'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/ResumeTask.tsx`.
+ *
+ * Fetches recent Claude Code sessions for the current repo, shows them
+ * in a padded list, and lets the user pick one to resume. Upstream
+ * reaches through `src/utils/teleport/api.ts` + `detectRepository`;
+ * the Lite port lifts those out into `loader` so the component can be
+ * reused regardless of how sessions are discovered.
+ */
+
+export type CodeSession = {
+  id: string
+  title: string
+  updated_at: string
+  repo?: {
+    owner: { login: string }
+    name: string
+  } | null
+}
+
+type LoadErrorType = 'network' | 'auth' | 'api' | 'other'
+
+type Props = {
+  onSelect: (session: CodeSession) => void
+  onCancel: () => void
+  loader: () => Promise<CodeSession[]>
+  /** Current repository hint (e.g. `owner/name`) used in the title. */
+  currentRepo?: string | null
+  /** Compact mode — used by the embedded `/resume` picker. */
+  isEmbedded?: boolean
+}
+
+const UPDATED_STRING = 'Updated'
+const COL_SEP = '  '
+
+function formatRelative(date: Date): string {
+  const diff = Date.now() - date.getTime()
+  if (diff < 0) return 'now'
+  const minutes = Math.floor(diff / 60_000)
+  if (minutes < 1) return 'just now'
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days}d ago`
+  const months = Math.floor(days / 30)
+  if (months < 12) return `${months}mo ago`
+  const years = Math.floor(months / 12)
+  return `${years}y ago`
+}
+
+function classifyError(message: string): LoadErrorType {
+  const m = message.toLowerCase()
+  if (m.includes('fetch') || m.includes('network') || m.includes('timeout')) {
+    return 'network'
+  }
+  if (
+    m.includes('auth') ||
+    m.includes('token') ||
+    m.includes('permission') ||
+    m.includes('oauth') ||
+    m.includes('/login') ||
+    m.includes('403')
+  ) {
+    return 'auth'
+  }
+  if (
+    m.includes('api') ||
+    m.includes('rate limit') ||
+    m.includes('500') ||
+    m.includes('529')
+  ) {
+    return 'api'
+  }
+  return 'other'
+}
+
+function ErrorGuidance({ kind }: { kind: LoadErrorType }) {
+  switch (kind) {
+    case 'network':
+      return <text fg={c.dim}>Check your internet connection</text>
+    case 'auth':
+      return (
+        <box flexDirection="column">
+          <text fg={c.dim}>Teleport requires a Claude account</text>
+          <text fg={c.dim}>
+            Run <strong>/login</strong> and select &quot;Claude account with
+            subscription&quot;
+          </text>
+        </box>
+      )
+    case 'api':
+      return <text fg={c.dim}>Sorry, Claude encountered an error</text>
+    case 'other':
+    default:
+      return <text fg={c.dim}>Sorry, Claude Code encountered an error</text>
+  }
+}
+
+export function ResumeTask({
+  onSelect,
+  onCancel,
+  loader,
+  currentRepo,
+  isEmbedded = false,
+}: Props) {
+  const [sessions, setSessions] = useState<CodeSession[]>([])
+  const [loading, setLoading] = useState(true)
+  const [errorKind, setErrorKind] = useState<LoadErrorType | null>(null)
+  const [selected, setSelected] = useState(0)
+  const [retrying, setRetrying] = useState(false)
+
+  const load = useCallback(() => {
+    setLoading(true)
+    setErrorKind(null)
+    loader()
+      .then(result => {
+        const sorted = [...result].sort(
+          (a, b) =>
+            new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+        )
+        setSessions(sorted)
+        setSelected(0)
+      })
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err)
+        setErrorKind(classifyError(message))
+      })
+      .finally(() => {
+        setLoading(false)
+        setRetrying(false)
+      })
+  }, [loader])
+
+  useEffect(load, [load])
+
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const seq = event.sequence?.length === 1 ? event.sequence : undefined
+    const key = (seq ?? name ?? '').toLowerCase()
+
+    if (name === 'escape') {
+      onCancel()
+      return
+    }
+    if (errorKind !== null) {
+      if (event.ctrl && key === 'r') {
+        setRetrying(true)
+        load()
+        return
+      }
+      if (name === 'return' || name === 'enter') {
+        onCancel()
+      }
+      return
+    }
+    if (sessions.length === 0) return
+    if (name === 'up' || key === 'k') {
+      setSelected(idx => Math.max(0, idx - 1))
+      return
+    }
+    if (name === 'down' || key === 'j') {
+      setSelected(idx => Math.min(sessions.length - 1, idx + 1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      const target = sessions[selected]
+      if (target) onSelect(target)
+    }
+  })
+
+  if (loading) {
+    return (
+      <box flexDirection="column" padding={1}>
+        <box flexDirection="row">
+          <Spinner label="Loading Claude Code sessions…" />
+        </box>
+        <text fg={c.dim}>
+          {retrying ? 'Retrying…' : 'Fetching your Claude Code sessions…'}
+        </text>
+      </box>
+    )
+  }
+
+  if (errorKind) {
+    return (
+      <box flexDirection="column" padding={1}>
+        <strong>
+          <text fg={c.error}>Error loading Claude Code sessions</text>
+        </strong>
+        <box marginY={1} flexDirection="column">
+          <ErrorGuidance kind={errorKind} />
+        </box>
+        <text fg={c.dim}>
+          Press <strong>Ctrl+R</strong> to retry · Press <strong>Esc</strong> to
+          cancel
+        </text>
+      </box>
+    )
+  }
+
+  if (sessions.length === 0) {
+    return (
+      <box flexDirection="column" padding={1}>
+        <strong>
+          <text>
+            No Claude Code sessions found
+            {currentRepo ? ` for ${currentRepo}` : ''}
+          </text>
+        </strong>
+        <box marginTop={1}>
+          <text fg={c.dim}>
+            Press <strong>Esc</strong> to cancel
+          </text>
+        </box>
+      </box>
+    )
+  }
+
+  const metadata = sessions.map(s => ({
+    ...s,
+    relative: formatRelative(new Date(s.updated_at)),
+  }))
+  const colWidth = Math.max(
+    UPDATED_STRING.length,
+    ...metadata.map(m => m.relative.length),
+  )
+  const header = `${UPDATED_STRING.padEnd(colWidth, ' ')}${COL_SEP}Session Title`
+
+  const visibleCount = isEmbedded
+    ? Math.min(5, metadata.length)
+    : Math.min(20, metadata.length)
+  const startIdx = Math.max(
+    0,
+    Math.min(selected - Math.floor(visibleCount / 2), metadata.length - visibleCount),
+  )
+  const slice = metadata.slice(startIdx, startIdx + visibleCount)
+
+  return (
+    <box flexDirection="column" padding={1}>
+      <strong>
+        <text>
+          Select a session to resume
+          {metadata.length > visibleCount && (
+            <text fg={c.dim}>
+              {' '}
+              ({selected + 1} of {metadata.length})
+            </text>
+          )}
+          {currentRepo && <text fg={c.dim}> ({currentRepo})</text>}:
+        </text>
+      </strong>
+
+      <box flexDirection="column" marginTop={1}>
+        <box paddingLeft={2}>
+          <strong>
+            <text>{header}</text>
+          </strong>
+        </box>
+        {slice.map((s, i) => {
+          const absIdx = startIdx + i
+          const isSelected = absIdx === selected
+          const row = `${s.relative.padEnd(colWidth, ' ')}${COL_SEP}${s.title}`
+          return (
+            <box key={s.id} paddingLeft={2}>
+              <text fg={isSelected ? c.bg : undefined} bg={isSelected ? c.textBright : undefined}>
+                {isSelected ? '\u276F ' : '  '}
+                {row}
+              </text>
+            </box>
+          )
+        })}
+      </box>
+
+      <box marginTop={1}>
+        <text fg={c.dim}>\u2191/\u2193 to select · Enter to confirm · Esc to cancel</text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/SandboxViolationExpandedView.tsx
+++ b/ui/src/components/SandboxViolationExpandedView.tsx
@@ -1,0 +1,80 @@
+import React from 'react'
+import { c } from '../theme.js'
+import { useAppState } from '../store/app-store.js'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/SandboxViolationExpandedView.tsx`.
+ *
+ * Upstream subscribes to a `SandboxManager` event store that is not
+ * wired into the Lite frontend. Violations are instead surfaced via the
+ * shared `SubsystemState.sandbox_violations` snapshot the backend
+ * pushes over IPC. If the app state has no violations (or the sandbox
+ * subsystem isn't present), the view renders `null` — matching the
+ * upstream "invisible until something is blocked" contract.
+ */
+
+export type SandboxViolationEvent = {
+  timestamp: number
+  command?: string
+  line: string
+}
+
+const MAX_ROWS = 10
+
+function formatTime(timestamp: number): string {
+  const d = new Date(timestamp)
+  const h = d.getHours() % 12 || 12
+  const m = String(d.getMinutes()).padStart(2, '0')
+  const s = String(d.getSeconds()).padStart(2, '0')
+  const ampm = d.getHours() < 12 ? 'am' : 'pm'
+  return `${h}:${m}:${s}${ampm}`
+}
+
+function readViolations(
+  subsystems: Record<string, unknown> | undefined,
+): { violations: SandboxViolationEvent[]; total: number } | null {
+  const sandbox = subsystems?.sandbox as
+    | { violations?: SandboxViolationEvent[]; total?: number }
+    | undefined
+  if (!sandbox) return null
+  const violations = Array.isArray(sandbox.violations) ? sandbox.violations : []
+  const total = typeof sandbox.total === 'number' ? sandbox.total : violations.length
+  return { violations, total }
+}
+
+export function SandboxViolationExpandedView() {
+  const state = useAppState() as unknown as { subsystems?: Record<string, unknown> }
+  const snapshot = readViolations(state.subsystems)
+
+  if (!snapshot || snapshot.total === 0) {
+    return null
+  }
+
+  const { violations, total } = snapshot
+  const recent = violations.slice(-MAX_ROWS)
+  const suffix = total === 1 ? 'operation' : 'operations'
+
+  return (
+    <box flexDirection="column" marginTop={1}>
+      <box>
+        <text fg={c.warning}>
+          {`\u29C8 Sandbox blocked ${total} total ${suffix}`}
+        </text>
+      </box>
+      {recent.map((v, i) => (
+        <box key={`${v.timestamp}-${i}`} paddingLeft={2}>
+          <text fg={c.dim}>
+            {formatTime(v.timestamp)}
+            {v.command ? ` ${v.command}:` : ''} {v.line}
+          </text>
+        </box>
+      ))}
+      <box paddingLeft={2}>
+        <text fg={c.dim}>
+          … showing last {Math.min(MAX_ROWS, recent.length)} of {total}
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/ScrollKeybindingHandler.tsx
+++ b/ui/src/components/ScrollKeybindingHandler.tsx
@@ -1,0 +1,306 @@
+import React, { type RefObject, useEffect, useRef } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { matchesShortcut } from '../keybindings.js'
+import { useAppState } from '../store/app-store.js'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/ScrollKeybindingHandler.tsx`.
+ *
+ * Upstream owns a small empire: wheel acceleration curves (native and
+ * xterm.js), drag-to-scroll, OSC 52 clipboard integration, less-style
+ * modal pager keys, and cooperative text selection with Ink. None of
+ * those scaffolding pieces exist on the Lite frontend — OpenTUI's
+ * `<scrollbox>` provides only the handle methods used below.
+ *
+ * The Lite port keeps the same API surface (scrollRef, isActive,
+ * onScroll, isModal) and wires up the subset of keystrokes we can
+ * service: PgUp/PgDn (half page), ↑/↓ (line), Home/End (top/bottom),
+ * and — when `isModal` — the less-lineage `g`/`G`/`ctrl+u`/`ctrl+d`/
+ * `ctrl+b`/`ctrl+f`/`j`/`k`/space/`b` modal pager chords. Wheel and
+ * drag handling stay in the framework — OpenTUI already consumes
+ * wheel events natively.
+ */
+
+// Types kept close to upstream so call sites don't need to rewire.
+export type ScrollBoxHandle = {
+  scrollBy: (delta: number) => void
+  scrollTo: (top: number) => void
+  scrollToBottom: () => void
+  getScrollTop: () => number
+  getScrollHeight: () => number
+  getViewportHeight: () => number
+  getViewportTop?: () => number
+  getPendingDelta?: () => number
+}
+
+type Props = {
+  scrollRef: RefObject<ScrollBoxHandle | null>
+  isActive: boolean
+  onScroll?: (sticky: boolean, handle: ScrollBoxHandle) => void
+  /** Enables `g`/`G` + `ctrl+u/d/b/f` modal pager chords. Safe only
+   *  when no text input is competing for those keys. */
+  isModal?: boolean
+}
+
+export type ModalPagerAction =
+  | 'lineUp'
+  | 'lineDown'
+  | 'halfPageUp'
+  | 'halfPageDown'
+  | 'fullPageUp'
+  | 'fullPageDown'
+  | 'top'
+  | 'bottom'
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for tests — mirrors the upstream surface).
+// ---------------------------------------------------------------------------
+
+/**
+ * Keyboard page jump. `scrollTo` writes directly, clearing any pending
+ * wheel accumulator. Returns true when the target clamps against the
+ * bottom — callers use this to re-enable sticky mode.
+ */
+export function jumpBy(s: ScrollBoxHandle, delta: number): boolean {
+  const max = Math.max(0, s.getScrollHeight() - s.getViewportHeight())
+  const current = s.getScrollTop() + (s.getPendingDelta?.() ?? 0)
+  const target = current + delta
+  if (target >= max) {
+    s.scrollTo(max)
+    s.scrollToBottom()
+    return true
+  }
+  s.scrollTo(Math.max(0, target))
+  return false
+}
+
+export function scrollDown(s: ScrollBoxHandle, amount: number): boolean {
+  const max = Math.max(0, s.getScrollHeight() - s.getViewportHeight())
+  const effective = s.getScrollTop() + (s.getPendingDelta?.() ?? 0)
+  if (effective + amount >= max) {
+    s.scrollToBottom()
+    return true
+  }
+  s.scrollBy(amount)
+  return false
+}
+
+export function scrollUp(s: ScrollBoxHandle, amount: number): void {
+  const effective = s.getScrollTop() + (s.getPendingDelta?.() ?? 0)
+  if (effective - amount <= 0) {
+    s.scrollTo(0)
+    return
+  }
+  s.scrollBy(-amount)
+}
+
+type PagerKeyInput = {
+  ctrl?: boolean
+  meta?: boolean
+  shift?: boolean
+  upArrow?: boolean
+  downArrow?: boolean
+  home?: boolean
+  end?: boolean
+}
+
+/**
+ * Maps a keystroke to a modal pager action. Follows the less lineage
+ * (`ctrl+u/d/b/f`, `g`/`G`, space, `b`) plus the j/k/↑/↓ re-add Tom
+ * requested in the upstream thread. Returns null for keys that aren't
+ * pager chords so callers can fall through.
+ */
+export function modalPagerAction(
+  input: string,
+  key: PagerKeyInput,
+): ModalPagerAction | null {
+  if (key.meta) return null
+  if (!key.ctrl && !key.shift) {
+    if (key.upArrow) return 'lineUp'
+    if (key.downArrow) return 'lineDown'
+    if (key.home) return 'top'
+    if (key.end) return 'bottom'
+  }
+  if (key.ctrl) {
+    if (key.shift) return null
+    switch (input) {
+      case 'u':
+        return 'halfPageUp'
+      case 'd':
+        return 'halfPageDown'
+      case 'b':
+        return 'fullPageUp'
+      case 'f':
+        return 'fullPageDown'
+      case 'n':
+        return 'lineDown'
+      case 'p':
+        return 'lineUp'
+      default:
+        return null
+    }
+  }
+  const c = input[0]
+  if (!c || input !== c.repeat(input.length)) return null
+  if (c === 'G' || (c === 'g' && key.shift)) return 'bottom'
+  if (key.shift) return null
+  switch (c) {
+    case 'g':
+      return 'top'
+    case 'j':
+      return 'lineDown'
+    case 'k':
+      return 'lineUp'
+    case ' ':
+      return 'fullPageDown'
+    case 'b':
+      return 'fullPageUp'
+    default:
+      return null
+  }
+}
+
+/**
+ * Applies a pager action to a ScrollBox handle. Returns the resulting
+ * sticky state, or `null` when `act === null`.
+ */
+export function applyModalPagerAction(
+  s: ScrollBoxHandle,
+  act: ModalPagerAction | null,
+): boolean | null {
+  switch (act) {
+    case null:
+      return null
+    case 'lineUp':
+      return jumpBy(s, -1)
+    case 'lineDown':
+      return jumpBy(s, 1)
+    case 'halfPageUp':
+    case 'halfPageDown': {
+      const half = Math.max(1, Math.floor(s.getViewportHeight() / 2))
+      return jumpBy(s, act === 'halfPageDown' ? half : -half)
+    }
+    case 'fullPageUp':
+    case 'fullPageDown': {
+      const page = Math.max(1, s.getViewportHeight())
+      return jumpBy(s, act === 'fullPageDown' ? page : -page)
+    }
+    case 'top':
+      s.scrollTo(0)
+      return false
+    case 'bottom': {
+      const max = Math.max(0, s.getScrollHeight() - s.getViewportHeight())
+      s.scrollTo(max)
+      s.scrollToBottom()
+      return true
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+function toShortcutKey(event: KeyEvent) {
+  const name = event.name ?? ''
+  return {
+    ctrl: event.ctrl ?? false,
+    meta: event.meta ?? false,
+    shift: event.shift ?? false,
+    pageUp: name === 'pageup',
+    pageDown: name === 'pagedown',
+    upArrow: name === 'up',
+    downArrow: name === 'down',
+    home: name === 'home',
+    end: name === 'end',
+  }
+}
+
+export function ScrollKeybindingHandler({
+  scrollRef,
+  isActive,
+  onScroll,
+  isModal = false,
+}: Props): React.ReactNode {
+  const { keybindingConfig } = useAppState()
+  const onScrollRef = useRef(onScroll)
+  onScrollRef.current = onScroll
+
+  useEffect(() => () => void 0, [])
+
+  useKeyboard((event: KeyEvent) => {
+    if (!isActive || event.eventType === 'release') return
+    const s = scrollRef.current
+    if (!s) return
+
+    const key = toShortcutKey(event)
+    const name = event.name
+    const input =
+      event.sequence && event.sequence.length <= 4 ? event.sequence : name ?? ''
+
+    const runBinding = (
+      action: string,
+      ctx: string,
+      handler: (handle: ScrollBoxHandle) => boolean,
+    ): boolean => {
+      if (!matchesShortcut(action, '', key, name, { context: ctx, config: keybindingConfig })) {
+        return false
+      }
+      const sticky = handler(s)
+      onScrollRef.current?.(sticky, s)
+      return true
+    }
+
+    if (
+      runBinding('scroll:pageUp', 'Scroll', h => {
+        const d = -Math.max(1, Math.floor(h.getViewportHeight() / 2))
+        return jumpBy(h, d)
+      }) ||
+      runBinding('scroll:pageDown', 'Scroll', h => {
+        const d = Math.max(1, Math.floor(h.getViewportHeight() / 2))
+        return jumpBy(h, d)
+      }) ||
+      runBinding('scroll:lineUp', 'Scroll', h => {
+        scrollUp(h, 3)
+        return false
+      }) ||
+      runBinding('scroll:lineDown', 'Scroll', h => scrollDown(h, 3)) ||
+      runBinding('scroll:top', 'Scroll', h => {
+        h.scrollTo(0)
+        return false
+      }) ||
+      runBinding('scroll:bottom', 'Scroll', h => {
+        const max = Math.max(0, h.getScrollHeight() - h.getViewportHeight())
+        h.scrollTo(max)
+        h.scrollToBottom()
+        return true
+      }) ||
+      runBinding('scroll:halfPageUp', 'Scroll', h =>
+        jumpBy(h, -Math.max(1, Math.floor(h.getViewportHeight() / 2))),
+      ) ||
+      runBinding('scroll:halfPageDown', 'Scroll', h =>
+        jumpBy(h, Math.max(1, Math.floor(h.getViewportHeight() / 2))),
+      ) ||
+      runBinding('scroll:fullPageUp', 'Scroll', h =>
+        jumpBy(h, -Math.max(1, h.getViewportHeight())),
+      ) ||
+      runBinding('scroll:fullPageDown', 'Scroll', h =>
+        jumpBy(h, Math.max(1, h.getViewportHeight())),
+      )
+    ) {
+      return
+    }
+
+    if (isModal) {
+      const act = modalPagerAction(input, key)
+      if (act) {
+        const sticky = applyModalPagerAction(s, act)
+        if (sticky !== null) onScrollRef.current?.(sticky, s)
+      }
+    }
+  })
+
+  return null
+}

--- a/ui/src/components/SearchBox.tsx
+++ b/ui/src/components/SearchBox.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../theme.js'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/SearchBox.tsx`.
+ *
+ * Upstream re-exports `@anthropic/ink`'s internal `SearchBox`, which is
+ * not available in the Lite frontend. This is a minimal Lite-native
+ * equivalent — a single-line text input with the familiar `/ query` look
+ * used by the transcript search UI. `onChange` fires on every edit,
+ * `onSubmit` on <Enter>, `onCancel` on <Esc>.
+ */
+
+type Props = {
+  placeholder?: string
+  initialValue?: string
+  prefix?: string
+  isActive?: boolean
+  onChange?: (value: string) => void
+  onSubmit?: (value: string) => void
+  onCancel?: () => void
+}
+
+export function SearchBox({
+  placeholder = 'Search…',
+  initialValue = '',
+  prefix = '/',
+  isActive = true,
+  onChange,
+  onSubmit,
+  onCancel,
+}: Props) {
+  const [value, setValue] = useState(initialValue)
+  const valueRef = useRef(value)
+  valueRef.current = value
+
+  useEffect(() => {
+    onChange?.(value)
+  }, [value, onChange])
+
+  useKeyboard((event: KeyEvent) => {
+    if (!isActive || event.eventType === 'release') return
+    const name = event.name
+
+    if (name === 'escape') {
+      onCancel?.()
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      onSubmit?.(valueRef.current)
+      return
+    }
+    if (name === 'backspace' || name === 'delete') {
+      setValue(v => v.slice(0, -1))
+      return
+    }
+    const seq = event.sequence
+    if (seq && seq.length === 1 && !event.ctrl && !event.meta) {
+      setValue(v => v + seq)
+    }
+  })
+
+  const display = value.length > 0 ? value : placeholder
+  const displayColor = value.length > 0 ? c.text : c.dim
+
+  return (
+    <box
+      flexDirection="row"
+      paddingX={1}
+      borderStyle="single"
+      borderColor={c.dim}
+    >
+      <text fg={c.accent}>{prefix} </text>
+      <text fg={displayColor}>{display}</text>
+      {isActive && <text fg={c.accent}>{'\u2588'}</text>}
+    </box>
+  )
+}

--- a/ui/src/components/SentryErrorBoundary.ts
+++ b/ui/src/components/SentryErrorBoundary.ts
@@ -1,0 +1,46 @@
+import * as React from 'react'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/SentryErrorBoundary.ts`.
+ *
+ * The Lite frontend doesn't ship the Sentry SDK upstream uses
+ * (`src/utils/sentry.ts`). We keep the same contract — a React class
+ * error boundary that swallows render errors and logs them — but route
+ * the capture to `console.error` so the browser/terminal devtools still
+ * surface the failure for debugging.
+ */
+
+interface Props {
+  children: React.ReactNode
+  /** Optional label identifying which component boundary caught the error. */
+  name?: string
+}
+
+interface State {
+  hasError: boolean
+}
+
+export class SentryErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    const boundary = this.props.name || 'SentryErrorBoundary'
+    // eslint-disable-next-line no-console
+    console.error(`[${boundary}]`, error, errorInfo.componentStack)
+  }
+
+  render(): React.ReactNode {
+    if (this.state.hasError) {
+      return null
+    }
+    return this.props.children
+  }
+}

--- a/ui/src/components/SessionBackgroundHint.tsx
+++ b/ui/src/components/SessionBackgroundHint.tsx
@@ -1,0 +1,102 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../theme.js'
+import { matchesShortcut, shortcutLabel } from '../keybindings.js'
+import { useAppState } from '../store/app-store.js'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/SessionBackgroundHint.tsx`.
+ *
+ * Renders a "press ctrl+b again to background" hint when the user taps
+ * the configured `task:background` chord while a query is in flight.
+ * Two presses within 800 ms trigger `onBackgroundSession`; a single
+ * press just surfaces the hint. Only armed while `isLoading`.
+ */
+
+const DOUBLE_PRESS_WINDOW_MS = 800
+
+type Props = {
+  onBackgroundSession: () => void
+  isLoading: boolean
+}
+
+function toShortcutKey(event: KeyEvent) {
+  const name = event.name ?? ''
+  return {
+    ctrl: event.ctrl ?? false,
+    meta: event.meta ?? false,
+    shift: event.shift ?? false,
+    pageUp: name === 'pageup',
+    pageDown: name === 'pagedown',
+    upArrow: name === 'up',
+    downArrow: name === 'down',
+    home: name === 'home',
+    end: name === 'end',
+  }
+}
+
+export function SessionBackgroundHint({
+  onBackgroundSession,
+  isLoading,
+}: Props): React.ReactElement | null {
+  const { keybindingConfig } = useAppState()
+  const [showHint, setShowHint] = useState(false)
+  const lastPressRef = useRef(0)
+  const clearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const armed = isLoading
+
+  const handleBackground = useCallback(() => {
+    const now = Date.now()
+    if (now - lastPressRef.current <= DOUBLE_PRESS_WINDOW_MS) {
+      lastPressRef.current = 0
+      setShowHint(false)
+      onBackgroundSession()
+      return
+    }
+    lastPressRef.current = now
+    setShowHint(true)
+    if (clearTimerRef.current) clearTimeout(clearTimerRef.current)
+    clearTimerRef.current = setTimeout(() => {
+      setShowHint(false)
+      lastPressRef.current = 0
+    }, DOUBLE_PRESS_WINDOW_MS)
+  }, [onBackgroundSession])
+
+  useEffect(() => {
+    return () => {
+      if (clearTimerRef.current) clearTimeout(clearTimerRef.current)
+    }
+  }, [])
+
+  useKeyboard((event: KeyEvent) => {
+    if (!armed || event.eventType === 'release') return
+    const key = toShortcutKey(event)
+    const name = event.name
+    if (
+      matchesShortcut('task:background', '', key, name, {
+        context: 'Task',
+        config: keybindingConfig,
+      })
+    ) {
+      handleBackground()
+    }
+  })
+
+  if (!armed || !showHint) {
+    return null
+  }
+
+  const shortcut = shortcutLabel('task:background', {
+    context: 'Task',
+    config: keybindingConfig,
+  })
+
+  return (
+    <box paddingLeft={2}>
+      <text fg={c.dim}>{shortcut} to background</text>
+    </box>
+  )
+}

--- a/ui/src/components/SessionPreview.tsx
+++ b/ui/src/components/SessionPreview.tsx
@@ -1,0 +1,145 @@
+import React, { useEffect, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../theme.js'
+import { Spinner } from './Spinner.js'
+import { MessageBubble } from './MessageBubble.js'
+import { buildRenderItems, type RawMessage } from '../store/message-model.js'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/SessionPreview.tsx`.
+ *
+ * Shows the messages of a stored session in read-only form so the user
+ * can decide whether to resume it. Upstream loads a full log off disk
+ * (`loadFullLog(log)`) and renders them via `<Messages>`; the Lite
+ * frontend already has a dispatcher (`MessageBubble`) that understands
+ * `RenderItem`, so we take the messages directly and reuse that
+ * pipeline.
+ */
+
+export type LogSummary = {
+  id: string
+  messageCount: number
+  modified: number
+  gitBranch?: string
+  /** Already-loaded messages. When absent, the caller can lazy-load via
+   *  `loadMessages`. */
+  messages?: RawMessage[]
+}
+
+type Props = {
+  log: LogSummary
+  /** Lazy-loads the message list when `log.messages` is empty. */
+  loadMessages?: (log: LogSummary) => Promise<RawMessage[]>
+  onExit: () => void
+  onSelect: (log: LogSummary) => void
+}
+
+function formatRelativeAgo(ts: number): string {
+  const diff = Date.now() - ts
+  if (diff < 0) return 'now'
+  const minutes = Math.floor(diff / 60_000)
+  if (minutes < 1) return 'just now'
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days}d ago`
+  const months = Math.floor(days / 30)
+  if (months < 12) return `${months}mo ago`
+  return `${Math.floor(months / 12)}y ago`
+}
+
+export function SessionPreview({ log, loadMessages, onExit, onSelect }: Props) {
+  const [messages, setMessages] = useState<RawMessage[] | null>(
+    log.messages ?? null,
+  )
+  const [loading, setLoading] = useState(messages === null)
+
+  useEffect(() => {
+    if (log.messages && log.messages.length > 0) {
+      setMessages(log.messages)
+      setLoading(false)
+      return
+    }
+    if (!loadMessages) {
+      setMessages(log.messages ?? [])
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    void loadMessages(log)
+      .then(result => {
+        if (!cancelled) {
+          setMessages(result)
+          setLoading(false)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setMessages([])
+          setLoading(false)
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [log, loadMessages])
+
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    if (name === 'escape') {
+      onExit()
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      onSelect(log)
+    }
+  })
+
+  if (loading) {
+    return (
+      <box flexDirection="column" padding={1}>
+        <Spinner label="Loading session…" />
+        <text fg={c.dim}>Esc to cancel</text>
+      </box>
+    )
+  }
+
+  const items = messages
+    ? buildRenderItems(messages, {
+        viewMode: 'transcript',
+        isBusy: false,
+        streamingText: '',
+        streamingThinking: '',
+      })
+    : []
+
+  return (
+    <box flexDirection="column">
+      <scrollbox flexGrow={1} width="100%">
+        {items.map(item => (
+          <box key={item.id} width="100%">
+            <MessageBubble item={item} viewMode="transcript" />
+          </box>
+        ))}
+      </scrollbox>
+      <box
+        flexShrink={0}
+        flexDirection="column"
+        borderStyle="single"
+        borderColor={c.dim}
+        paddingLeft={2}
+      >
+        <text>
+          {formatRelativeAgo(log.modified)} · {log.messageCount} messages
+          {log.gitBranch ? ` · ${log.gitBranch}` : ''}
+        </text>
+        <text fg={c.dim}>Enter to resume · Esc to cancel</text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/ShowInIDEPrompt.tsx
+++ b/ui/src/components/ShowInIDEPrompt.tsx
@@ -1,0 +1,193 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../theme.js'
+
+/**
+ * OpenTUI port of the upstream
+ * `ui/examples/upstream-patterns/src/components/ShowInIDEPrompt.tsx`.
+ *
+ * Rendered when a file-edit permission request is being visualised in
+ * an IDE diff view and the user must decide from the terminal. Mirrors
+ * the upstream chrome (title with the IDE name, filename, option list,
+ * symlink / save hints) using OpenTUI primitives.
+ */
+
+export type PermissionOption = {
+  value: string
+  label: string
+  hotkey?: string
+  /** Tagged union used by the parent flow to disambiguate accept vs
+   *  reject without re-parsing the label. */
+  option: { type: 'accept' | 'accept-once' | 'reject' | string }
+}
+
+type Props<A> = {
+  filePath: string
+  input: A
+  onChange: (option: PermissionOption['option'], args: A, feedback?: string) => void
+  options: PermissionOption[]
+  ideName: string
+  symlinkTarget?: string | null
+  rejectFeedback?: string
+  acceptFeedback?: string
+  setFocusedOption?: (value: string) => void
+  onInputModeToggle?: (value: string) => void
+  focusedOption?: string
+  yesInputMode?: boolean
+  noInputMode?: boolean
+  /** Prefix added to resolve `filePath` to a base name. */
+  cwd?: string
+  /** When true, render a "Save file to continue…" hint. */
+  isVscodeTerminal?: boolean
+}
+
+function baseName(path: string): string {
+  const m = /[^/\\]+$/.exec(path)
+  return m ? m[0] : path
+}
+
+function symlinkWarning(cwd: string | undefined, target: string): string {
+  if (cwd && target.startsWith(cwd)) {
+    return `Symlink target: ${target}`
+  }
+  return `This will modify ${target} (outside working directory) via a symlink`
+}
+
+export function ShowInIDEPrompt<A>({
+  filePath,
+  input,
+  onChange,
+  options,
+  ideName,
+  symlinkTarget,
+  rejectFeedback = '',
+  acceptFeedback = '',
+  setFocusedOption,
+  focusedOption,
+  yesInputMode = false,
+  noInputMode = false,
+  cwd,
+  isVscodeTerminal = false,
+}: Props<A>) {
+  const [selected, setSelected] = useState(() =>
+    Math.max(0, options.findIndex(o => o.value === focusedOption)),
+  )
+
+  const safeIndex = Math.max(
+    0,
+    Math.min(options.length - 1, Number.isNaN(selected) ? 0 : selected),
+  )
+
+  const commit = (idx: number) => {
+    const opt = options[idx]
+    if (!opt) return
+    if (opt.option.type === 'reject') {
+      const trimmed = rejectFeedback.trim()
+      onChange(opt.option, input, trimmed || undefined)
+      return
+    }
+    if (opt.option.type === 'accept-once') {
+      const trimmed = acceptFeedback.trim()
+      onChange(opt.option, input, trimmed || undefined)
+      return
+    }
+    onChange(opt.option, input)
+  }
+
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const seq = event.sequence?.length === 1 ? event.sequence : undefined
+    const input = (seq ?? (name?.length === 1 ? name : '') ?? '').toLowerCase()
+
+    if (input) {
+      const match = options.findIndex(
+        o => o.hotkey && o.hotkey.toLowerCase() === input,
+      )
+      if (match >= 0) {
+        commit(match)
+        return
+      }
+    }
+    if (name === 'escape') {
+      const rej = options.findIndex(o => o.option.type === 'reject')
+      commit(rej >= 0 ? rej : safeIndex)
+      return
+    }
+    if (name === 'up' || input === 'k') {
+      const next = Math.max(0, safeIndex - 1)
+      setSelected(next)
+      setFocusedOption?.(options[next]!.value)
+      return
+    }
+    if (name === 'down' || input === 'j') {
+      const next = Math.min(options.length - 1, safeIndex + 1)
+      setSelected(next)
+      setFocusedOption?.(options[next]!.value)
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      commit(safeIndex)
+    }
+  })
+
+  const focused = options[safeIndex]
+  const showTabHint =
+    (focused?.value === 'yes' && !yesInputMode) ||
+    (focused?.value === 'no' && !noInputMode)
+
+  return (
+    <box
+      position="absolute"
+      bottom={3}
+      left={1}
+      right={1}
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.warning}
+      paddingX={2}
+      paddingY={1}
+    >
+      <strong>
+        <text fg={c.warning}>Opened changes in {ideName} \u29C9</text>
+      </strong>
+
+      {symlinkTarget && (
+        <box marginTop={1}>
+          <text fg={c.warning}>{symlinkWarning(cwd, symlinkTarget)}</text>
+        </box>
+      )}
+
+      {isVscodeTerminal && (
+        <box marginTop={1}>
+          <text fg={c.dim}>Save file to continue…</text>
+        </box>
+      )}
+
+      <box marginTop={1} flexDirection="column">
+        <text>
+          Do you want to make this edit to{' '}
+          <strong>{baseName(filePath)}</strong>?
+        </text>
+        {options.map((opt, i) => {
+          const isSelected = i === safeIndex
+          return (
+            <box key={opt.value} flexDirection="row">
+              <text fg={isSelected ? c.bg : undefined} bg={isSelected ? c.textBright : undefined}>
+                <strong>{` ${opt.label} `}</strong>
+              </text>
+              {opt.hotkey && <text fg={c.dim}> ({opt.hotkey})</text>}
+            </box>
+          )
+        })}
+      </box>
+
+      <box marginTop={1}>
+        <text fg={c.dim}>
+          Esc to cancel{showTabHint ? ' · Tab to amend' : ''}
+        </text>
+      </box>
+    </box>
+  )
+}


### PR DESCRIPTION
## Summary
- Port 20 missing upstream reference components from `ui/examples/upstream-patterns/src/components/` to `ui/src/components/`, rewritten against OpenTUI primitives (`<box>`, `<text>`, `<span>`, `useKeyboard`, `useAppState`, theme `c`) so they compile against the Lite frontend runtime.
- Upstream-only dependencies (teleport API, `SandboxManager`, OAuth flow, native installer, package-manager detection, `FuzzyPicker`, etc.) are lifted into loader / handler props. Callers wire those through backend IPC instead of dragging Ink-era modules into the Lite build.
- No existing files were overwritten — every upstream component is recreated with the same public shape (props + exported helpers) so call sites can swap imports without further rewrites.

## What changed
New files under `ui/src/components/`:
- Pure display: `MessageTimestamp`, `OffscreenFreeze`, `PrBadge`, `SandboxViolationExpandedView`, `NotebookEditToolUseRejectedMessage`, `NativeAutoUpdater`, `PackageManagerAutoUpdater`, `SentryErrorBoundary`
- Pickers / dialogs: `ModelPicker`, `OutputStylePicker`, `Onboarding`, `QuickOpenDialog`, `RemoteCallout`, `RemoteEnvironmentDialog`, `ResumeTask`, `SessionPreview`, `ShowInIDEPrompt`, `SearchBox`
- Keyboard / state: `ScrollKeybindingHandler` (plus the pure `jumpBy` / `modalPagerAction` / `applyModalPagerAction` helpers), `SessionBackgroundHint`

## Design notes for reviewers
- `ScrollKeybindingHandler` keeps the upstream API surface (`scrollRef`, `isActive`, `onScroll`, `isModal`) but drops the wheel-acceleration / drag-to-scroll / OSC 52 plumbing — OpenTUI's `<scrollbox>` already handles wheel, and the rest of that machinery isn't wired up in Lite.
- `SessionPreview` reuses the existing `MessageBubble` + `buildRenderItems` dispatcher instead of the upstream `<Messages>` component.
- `SentryErrorBoundary` falls back to `console.error` because the Lite frontend doesn't ship the Sentry SDK. Same contract, different sink.
- `RemoteEnvironmentDialog`, `ResumeTask`, `SessionPreview`, `QuickOpenDialog`, `OutputStylePicker`, `ModelPicker` all take a `loader` / `options` / `previewFor` prop so consumers can plug in their own data source.
- Type-check output shows no new functional errors — only the pre-existing environmental `react` / `@opentui/*` declaration-file warnings that affect every `.tsx` file in the project.

## Test plan
- [ ] `bunx tsc --noEmit` inside `ui/` reports no *new* errors beyond the existing environmental ones
- [ ] Components mount cleanly when wired into the app (spot-check via `/resume`, `/model`, `/output-style`, remote callout)
- [ ] `MessageTimestamp`, `PrBadge`, `OffscreenFreeze` render in transcript mode without visual regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)