### PR TITLE
feat(ui): port 20 upstream components to OpenTUI-native lite (A\u2013C batch)

### DIFF
--- a/ui/src/components/AgentProgressLine.tsx
+++ b/ui/src/components/AgentProgressLine.tsx
@@ -1,0 +1,112 @@
+import React from 'react'
+import { c } from '../theme.js'
+import { formatNumber } from '../utils.js'
+
+/**
+ * Single-row agent progress indicator. OpenTUI-native port of the
+ * upstream `AgentProgressLine`
+ * (`ui/examples/upstream-patterns/src/components/AgentProgressLine.tsx`).
+ *
+ * Rendered underneath an active agent to show:
+ *   - tree-style prefix (`├─`/`└─`) chaining to siblings,
+ *   - optional `agentType` / `description` chips,
+ *   - tool-use counter + token total,
+ *   - a second line with the latest tool activity or a completion state.
+ */
+
+type Props = {
+  agentType: string
+  description?: string
+  name?: string
+  descriptionColor?: string
+  taskDescription?: string
+  toolUseCount: number
+  tokens: number | null
+  color?: string
+  isLast: boolean
+  isResolved: boolean
+  isError: boolean
+  isAsync?: boolean
+  shouldAnimate?: boolean
+  lastToolInfo?: string | null
+  hideType?: boolean
+}
+
+export function AgentProgressLine({
+  agentType,
+  description,
+  name,
+  descriptionColor,
+  taskDescription,
+  toolUseCount,
+  tokens,
+  color,
+  isLast,
+  isResolved,
+  isError,
+  isAsync = false,
+  lastToolInfo,
+  hideType = false,
+}: Props) {
+  const treeChar = isLast ? '\u2514\u2500' : '\u251C\u2500'
+  const isBackgrounded = isAsync && isResolved
+
+  const statusText = !isResolved
+    ? lastToolInfo || 'Initializing\u2026'
+    : isBackgrounded
+      ? taskDescription ?? 'Running in the background'
+      : isError
+        ? 'Errored'
+        : 'Done'
+
+  const headerBgColor = color ?? undefined
+  const descBgColor = descriptionColor ?? undefined
+  const labelFg = headerBgColor ? c.bg : undefined
+  const descFg = descBgColor ? c.bg : undefined
+
+  return (
+    <box flexDirection="column">
+      <box paddingLeft={3} flexDirection="row">
+        <text fg={c.dim}>{treeChar} </text>
+        <text fg={isResolved ? undefined : c.dim}>
+          {hideType ? (
+            <>
+              <strong>{name ?? description ?? agentType}</strong>
+              {name && description && (
+                <span fg={c.dim}>{`: ${description}`}</span>
+              )}
+            </>
+          ) : (
+            <>
+              <strong>
+                <span fg={labelFg} bg={headerBgColor}>{agentType}</span>
+              </strong>
+              {description && (
+                <>
+                  {' ('}
+                  <span fg={descFg} bg={descBgColor}>{description}</span>
+                  {')'}
+                </>
+              )}
+            </>
+          )}
+          {!isBackgrounded && (
+            <>
+              {' \u00B7 '}
+              {toolUseCount} tool {toolUseCount === 1 ? 'use' : 'uses'}
+              {tokens !== null && tokens !== undefined && (
+                <> {' \u00B7 '} {formatNumber(tokens)} tokens</>
+              )}
+            </>
+          )}
+        </text>
+      </box>
+      {!isBackgrounded && (
+        <box paddingLeft={3} flexDirection="row">
+          <text fg={c.dim}>{isLast ? '   \u23BF  ' : '\u2502  \u23BF  '}</text>
+          <text fg={c.dim}>{statusText}</text>
+        </box>
+      )}
+    </box>
+  )
+}

--- a/ui/src/components/ApproveApiKey.tsx
+++ b/ui/src/components/ApproveApiKey.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../theme.js'
+
+/**
+ * "Detected a custom API key in your environment" confirmation dialog.
+ *
+ * OpenTUI-native port of the upstream `ApproveApiKey`
+ * (`ui/examples/upstream-patterns/src/components/ApproveApiKey.tsx`).
+ * The upstream version calls `saveGlobalConfig` to remember the
+ * approved/rejected truncated key prefix. This Lite-native port
+ * surfaces the same confirmation UX but delegates persistence to the
+ * caller via `onDone(approved, remember)` — the OpenTUI frontend does
+ * not hold the global-config mutation helpers, they live in the Rust
+ * backend.
+ */
+
+type Props = {
+  customApiKeyTruncated: string
+  onDone: (approved: boolean) => void
+}
+
+const OPTIONS: Array<{ value: 'yes' | 'no'; label: string }> = [
+  { value: 'no', label: 'No (recommended)' },
+  { value: 'yes', label: 'Yes, use this API key' },
+]
+
+export function ApproveApiKey({ customApiKeyTruncated, onDone }: Props) {
+  const [selected, setSelected] = useState(0)
+
+  useEffect(() => {
+    setSelected(0)
+  }, [customApiKeyTruncated])
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const seq = event.sequence?.length === 1 ? event.sequence : undefined
+    const input = (seq ?? (name?.length === 1 ? name : '') ?? '').toLowerCase()
+
+    if (input === 'y') {
+      onDone(true)
+      return
+    }
+    if (input === 'n') {
+      onDone(false)
+      return
+    }
+    if (name === 'escape') {
+      onDone(false)
+      return
+    }
+    if (name === 'up' || input === 'k') {
+      setSelected(prev => Math.max(0, prev - 1))
+      return
+    }
+    if (name === 'down' || input === 'j' || name === 'tab') {
+      setSelected(prev => Math.min(OPTIONS.length - 1, prev + 1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      const option = OPTIONS[selected]
+      if (option) onDone(option.value === 'yes')
+    }
+  })
+
+  return (
+    <box
+      position="absolute"
+      bottom={3}
+      left={1}
+      right={1}
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.warning}
+      title="Detected a custom API key in your environment"
+      titleAlignment="center"
+      paddingX={2}
+      paddingY={1}
+    >
+      <text>
+        <strong>ANTHROPIC_API_KEY</strong>
+        {': sk-ant-\u2026'}
+        <span fg={c.warning}>{customApiKeyTruncated}</span>
+      </text>
+      <box marginTop={1}>
+        <text>Do you want to use this API key?</text>
+      </box>
+      <box marginTop={1} flexDirection="column">
+        {OPTIONS.map((opt, i) => {
+          const isSelected = i === selected
+          return (
+            <box key={opt.value} flexDirection="row">
+              <text
+                fg={isSelected ? c.bg : undefined}
+                bg={isSelected ? c.textBright : undefined}
+              >
+                <strong>{` ${opt.label} `}</strong>
+              </text>
+              <text fg={c.dim}>{` (${opt.value[0]})`}</text>
+            </box>
+          )
+        })}
+      </box>
+      <box marginTop={1}>
+        <text>
+          <em>
+            <span fg={c.dim}>
+              Up/Down to move \u00B7 Enter to confirm \u00B7 y/n hotkeys \u00B7
+              Esc = No
+            </span>
+          </em>
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/AutoModeOptInDialog.tsx
+++ b/ui/src/components/AutoModeOptInDialog.tsx
@@ -1,0 +1,116 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../theme.js'
+
+/**
+ * "Enable auto mode?" opt-in dialog.
+ *
+ * OpenTUI-native port of the upstream `AutoModeOptInDialog`
+ * (`ui/examples/upstream-patterns/src/components/AutoModeOptInDialog.tsx`).
+ * The copy here mirrors the legally-reviewed upstream text byte-for-byte.
+ * Persistence (`skipAutoPermissionPrompt`, default-mode preference) and
+ * analytics events live in the Rust backend — the frontend delegates
+ * that via `onAccept(setAsDefault)` / `onDecline()`.
+ */
+
+// NOTE: legally-reviewed copy — keep in sync with the upstream constant.
+export const AUTO_MODE_DESCRIPTION =
+  "Auto mode lets Claude handle permission prompts automatically \u2014 Claude checks each tool call for risky actions and prompt injection before executing. Actions Claude identifies as safe are executed, while actions Claude identifies as risky are blocked and Claude may try a different approach. Ideal for long-running tasks. Sessions are slightly more expensive. Claude can make mistakes that allow harmful commands to run, it's recommended to only use in isolated environments. Shift+Tab to change mode."
+
+type Choice = 'accept' | 'accept-default' | 'decline'
+
+type Props = {
+  onAccept: (setAsDefault: boolean) => void
+  onDecline: () => void
+  /** When true, the "No" button label becomes "No, exit" to reflect
+   *  the startup-gate flow. */
+  declineExits?: boolean
+}
+
+export function AutoModeOptInDialog({
+  onAccept,
+  onDecline,
+  declineExits = false,
+}: Props) {
+  const options: Array<{ label: string; value: Choice }> = [
+    { label: 'Yes, and make it my default mode', value: 'accept-default' },
+    { label: 'Yes, enable auto mode', value: 'accept' },
+    { label: declineExits ? 'No, exit' : 'No, go back', value: 'decline' },
+  ]
+
+  const [selected, setSelected] = useState(0)
+
+  const commit = (choice: Choice) => {
+    if (choice === 'decline') {
+      onDecline()
+    } else {
+      onAccept(choice === 'accept-default')
+    }
+  }
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    if (name === 'escape') {
+      onDecline()
+      return
+    }
+    if (name === 'up' || event.sequence === 'k') {
+      setSelected(prev => Math.max(0, prev - 1))
+      return
+    }
+    if (name === 'down' || event.sequence === 'j' || name === 'tab') {
+      setSelected(prev => Math.min(options.length - 1, prev + 1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      const option = options[selected]
+      if (option) commit(option.value)
+    }
+  })
+
+  return (
+    <box
+      position="absolute"
+      bottom={3}
+      left={1}
+      right={1}
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.warning}
+      title="Enable auto mode?"
+      titleAlignment="center"
+      paddingX={2}
+      paddingY={1}
+    >
+      <text>{AUTO_MODE_DESCRIPTION}</text>
+      <box marginTop={1}>
+        <text fg={c.info}>
+          Learn more: https://docs.claude.com/en/docs/claude-code/security
+        </text>
+      </box>
+      <box marginTop={1} flexDirection="column">
+        {options.map((opt, i) => {
+          const isSelected = i === selected
+          return (
+            <box key={opt.value} flexDirection="row">
+              <text
+                fg={isSelected ? c.bg : undefined}
+                bg={isSelected ? c.textBright : undefined}
+              >
+                <strong>{` ${opt.label} `}</strong>
+              </text>
+            </box>
+          )
+        })}
+      </box>
+      <box marginTop={1}>
+        <text>
+          <em>
+            <span fg={c.dim}>Up/Down to move \u00B7 Enter to confirm \u00B7 Esc to decline</span>
+          </em>
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/BaseTextInput.tsx
+++ b/ui/src/components/BaseTextInput.tsx
@@ -1,0 +1,218 @@
+import React from 'react'
+import { c } from '../theme.js'
+
+/**
+ * Generic single-row text input renderer.
+ *
+ * Lite-native OpenTUI port of the upstream `BaseTextInput`
+ * (`ui/examples/upstream-patterns/src/components/BaseTextInput.tsx`).
+ * The upstream version is tied to Ink-specific hooks
+ * (`useDeclaredCursor`, `usePasteHandler`, `useInput`, the `<Ansi>`
+ * element) that do not have direct equivalents in OpenTUI. This port
+ * preserves the visual contract — value, placeholder, cursor, optional
+ * argument hint — and leaves the keyboard / paste / IME handling to the
+ * caller.
+ *
+ * For the full project-specific input pipeline see
+ * `components/PromptInput/ComposerBuffer.tsx`, which drives the real
+ * prompt; this component is kept so upstream-style surfaces (OAuth
+ * flow, bridge dialog, etc.) can mount a simpler input visual.
+ */
+
+export type TextHighlight = {
+  start: number
+  end: number
+  color?: string
+  backgroundColor?: string
+  dimColor?: boolean
+}
+
+type Props = {
+  /** Raw text value. Empty renders the placeholder slot. */
+  value: string
+  /** 0-based cursor position into `value`. Clamped to `[0, value.length]`. */
+  cursorOffset: number
+  /** Whether to render a blinking block cursor indicator. */
+  showCursor?: boolean
+  /** Whether the input has focus — controls the cursor color. */
+  focus?: boolean
+  /** Placeholder text drawn in dim when `value` is empty. */
+  placeholder?: string
+  /** Override placeholder with a rich node (takes precedence). */
+  placeholderElement?: React.ReactNode
+  /** Dim the value color. */
+  dimColor?: boolean
+  /** Hide the cursor even when `focus && showCursor`. */
+  hideCursor?: boolean
+  /** Secret-input masking character. Replaces each grapheme in `value`. */
+  mask?: string
+  /**
+   * Inline hint appended after the value — e.g. `[message]` for a slash
+   * command. Only shown when the value is a slash command without args.
+   */
+  argumentHint?: string
+  /** Optional ranges to render with a distinct color / background. */
+  highlights?: TextHighlight[]
+  /** Foreground override for the main value color. */
+  color?: string
+  /** Background override. Defaults to the OpenTUI app background. */
+  backgroundColor?: string
+}
+
+function renderHighlighted(
+  value: string,
+  highlights: TextHighlight[],
+  cursorOffset: number,
+  showCursor: boolean,
+): React.ReactNode[] {
+  const sorted = [...highlights].sort((a, b) => a.start - b.start)
+  const out: React.ReactNode[] = []
+  let pos = 0
+  let keyCounter = 0
+
+  for (const highlight of sorted) {
+    if (highlight.start > pos) {
+      out.push(
+        <span key={`pre-${keyCounter++}`}>{value.slice(pos, highlight.start)}</span>,
+      )
+    }
+    const span = value.slice(highlight.start, highlight.end)
+    out.push(
+      <span
+        key={`hl-${keyCounter++}`}
+        fg={highlight.color}
+        bg={highlight.backgroundColor}
+      >
+        {highlight.dimColor ? <em>{span}</em> : span}
+      </span>,
+    )
+    pos = Math.max(pos, highlight.end)
+  }
+
+  if (pos < value.length) {
+    out.push(<span key={`tail-${keyCounter++}`}>{value.slice(pos)}</span>)
+  }
+
+  if (showCursor) {
+    const before = value.slice(0, cursorOffset)
+    const cursorChar = value[cursorOffset] ?? ' '
+    const after = value.slice(cursorOffset + 1)
+    out.length = 0
+    out.push(
+      <span key="before">{before}</span>,
+      <span key="cursor" fg={c.bg} bg={c.text}>{cursorChar}</span>,
+      <span key="after">{after}</span>,
+    )
+  }
+
+  return out
+}
+
+export function BaseTextInput({
+  value,
+  cursorOffset,
+  showCursor = true,
+  focus = true,
+  placeholder,
+  placeholderElement,
+  dimColor,
+  hideCursor,
+  mask,
+  argumentHint,
+  highlights,
+  color,
+  backgroundColor = c.bg,
+}: Props) {
+  const isEmpty = value.length === 0
+  const renderValue = mask ? mask.repeat(value.length) : value
+  const shouldDrawCursor = Boolean(focus && showCursor && !hideCursor)
+
+  const safeCursor = Math.max(0, Math.min(cursorOffset, renderValue.length))
+
+  const showArgumentHint = Boolean(
+    argumentHint &&
+      renderValue.startsWith('/') &&
+      (renderValue.trim().indexOf(' ') === -1 || renderValue.endsWith(' ')),
+  )
+
+  if (isEmpty) {
+    return (
+      <box flexDirection="row">
+        {shouldDrawCursor && (
+          <text fg={c.bg} bg={c.text}> </text>
+        )}
+        {placeholderElement ? (
+          placeholderElement
+        ) : placeholder ? (
+          <text fg="#45475A" bg={backgroundColor}>{placeholder}</text>
+        ) : null}
+        {showArgumentHint && (
+          <text fg={c.dim} bg={backgroundColor}>{` ${argumentHint}`}</text>
+        )}
+      </box>
+    )
+  }
+
+  if (highlights && highlights.length > 0) {
+    return (
+      <box flexDirection="row">
+        <text fg={color} bg={backgroundColor}>
+          {renderHighlighted(renderValue, highlights, safeCursor, shouldDrawCursor)}
+        </text>
+        {showArgumentHint && (
+          <text fg={c.dim}>
+            {value.endsWith(' ') ? '' : ' '}
+            {argumentHint}
+          </text>
+        )}
+      </box>
+    )
+  }
+
+  if (shouldDrawCursor) {
+    const before = renderValue.slice(0, safeCursor)
+    const cursorChar = renderValue[safeCursor] ?? ' '
+    const after = renderValue.slice(safeCursor + 1)
+    return (
+      <box flexDirection="row">
+        <text fg={color} bg={backgroundColor}>
+          {dimColor ? (
+            <em>
+              <span>{before}</span>
+            </em>
+          ) : (
+            <span>{before}</span>
+          )}
+          <span fg={c.bg} bg={c.text}>{cursorChar}</span>
+          {dimColor ? (
+            <em>
+              <span>{after}</span>
+            </em>
+          ) : (
+            <span>{after}</span>
+          )}
+        </text>
+        {showArgumentHint && (
+          <text fg={c.dim}>
+            {value.endsWith(' ') ? '' : ' '}
+            {argumentHint}
+          </text>
+        )}
+      </box>
+    )
+  }
+
+  return (
+    <box flexDirection="row">
+      <text fg={color} bg={backgroundColor}>
+        {dimColor ? <em>{renderValue}</em> : renderValue}
+      </text>
+      {showArgumentHint && (
+        <text fg={c.dim}>
+          {value.endsWith(' ') ? '' : ' '}
+          {argumentHint}
+        </text>
+      )}
+    </box>
+  )
+}

--- a/ui/src/components/BashModeProgress.tsx
+++ b/ui/src/components/BashModeProgress.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { c } from '../theme.js'
+import { ShellProgressMessage } from './shell/index.js'
+
+/**
+ * Progress chrome for inline `!bash-mode` commands.
+ *
+ * OpenTUI-native port of the upstream `BashModeProgress`
+ * (`ui/examples/upstream-patterns/src/components/BashModeProgress.tsx`).
+ * Upstream composed `UserBashInputMessage` + `ShellProgressMessage`; the
+ * Lite tree keeps a simpler `<bash-input>` preview (the prompt bubble
+ * renders the user-facing `!…` already) and delegates live progress
+ * to the existing `ShellProgressMessage` port in `components/shell/`.
+ */
+
+export interface ShellProgressSnapshot {
+  /** Most-recent (possibly tail-capped) output. */
+  output: string
+  /** Full accumulated output — used in verbose mode. */
+  fullOutput: string
+  elapsedTimeSeconds: number
+  totalLines?: number
+  totalBytes?: number
+  timeoutMs?: number
+}
+
+type Props = {
+  /** The command the user typed after the `!` bash-mode prefix. */
+  input: string
+  /** Latest progress snapshot, or null before the tool has emitted any. */
+  progress: ShellProgressSnapshot | null
+  /** Render the full output instead of the tail cap. */
+  verbose: boolean
+}
+
+export function BashModeProgress({ input, progress, verbose }: Props) {
+  return (
+    <box flexDirection="column" marginTop={1}>
+      <text>
+        <span fg={c.warning}>$ </span>
+        <span>{input}</span>
+      </text>
+      {progress ? (
+        <ShellProgressMessage
+          output={progress.output}
+          fullOutput={progress.fullOutput}
+          elapsedTimeSeconds={progress.elapsedTimeSeconds}
+          totalLines={progress.totalLines}
+          totalBytes={progress.totalBytes}
+          timeoutMs={progress.timeoutMs}
+          verbose={verbose}
+        />
+      ) : (
+        <text fg={c.dim}>{'Running\u2026'}</text>
+      )}
+    </box>
+  )
+}

--- a/ui/src/components/BridgeDialog.tsx
+++ b/ui/src/components/BridgeDialog.tsx
@@ -1,0 +1,146 @@
+import React, { useEffect, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../theme.js'
+
+/**
+ * Remote-control bridge overlay.
+ *
+ * OpenTUI-native port of the upstream `BridgeDialog`
+ * (`ui/examples/upstream-patterns/src/components/BridgeDialog.tsx`).
+ * Upstream read live state from `AppState` (replBridge* slice) and used
+ * Ink's `Dialog` chrome. The Lite port keeps the same informational
+ * surface but expects the caller to pass a `BridgeStatus` snapshot —
+ * OpenTUI does not yet have a persistent bridge state slice, so keeping
+ * this component props-driven lets the backend decide what to show.
+ *
+ * Interactions:
+ *   - `d`                       \u2192 disconnect (calls `onDisconnect`)
+ *   - `space`                   \u2192 toggle QR view
+ *   - `enter` / `escape`        \u2192 close
+ */
+
+export type BridgeStatus = {
+  connected: boolean
+  sessionActive: boolean
+  reconnecting: boolean
+  error?: string | null
+  connectUrl?: string | null
+  sessionUrl?: string | null
+  repoName?: string | null
+  branchName?: string | null
+  environmentId?: string | null
+  sessionId?: string | null
+  verbose?: boolean
+}
+
+type Props = {
+  status: BridgeStatus
+  onClose: () => void
+  onDisconnect: () => void
+  /** Optional resolver for the QR render — the OpenTUI port does not
+   *  bundle `qrcode`, so callers pass the rendered lines (or null). */
+  qrLines?: string[] | null
+  onToggleQr?: (visible: boolean) => void
+}
+
+function statusLabelFor(s: BridgeStatus): { label: string; color: string } {
+  if (s.error) return { label: 'Failed', color: c.error }
+  if (s.reconnecting) return { label: 'Reconnecting\u2026', color: c.warning }
+  if (s.sessionActive) return { label: 'Connected', color: c.success }
+  if (s.connected) return { label: 'Ready', color: c.info }
+  return { label: 'Idle', color: c.dim }
+}
+
+export function BridgeDialog({
+  status,
+  onClose,
+  onDisconnect,
+  qrLines,
+  onToggleQr,
+}: Props) {
+  const [showQR, setShowQR] = useState(false)
+
+  useEffect(() => {
+    onToggleQr?.(showQR)
+  }, [showQR, onToggleQr])
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const input = event.sequence ?? name ?? ''
+    if (input === 'd') {
+      onDisconnect()
+      return
+    }
+    if (name === 'space' || input === ' ') {
+      setShowQR(prev => !prev)
+      return
+    }
+    if (name === 'escape' || name === 'return' || name === 'enter') {
+      onClose()
+    }
+  })
+
+  const { label, color } = statusLabelFor(status)
+  const indicator = status.error ? '\u2716' : '\u25CF'
+  const contextParts: string[] = []
+  if (status.repoName) contextParts.push(status.repoName)
+  if (status.branchName) contextParts.push(status.branchName)
+  const contextSuffix = contextParts.length
+    ? ' \u00B7 ' + contextParts.join(' \u00B7 ')
+    : ''
+
+  const displayUrl = status.sessionActive ? status.sessionUrl : status.connectUrl
+
+  return (
+    <box
+      position="absolute"
+      bottom={3}
+      left={1}
+      right={1}
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={color}
+      title="Remote Control"
+      titleAlignment="center"
+      paddingX={2}
+      paddingY={1}
+    >
+      <text>
+        <span fg={color}>
+          {indicator} {label}
+        </span>
+        <span fg={c.dim}>{contextSuffix}</span>
+      </text>
+      {status.error && (
+        <box marginTop={1}>
+          <text fg={c.error}>{status.error}</text>
+        </box>
+      )}
+      {status.verbose && status.environmentId && (
+        <text fg={c.dim}>Environment: {status.environmentId}</text>
+      )}
+      {status.verbose && status.sessionId && (
+        <text fg={c.dim}>Session: {status.sessionId}</text>
+      )}
+      {displayUrl && (
+        <box marginTop={1} flexDirection="column">
+          <text fg={c.dim}>URL:</text>
+          <text fg={c.info}>{displayUrl}</text>
+        </box>
+      )}
+      {showQR && qrLines && qrLines.length > 0 && (
+        <box marginTop={1} flexDirection="column">
+          {qrLines.map((line, i) => (
+            <text key={i}>{line}</text>
+          ))}
+        </box>
+      )}
+      <box marginTop={1}>
+        <text fg={c.dim}>
+          d to disconnect \u00B7 space for QR code \u00B7 Enter/Esc to close
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/BuiltinStatusLine.tsx
+++ b/ui/src/components/BuiltinStatusLine.tsx
@@ -1,0 +1,151 @@
+import React, { useEffect, useState } from 'react'
+import { c } from '../theme.js'
+import { formatCost, formatTokens } from '../utils.js'
+
+/**
+ * Built-in statusline renderer focused on model / context usage /
+ * rate-limit meters + session cost.
+ *
+ * OpenTUI-native port of the upstream `BuiltinStatusLine`
+ * (`ui/examples/upstream-patterns/src/components/BuiltinStatusLine.tsx`).
+ * The existing repository-side `components/StatusLine/BuiltinStatusLine.tsx`
+ * renders a different surface (cwd, model, agent/team/MCP/LSP counts)
+ * for the main status bar; this component keeps the upstream's
+ * rate-limit-aware layout intact so any surface that needs that view
+ * (e.g. a custom statusline configuration) has an in-tree port.
+ */
+
+export type RateLimitBucket = {
+  /** 0.0 \u2013 1.0 */
+  utilization: number
+  /** Epoch seconds (0 / negative to hide). */
+  resets_at: number
+}
+
+export type BuiltinStatusLineProps = {
+  modelName: string
+  contextUsedPct: number
+  usedTokens: number
+  contextWindowSize: number
+  totalCostUsd: number
+  rateLimits: {
+    five_hour?: RateLimitBucket
+    seven_day?: RateLimitBucket
+  }
+  /** Available terminal columns. Defaults to 100. */
+  columns?: number
+}
+
+export function formatCountdown(epochSeconds: number): string {
+  const diff = epochSeconds - Date.now() / 1000
+  if (diff <= 0) return 'now'
+  const days = Math.floor(diff / 86400)
+  const hours = Math.floor((diff % 86400) / 3600)
+  const minutes = Math.floor((diff % 3600) / 60)
+  if (days >= 1) return `${days}d${hours}h`
+  if (hours >= 1) return `${hours}h${minutes}m`
+  return `${minutes}m`
+}
+
+function progressBar(ratio: number, width: number): string {
+  const safe = Math.max(0, Math.min(1, ratio))
+  const filledCells = Math.round(safe * width)
+  return '\u2588'.repeat(filledCells) + '\u2591'.repeat(Math.max(0, width - filledCells))
+}
+
+function Separator() {
+  return <span fg={c.dim}>{' \u2502 '}</span>
+}
+
+function BuiltinStatusLineInner({
+  modelName,
+  contextUsedPct,
+  usedTokens,
+  contextWindowSize,
+  totalCostUsd,
+  rateLimits,
+  columns = 100,
+}: BuiltinStatusLineProps) {
+  const [, setTick] = useState(0)
+  useEffect(() => {
+    const hasResetTime =
+      (rateLimits.five_hour?.resets_at ?? 0) ||
+      (rateLimits.seven_day?.resets_at ?? 0)
+    if (!hasResetTime) return
+    const id = setInterval(() => setTick(t => t + 1), 60_000)
+    return () => clearInterval(id)
+  }, [rateLimits.five_hour?.resets_at, rateLimits.seven_day?.resets_at])
+
+  const modelParts = modelName.split(' ')
+  const shortModel =
+    modelParts.length >= 2 ? `${modelParts[0]} ${modelParts[1]}` : modelName
+
+  const wide = columns >= 100
+  const narrow = columns < 60
+
+  const hasFiveHour = rateLimits.five_hour != null
+  const hasSevenDay = rateLimits.seven_day != null
+
+  const fiveHourPct = hasFiveHour
+    ? Math.round((rateLimits.five_hour?.utilization ?? 0) * 100)
+    : 0
+  const sevenDayPct = hasSevenDay
+    ? Math.round((rateLimits.seven_day?.utilization ?? 0) * 100)
+    : 0
+
+  const tokenDisplay = `${formatTokens(usedTokens)}/${formatTokens(contextWindowSize)}`
+
+  return (
+    <text>
+      {shortModel}
+      <Separator />
+      <span fg={c.dim}>Context </span>
+      {contextUsedPct}%
+      {!narrow && <span fg={c.dim}>{` (${tokenDisplay})`}</span>}
+      {hasFiveHour && (
+        <>
+          <Separator />
+          <span fg={c.dim}>Session </span>
+          {wide && (
+            <>
+              <span fg={c.warning}>
+                {progressBar(rateLimits.five_hour?.utilization ?? 0, 10)}
+              </span>
+              {' '}
+            </>
+          )}
+          {fiveHourPct}%
+          {!narrow && (rateLimits.five_hour?.resets_at ?? 0) > 0 && (
+            <span fg={c.dim}>{` ${formatCountdown(rateLimits.five_hour!.resets_at)}`}</span>
+          )}
+        </>
+      )}
+      {hasSevenDay && (
+        <>
+          <Separator />
+          <span fg={c.dim}>Weekly </span>
+          {wide && (
+            <>
+              <span fg={c.warning}>
+                {progressBar(rateLimits.seven_day?.utilization ?? 0, 10)}
+              </span>
+              {' '}
+            </>
+          )}
+          {sevenDayPct}%
+          {!narrow && (rateLimits.seven_day?.resets_at ?? 0) > 0 && (
+            <span fg={c.dim}>{` ${formatCountdown(rateLimits.seven_day!.resets_at)}`}</span>
+          )}
+        </>
+      )}
+      {totalCostUsd > 0 && (
+        <>
+          <Separator />
+          {formatCost(totalCostUsd)}
+        </>
+      )}
+    </text>
+  )
+}
+
+export const BuiltinStatusLine = React.memo(BuiltinStatusLineInner)

--- a/ui/src/components/BypassPermissionsModeDialog.tsx
+++ b/ui/src/components/BypassPermissionsModeDialog.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../theme.js'
+
+/**
+ * "Bypass Permissions mode" danger-mode opt-in dialog.
+ *
+ * OpenTUI-native port of the upstream `BypassPermissionsModeDialog`
+ * (`ui/examples/upstream-patterns/src/components/BypassPermissionsModeDialog.tsx`).
+ * Upstream called `gracefulShutdownSync` on decline and wrote
+ * `skipDangerousModePermissionPrompt` into user settings on accept;
+ * the Lite port hands both back through callbacks so the surrounding
+ * backend/bootstrap code owns persistence and shutdown.
+ */
+
+type Choice = 'accept' | 'decline'
+
+type Props = {
+  onAccept: () => void
+  /** Called when the user selects "No, exit" or presses Esc. Caller is
+   *  expected to trigger a graceful shutdown. */
+  onDecline: () => void
+}
+
+const OPTIONS: Array<{ label: string; value: Choice }> = [
+  { label: 'No, exit', value: 'decline' },
+  { label: 'Yes, I accept', value: 'accept' },
+]
+
+export function BypassPermissionsModeDialog({ onAccept, onDecline }: Props) {
+  const [selected, setSelected] = useState(0)
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const seq = event.sequence?.length === 1 ? event.sequence : undefined
+    const input = (seq ?? (name?.length === 1 ? name : '') ?? '').toLowerCase()
+
+    if (name === 'escape') {
+      onDecline()
+      return
+    }
+    if (name === 'up' || input === 'k') {
+      setSelected(prev => Math.max(0, prev - 1))
+      return
+    }
+    if (name === 'down' || input === 'j' || name === 'tab') {
+      setSelected(prev => Math.min(OPTIONS.length - 1, prev + 1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      const option = OPTIONS[selected]
+      if (option?.value === 'accept') onAccept()
+      else onDecline()
+    }
+  })
+
+  return (
+    <box
+      position="absolute"
+      bottom={3}
+      left={1}
+      right={1}
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.error}
+      title="WARNING: Claude Code running in Bypass Permissions mode"
+      titleAlignment="center"
+      paddingX={2}
+      paddingY={1}
+    >
+      <text>
+        In Bypass Permissions mode, Claude Code will not ask for your approval
+        before running potentially dangerous commands.
+      </text>
+      <box marginTop={1}>
+        <text>
+          This mode should only be used in a sandboxed container/VM that has
+          restricted internet access and can easily be restored if damaged.
+        </text>
+      </box>
+      <box marginTop={1}>
+        <text>
+          By proceeding, you accept all responsibility for actions taken while
+          running in Bypass Permissions mode.
+        </text>
+      </box>
+      <box marginTop={1}>
+        <text fg={c.info}>
+          Learn more: https://docs.claude.com/en/docs/claude-code/security
+        </text>
+      </box>
+      <box marginTop={1} flexDirection="column">
+        {OPTIONS.map((opt, i) => {
+          const isSelected = i === selected
+          return (
+            <box key={opt.value} flexDirection="row">
+              <text
+                fg={isSelected ? c.bg : undefined}
+                bg={isSelected ? c.textBright : undefined}
+              >
+                <strong>{` ${opt.label} `}</strong>
+              </text>
+            </box>
+          )
+        })}
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/ChannelDowngradeDialog.tsx
+++ b/ui/src/components/ChannelDowngradeDialog.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../theme.js'
+
+/**
+ * Dialog shown when switching from the `latest` release channel to
+ * `stable`, where the stable channel may be on an older version.
+ *
+ * OpenTUI-native port of the upstream `ChannelDowngradeDialog`
+ * (`ui/examples/upstream-patterns/src/components/ChannelDowngradeDialog.tsx`).
+ */
+
+export type ChannelDowngradeChoice = 'downgrade' | 'stay' | 'cancel'
+
+type Props = {
+  currentVersion: string
+  onChoice: (choice: ChannelDowngradeChoice) => void
+}
+
+const OPTIONS: Array<{ label: (v: string) => string; value: ChannelDowngradeChoice }> = [
+  { label: () => 'Allow possible downgrade to stable version', value: 'downgrade' },
+  {
+    label: v => `Stay on current version (${v}) until stable catches up`,
+    value: 'stay',
+  },
+]
+
+export function ChannelDowngradeDialog({ currentVersion, onChoice }: Props) {
+  const [selected, setSelected] = useState(0)
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const input = event.sequence ?? name ?? ''
+    if (name === 'escape') {
+      onChoice('cancel')
+      return
+    }
+    if (name === 'up' || input === 'k') {
+      setSelected(prev => Math.max(0, prev - 1))
+      return
+    }
+    if (name === 'down' || input === 'j' || name === 'tab') {
+      setSelected(prev => Math.min(OPTIONS.length - 1, prev + 1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      const option = OPTIONS[selected]
+      if (option) onChoice(option.value)
+    }
+  })
+
+  return (
+    <box
+      position="absolute"
+      bottom={3}
+      left={1}
+      right={1}
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.warning}
+      title="Switch to Stable Channel"
+      titleAlignment="center"
+      paddingX={2}
+      paddingY={1}
+    >
+      <text>
+        The stable channel may have an older version than what you&apos;re
+        currently running ({currentVersion}).
+      </text>
+      <box marginTop={1}>
+        <text fg={c.dim}>How would you like to handle this?</text>
+      </box>
+      <box marginTop={1} flexDirection="column">
+        {OPTIONS.map((opt, i) => {
+          const isSelected = i === selected
+          return (
+            <box key={opt.value} flexDirection="row">
+              <text
+                fg={isSelected ? c.bg : undefined}
+                bg={isSelected ? c.textBright : undefined}
+              >
+                <strong>{` ${opt.label(currentVersion)} `}</strong>
+              </text>
+            </box>
+          )
+        })}
+      </box>
+      <box marginTop={1}>
+        <text>
+          <em>
+            <span fg={c.dim}>Up/Down to move \u00B7 Enter to confirm \u00B7 Esc to cancel</span>
+          </em>
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/ClaudeInChromeOnboarding.tsx
+++ b/ui/src/components/ClaudeInChromeOnboarding.tsx
@@ -1,0 +1,95 @@
+import React from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../theme.js'
+
+/**
+ * One-shot onboarding for the "Claude in Chrome" feature.
+ *
+ * OpenTUI-native port of the upstream `ClaudeInChromeOnboarding`
+ * (`ui/examples/upstream-patterns/src/components/ClaudeInChromeOnboarding.tsx`).
+ * Upstream used `saveGlobalConfig`, `logEvent`, and a Chrome-extension
+ * probe to mark onboarding as complete and decide whether to show the
+ * install link. The Lite port keeps the copy and the "press Enter to
+ * continue" gesture, and leaves those side effects to the caller.
+ */
+
+const CHROME_EXTENSION_URL = 'https://docs.claude.com/en/docs/claude-code/chrome'
+const CHROME_PERMISSIONS_URL =
+  'https://docs.claude.com/en/docs/claude-code/chrome/permissions'
+const DOCS_URL = 'https://docs.claude.com/en/docs/claude-code/chrome'
+
+type Props = {
+  onDone: () => void
+  /** Optional probe result so the dialog can skip the install prompt. */
+  isExtensionInstalled?: boolean
+}
+
+export function ClaudeInChromeOnboarding({
+  onDone,
+  isExtensionInstalled = false,
+}: Props) {
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    if (
+      event.name === 'return' ||
+      event.name === 'enter' ||
+      event.name === 'escape'
+    ) {
+      onDone()
+    }
+  })
+
+  return (
+    <box
+      position="absolute"
+      bottom={3}
+      left={1}
+      right={1}
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.warningBright}
+      title="Claude in Chrome (Beta)"
+      titleAlignment="center"
+      paddingX={2}
+      paddingY={1}
+    >
+      <text>
+        Claude in Chrome works with the Chrome extension to let you control
+        your browser directly from Claude Code. You can navigate websites,
+        fill forms, capture screenshots, record GIFs, and debug with console
+        logs and network requests.
+      </text>
+      {!isExtensionInstalled && (
+        <box marginTop={1}>
+          <text>
+            Requires the Chrome extension. Get started at{' '}
+            <span fg={c.info}>{CHROME_EXTENSION_URL}</span>
+          </text>
+        </box>
+      )}
+      <box marginTop={1}>
+        <text fg={c.dim}>
+          Site-level permissions are inherited from the Chrome extension.
+          Manage permissions in the Chrome extension settings to control
+          which sites Claude can browse, click, and type on
+          {isExtensionInstalled ? ` (${CHROME_PERMISSIONS_URL})` : ''}
+          .
+        </text>
+      </box>
+      <box marginTop={1}>
+        <text fg={c.dim}>
+          For more info, use{' '}
+          <strong>
+            <span fg={c.warningBright}>/chrome</span>
+          </strong>{' '}
+          or visit <span fg={c.info}>{DOCS_URL}</span>
+        </text>
+      </box>
+      <box marginTop={1}>
+        <text>
+          Press <strong>Enter</strong> to continue\u2026
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/ClaudeMdExternalIncludesDialog.tsx
+++ b/ui/src/components/ClaudeMdExternalIncludesDialog.tsx
@@ -1,0 +1,128 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../theme.js'
+
+/**
+ * "Allow external CLAUDE.md file imports?" consent dialog.
+ *
+ * OpenTUI-native port of the upstream `ClaudeMdExternalIncludesDialog`
+ * (`ui/examples/upstream-patterns/src/components/ClaudeMdExternalIncludesDialog.tsx`).
+ * The upstream version mutates project config and logs analytics; the
+ * Lite port surfaces the same prompt and reports `approved: boolean`
+ * via `onDone`. Persisting the decision is the caller's responsibility.
+ */
+
+export type ExternalClaudeMdInclude = {
+  path: string
+}
+
+type Props = {
+  onDone: (approved: boolean) => void
+  /** Hide the panel border/title when rendered inline (not a modal). */
+  isStandaloneDialog?: boolean
+  externalIncludes?: ExternalClaudeMdInclude[]
+}
+
+const OPTIONS: Array<{ label: string; value: 'yes' | 'no' }> = [
+  { label: 'Yes, allow external imports', value: 'yes' },
+  { label: 'No, disable external imports', value: 'no' },
+]
+
+export function ClaudeMdExternalIncludesDialog({
+  onDone,
+  isStandaloneDialog = true,
+  externalIncludes,
+}: Props) {
+  const [selected, setSelected] = useState(0)
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const seq = event.sequence?.length === 1 ? event.sequence : undefined
+    const input = (seq ?? (name?.length === 1 ? name : '') ?? '').toLowerCase()
+
+    if (name === 'escape') {
+      onDone(false)
+      return
+    }
+    if (name === 'up' || input === 'k') {
+      setSelected(prev => Math.max(0, prev - 1))
+      return
+    }
+    if (name === 'down' || input === 'j' || name === 'tab') {
+      setSelected(prev => Math.min(OPTIONS.length - 1, prev + 1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      const option = OPTIONS[selected]
+      if (option) onDone(option.value === 'yes')
+    }
+  })
+
+  const shellProps = isStandaloneDialog
+    ? {
+        borderStyle: 'rounded' as const,
+        borderColor: c.warning,
+        title: 'Allow external CLAUDE.md file imports?',
+        titleAlignment: 'center' as const,
+        paddingX: 2,
+        paddingY: 1,
+      }
+    : {
+        paddingX: 1,
+        paddingY: 0,
+      }
+
+  return (
+    <box
+      position={isStandaloneDialog ? 'absolute' : undefined}
+      bottom={isStandaloneDialog ? 3 : undefined}
+      left={isStandaloneDialog ? 1 : undefined}
+      right={isStandaloneDialog ? 1 : undefined}
+      flexDirection="column"
+      {...shellProps}
+    >
+      {!isStandaloneDialog && (
+        <text>
+          <strong>
+            <span fg={c.warning}>Allow external CLAUDE.md file imports?</span>
+          </strong>
+        </text>
+      )}
+      <text>
+        This project&apos;s CLAUDE.md imports files outside the current working
+        directory. Never allow this for third-party repositories.
+      </text>
+      {externalIncludes && externalIncludes.length > 0 && (
+        <box marginTop={1} flexDirection="column">
+          <text fg={c.dim}>External imports:</text>
+          {externalIncludes.map((include, i) => (
+            <text key={i} fg={c.dim}>{`  ${include.path}`}</text>
+          ))}
+        </box>
+      )}
+      <box marginTop={1}>
+        <text fg={c.dim}>
+          Important: Only use Claude Code with files you trust. Accessing
+          untrusted files may pose security risks. See
+          https://docs.claude.com/en/docs/claude-code/security
+        </text>
+      </box>
+      <box marginTop={1} flexDirection="column">
+        {OPTIONS.map((opt, i) => {
+          const isSelected = i === selected
+          return (
+            <box key={opt.value} flexDirection="row">
+              <text
+                fg={isSelected ? c.bg : undefined}
+                bg={isSelected ? c.textBright : undefined}
+              >
+                <strong>{` ${opt.label} `}</strong>
+              </text>
+            </box>
+          )
+        })}
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/ClickableImageRef.tsx
+++ b/ui/src/components/ClickableImageRef.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { pathToFileURL } from 'node:url'
+import { c } from '../theme.js'
+import { osc8Link } from './FilePathLink.js'
+
+/**
+ * Render an `[Image #N]` reference as an OSC 8 hyperlink.
+ *
+ * OpenTUI-native port of the upstream `ClickableImageRef`
+ * (`ui/examples/upstream-patterns/src/components/ClickableImageRef.tsx`).
+ * Upstream resolved the stored image path via `getStoredImagePath(id)`.
+ * The Lite port accepts the resolved path as a prop so the frontend
+ * stays decoupled from the Rust-side image store. When no path is
+ * available, the component falls back to styled text \u2014 still visible,
+ * but not clickable.
+ */
+
+type Props = {
+  imageId: number
+  /** Absolute path on disk (resolved by the backend image store). */
+  imagePath?: string | null
+  /** Highlight background, e.g. for message selectors. */
+  backgroundColor?: string
+  /** Render in inverse (selected) styling. */
+  isSelected?: boolean
+}
+
+export function ClickableImageRef({
+  imageId,
+  imagePath,
+  backgroundColor,
+  isSelected = false,
+}: Props) {
+  const displayText = `[Image #${imageId}]`
+  const invertedFg = isSelected ? c.bg : undefined
+  const invertedBg = isSelected ? c.text : backgroundColor
+
+  if (imagePath) {
+    const href = pathToFileURL(imagePath).href
+    const payload = osc8Link(href, displayText)
+    return (
+      <text fg={invertedFg} bg={invertedBg}>
+        {isSelected ? <strong>{payload}</strong> : payload}
+      </text>
+    )
+  }
+
+  return (
+    <text fg={invertedFg} bg={invertedBg}>
+      {isSelected ? <strong>{displayText}</strong> : displayText}
+    </text>
+  )
+}

--- a/ui/src/components/CompactSummary.tsx
+++ b/ui/src/components/CompactSummary.tsx
@@ -1,0 +1,120 @@
+import React from 'react'
+import { c } from '../theme.js'
+import type { ViewMode } from '../keybindings.js'
+import { ConfigurableShortcutHint } from './ConfigurableShortcutHint.js'
+
+/**
+ * Summary row rendered in place of a collapsed "compact" message.
+ *
+ * OpenTUI-native port of the upstream `CompactSummary`
+ * (`ui/examples/upstream-patterns/src/components/CompactSummary.tsx`).
+ * Upstream consumed `NormalizedUserMessage` / `screen` types that live
+ * in the Ink transcript pipeline. The Lite port accepts a flat
+ * `CompactSummaryData` shape so the message pipeline — which in this
+ * tree is `message-model.ts` — can project the same fields without
+ * pulling the upstream message normalizer in.
+ */
+
+const BLACK_CIRCLE = '\u25CF'
+
+export type CompactSummaryMetadata = {
+  messagesSummarized?: number
+  direction?: 'up_to' | 'from_here' | string
+  userContext?: string
+}
+
+export type CompactSummaryData = {
+  /** Rendered text form of the summary (shown in transcript mode). */
+  text: string
+  /** Present only for explicit "Summarize from here" / "up to" commands. */
+  metadata?: CompactSummaryMetadata
+}
+
+type Props = {
+  summary: CompactSummaryData
+  viewMode: ViewMode
+}
+
+export function CompactSummary({ summary, viewMode }: Props) {
+  const isTranscriptMode = viewMode === 'transcript'
+  const { metadata, text } = summary
+
+  if (metadata) {
+    return (
+      <box flexDirection="column" marginTop={1}>
+        <box flexDirection="row">
+          <box minWidth={2}>
+            <text>{BLACK_CIRCLE}</text>
+          </box>
+          <box flexDirection="column">
+            <text>
+              <strong>Summarized conversation</strong>
+            </text>
+            {!isTranscriptMode ? (
+              <box flexDirection="column" marginLeft={0}>
+                <text fg={c.dim}>
+                  Summarized {metadata.messagesSummarized} messages
+                  {metadata.direction === 'up_to'
+                    ? ' up to this point'
+                    : ' from this point'}
+                </text>
+                {metadata.userContext && (
+                  <text fg={c.dim}>
+                    {'Context: \u201C'}
+                    {metadata.userContext}
+                    {'\u201D'}
+                  </text>
+                )}
+                <text>
+                  <ConfigurableShortcutHint
+                    action="app:toggleTranscript"
+                    context="Global"
+                    fallback="ctrl+o"
+                    description="expand history"
+                    parens
+                  />
+                </text>
+              </box>
+            ) : (
+              <box marginLeft={0}>
+                <text>{text}</text>
+              </box>
+            )}
+          </box>
+        </box>
+      </box>
+    )
+  }
+
+  return (
+    <box flexDirection="column" marginTop={1}>
+      <box flexDirection="row">
+        <box minWidth={2}>
+          <text>{BLACK_CIRCLE}</text>
+        </box>
+        <box flexDirection="column">
+          <text>
+            <strong>Compact summary</strong>
+            {!isTranscriptMode && (
+              <>
+                {' '}
+                <ConfigurableShortcutHint
+                  action="app:toggleTranscript"
+                  context="Global"
+                  fallback="ctrl+o"
+                  description="expand"
+                  parens
+                />
+              </>
+            )}
+          </text>
+        </box>
+      </box>
+      {isTranscriptMode && (
+        <box marginLeft={2}>
+          <text>{text}</text>
+        </box>
+      )}
+    </box>
+  )
+}

--- a/ui/src/components/ConfigurableShortcutHint.tsx
+++ b/ui/src/components/ConfigurableShortcutHint.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { useAppState } from '../store/app-store.js'
+import {
+  shortcutLabel,
+  type ShortcutAction,
+  type ShortcutContext,
+} from '../keybindings.js'
+import { c } from '../theme.js'
+
+/**
+ * Render `<shortcut> <description>` (optionally wrapped in parens /
+ * bolded) that stays in sync with the user-configured keybinding.
+ *
+ * OpenTUI-native port of the upstream `ConfigurableShortcutHint`
+ * (`ui/examples/upstream-patterns/src/components/ConfigurableShortcutHint.tsx`).
+ * Upstream delegated to Ink's `KeyboardShortcutHint`; the Lite port
+ * resolves the chord through the shared `shortcutLabel` helper and
+ * renders using OpenTUI primitives.
+ */
+
+type Props = {
+  action: ShortcutAction | string
+  context: ShortcutContext
+  /** Default rendered chord when nothing is configured. */
+  fallback: string
+  /** Short verb shown next to the chord (e.g. `"expand"`). */
+  description: string
+  /** Wrap the whole hint in parentheses. */
+  parens?: boolean
+  /** Render in bold. */
+  bold?: boolean
+  /** Override the dim color (leave undefined to inherit). */
+  color?: string
+}
+
+function resolveShortcut(
+  action: ShortcutAction | string,
+  context: ShortcutContext,
+  fallback: string,
+  keybindingConfig: ReturnType<typeof useAppState>['keybindingConfig'],
+): string {
+  const resolved = shortcutLabel(action, {
+    context,
+    config: keybindingConfig ?? null,
+  })
+  return resolved || fallback
+}
+
+export function ConfigurableShortcutHint({
+  action,
+  context,
+  fallback,
+  description,
+  parens = false,
+  bold = false,
+  color,
+}: Props) {
+  const { keybindingConfig } = useAppState()
+  const shortcut = resolveShortcut(action, context, fallback, keybindingConfig)
+  const inner = `${shortcut} ${description}`
+  const labelFg = color ?? c.dim
+
+  const content = parens ? `(${inner})` : inner
+
+  return (
+    <span fg={labelFg}>
+      {bold ? <strong>{content}</strong> : content}
+    </span>
+  )
+}

--- a/ui/src/components/ConsoleOAuthFlow.tsx
+++ b/ui/src/components/ConsoleOAuthFlow.tsx
@@ -1,0 +1,477 @@
+import React, { useEffect, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../theme.js'
+import { Spinner } from './Spinner.js'
+
+/**
+ * Interactive OAuth / platform selection flow.
+ *
+ * OpenTUI-native port of the upstream `ConsoleOAuthFlow`
+ * (`ui/examples/upstream-patterns/src/components/ConsoleOAuthFlow.tsx`).
+ *
+ * The upstream component owns a 9-state machine that drives the whole
+ * login flow \u2014 platform picker, browser launch, manual code pasting,
+ * per-provider form entries (Anthropic-compat / OpenAI / Gemini), key
+ * creation, and success / retry surfaces. It depends on services the
+ * Lite tree doesn't expose to the frontend (`OAuthService`,
+ * `installOAuthTokens`, `getOauthAccountInfo`, `updateSettingsForSource`,
+ * analytics, notifications). Those live Rust-side in this port.
+ *
+ * To keep parity with the upstream UX while respecting our IPC
+ * boundary, this port exposes a **presentation-only** surface: callers
+ * pass a `status` object describing the current state and handler
+ * callbacks, the component renders the appropriate screen. The Rust
+ * backend drives the actual OAuth dance and pushes status updates.
+ */
+
+export type OAuthProviderKind =
+  | 'claudeai'
+  | 'console'
+  | 'platform'
+  | 'custom_platform'
+  | 'openai_chat_api'
+  | 'gemini_api'
+
+export type OAuthFormField =
+  | 'base_url'
+  | 'api_key'
+  | 'haiku_model'
+  | 'sonnet_model'
+  | 'opus_model'
+
+export type OAuthFormValues = Record<OAuthFormField, string>
+
+export type ConsoleOAuthStatus =
+  | { state: 'idle' }
+  | { state: 'platform_setup' }
+  | {
+      state: 'provider_form'
+      provider: 'custom_platform' | 'openai_chat_api' | 'gemini_api'
+      activeField: OAuthFormField
+      values: OAuthFormValues
+    }
+  | { state: 'ready_to_start' }
+  | { state: 'waiting_for_login'; url: string; showPastePrompt: boolean }
+  | { state: 'creating_api_key' }
+  | { state: 'about_to_retry' }
+  | { state: 'success'; token?: string; email?: string }
+  | { state: 'error'; message: string; canRetry: boolean }
+
+type Props = {
+  status: ConsoleOAuthStatus
+  mode?: 'login' | 'setup-token'
+  startingMessage?: string
+  forcedMethodMessage?: string | null
+  onSelectProvider: (provider: OAuthProviderKind) => void
+  onSubmitManualCode: (code: string) => void
+  onRetry: () => void
+  onCopyUrl: (url: string) => void
+  onDone: () => void
+}
+
+type OptionEntry = {
+  value: OAuthProviderKind
+  title: string
+  description: string
+}
+
+const DEFAULT_OPTIONS: OptionEntry[] = [
+  {
+    value: 'custom_platform',
+    title: 'Anthropic Compatible',
+    description: 'Configure your own API endpoint',
+  },
+  {
+    value: 'openai_chat_api',
+    title: 'OpenAI Compatible',
+    description: 'Ollama, DeepSeek, vLLM, One API, etc.',
+  },
+  {
+    value: 'gemini_api',
+    title: 'Gemini API',
+    description: 'Google Gemini native REST/SSE',
+  },
+  {
+    value: 'claudeai',
+    title: 'Claude account with subscription',
+    description: 'Pro, Max, Team, or Enterprise',
+  },
+  {
+    value: 'console',
+    title: 'Anthropic Console account',
+    description: 'API usage billing',
+  },
+  {
+    value: 'platform',
+    title: '3rd-party platform',
+    description: 'Amazon Bedrock, Microsoft Foundry, or Vertex AI',
+  },
+]
+
+const FORM_FIELDS: OAuthFormField[] = [
+  'base_url',
+  'api_key',
+  'haiku_model',
+  'sonnet_model',
+  'opus_model',
+]
+
+const FIELD_LABELS: Record<OAuthFormField, string> = {
+  base_url: 'Base URL ',
+  api_key: 'API Key  ',
+  haiku_model: 'Haiku    ',
+  sonnet_model: 'Sonnet   ',
+  opus_model: 'Opus     ',
+}
+
+function IdleView({
+  startingMessage,
+  onSelect,
+}: {
+  startingMessage?: string
+  onSelect: (provider: OAuthProviderKind) => void
+}) {
+  const [selected, setSelected] = useState(0)
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    if (name === 'up' || event.sequence === 'k') {
+      setSelected(prev => Math.max(0, prev - 1))
+      return
+    }
+    if (name === 'down' || event.sequence === 'j') {
+      setSelected(prev => Math.min(DEFAULT_OPTIONS.length - 1, prev + 1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      const opt = DEFAULT_OPTIONS[selected]
+      if (opt) onSelect(opt.value)
+    }
+  })
+
+  return (
+    <box flexDirection="column" gap={1}>
+      <text>
+        <strong>
+          {startingMessage ??
+            'Claude Code can be used with your Claude subscription or billed based on API usage through your Console account.'}
+        </strong>
+      </text>
+      <text>Select login method:</text>
+      <box flexDirection="column">
+        {DEFAULT_OPTIONS.map((opt, i) => {
+          const isSelected = i === selected
+          return (
+            <box key={opt.value} flexDirection="column" marginTop={i === 0 ? 0 : 1}>
+              <text
+                fg={isSelected ? c.bg : undefined}
+                bg={isSelected ? c.textBright : undefined}
+              >
+                <strong>{` ${opt.title} `}</strong>
+                {'  '}
+                <span fg={isSelected ? c.bg : c.dim}>\u00B7 {opt.description}</span>
+              </text>
+            </box>
+          )
+        })}
+      </box>
+      <text fg={c.dim}>Up/Down to move \u00B7 Enter to select</text>
+    </box>
+  )
+}
+
+function PlatformSetupView() {
+  return (
+    <box flexDirection="column" gap={1}>
+      <text>
+        <strong>Using 3rd-party platforms</strong>
+      </text>
+      <text>
+        Claude Code supports Amazon Bedrock, Microsoft Foundry, and Vertex
+        AI. Set the required environment variables, then restart Claude
+        Code.
+      </text>
+      <text>
+        If you are part of an enterprise organization, contact your
+        administrator for setup instructions.
+      </text>
+      <box flexDirection="column" marginTop={1}>
+        <text>
+          <strong>Documentation</strong>
+        </text>
+        <text>
+          \u00B7 Amazon Bedrock: <span fg={c.info}>https://docs.claude.com/en/docs/claude-code/amazon-bedrock</span>
+        </text>
+        <text>
+          \u00B7 Microsoft Foundry: <span fg={c.info}>https://docs.claude.com/en/docs/claude-code/microsoft-foundry</span>
+        </text>
+        <text>
+          \u00B7 Vertex AI: <span fg={c.info}>https://docs.claude.com/en/docs/claude-code/google-vertex-ai</span>
+        </text>
+      </box>
+      <box marginTop={1}>
+        <text fg={c.dim}>
+          Press <strong>Enter</strong> to go back to login options.
+        </text>
+      </box>
+    </box>
+  )
+}
+
+function ProviderFormView({
+  status,
+}: {
+  status: Extract<ConsoleOAuthStatus, { state: 'provider_form' }>
+}) {
+  const providerTitle =
+    status.provider === 'openai_chat_api'
+      ? 'OpenAI Compatible API Setup'
+      : status.provider === 'gemini_api'
+        ? 'Gemini API Setup'
+        : 'Anthropic Compatible Setup'
+
+  return (
+    <box flexDirection="column" gap={1}>
+      <text>
+        <strong>{providerTitle}</strong>
+      </text>
+      <box flexDirection="column" gap={1}>
+        {FORM_FIELDS.map(field => {
+          const active = status.activeField === field
+          const value = status.values[field] ?? ''
+          const isMasked = field === 'api_key'
+          const display = isMasked && value
+            ? value.slice(0, 8) + '\u00B7'.repeat(Math.max(0, value.length - 8))
+            : value
+          return (
+            <box key={field} flexDirection="row">
+              <text
+                fg={active ? c.bg : undefined}
+                bg={active ? c.textBright : undefined}
+              >
+                {` ${FIELD_LABELS[field]} `}
+              </text>
+              <text>
+                {' '}
+                {display ? (
+                  <span fg={c.success}>{display}</span>
+                ) : (
+                  <span fg={c.dim}>(empty)</span>
+                )}
+              </text>
+            </box>
+          )
+        })}
+      </box>
+      <text fg={c.dim}>
+        \u2191\u2193/Tab to switch \u00B7 Enter on last field to save \u00B7 Esc to go back
+      </text>
+    </box>
+  )
+}
+
+function WaitingForLoginView({
+  status,
+  forcedMethodMessage,
+  onCopyUrl,
+  onSubmitManualCode,
+}: {
+  status: Extract<ConsoleOAuthStatus, { state: 'waiting_for_login' }>
+  forcedMethodMessage?: string | null
+  onCopyUrl: (url: string) => void
+  onSubmitManualCode: (code: string) => void
+}) {
+  const [code, setCode] = useState('')
+
+  useKeyboard(event => {
+    if (!status.showPastePrompt) return
+    if (event.eventType === 'release') return
+    const name = event.name
+    if (event.sequence === 'c') {
+      onCopyUrl(status.url)
+      return
+    }
+    if (name === 'backspace') {
+      setCode(prev => prev.slice(0, -1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      if (code) onSubmitManualCode(code)
+      return
+    }
+    if (event.sequence && event.sequence.length === 1) {
+      setCode(prev => prev + event.sequence)
+    }
+  })
+
+  return (
+    <box flexDirection="column" gap={1}>
+      {forcedMethodMessage && (
+        <text fg={c.dim}>{forcedMethodMessage}</text>
+      )}
+      {!status.showPastePrompt ? (
+        <box flexDirection="row">
+          <Spinner label="Opening browser to sign in\u2026" />
+        </box>
+      ) : (
+        <>
+          <box flexDirection="column" gap={0}>
+            <text fg={c.dim}>
+              Browser didn&apos;t open? Use the url below to sign in.
+            </text>
+            <text fg={c.info}>{status.url}</text>
+            <text fg={c.dim}>Press <strong>c</strong> to copy the URL.</text>
+          </box>
+          <box flexDirection="row">
+            <text>Paste code here if prompted &gt; </text>
+            <text>{'*'.repeat(code.length)}</text>
+          </box>
+        </>
+      )}
+    </box>
+  )
+}
+
+function SuccessView({
+  status,
+  mode,
+}: {
+  status: Extract<ConsoleOAuthStatus, { state: 'success' }>
+  mode: 'login' | 'setup-token'
+}) {
+  if (mode === 'setup-token' && status.token) {
+    return (
+      <box flexDirection="column" gap={1}>
+        <text fg={c.success}>
+          \u2713 Long-lived authentication token created successfully!
+        </text>
+        <text>Your OAuth token (valid for 1 year):</text>
+        <text fg={c.warning}>{status.token}</text>
+        <text fg={c.dim}>
+          Store this token securely. You won&apos;t be able to see it again.
+        </text>
+        <text fg={c.dim}>
+          Use this token by setting: export CLAUDE_CODE_OAUTH_TOKEN=&lt;token&gt;
+        </text>
+      </box>
+    )
+  }
+  return (
+    <box flexDirection="column">
+      {status.email && (
+        <text fg={c.dim}>
+          Logged in as <span fg={c.text}>{status.email}</span>
+        </text>
+      )}
+      <text fg={c.success}>
+        Login successful. Press <strong>Enter</strong> to continue\u2026
+      </text>
+    </box>
+  )
+}
+
+function ErrorView({
+  status,
+}: {
+  status: Extract<ConsoleOAuthStatus, { state: 'error' }>
+}) {
+  return (
+    <box flexDirection="column" gap={1}>
+      <text fg={c.error}>OAuth error: {status.message}</text>
+      {status.canRetry && (
+        <text fg={c.warning}>
+          Press <strong>Enter</strong> to retry.
+        </text>
+      )}
+    </box>
+  )
+}
+
+export function ConsoleOAuthFlow({
+  status,
+  mode = 'login',
+  startingMessage,
+  forcedMethodMessage,
+  onSelectProvider,
+  onSubmitManualCode,
+  onRetry,
+  onCopyUrl,
+  onDone,
+}: Props) {
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    if (status.state === 'success' && mode !== 'setup-token') {
+      if (name === 'return' || name === 'enter') onDone()
+      return
+    }
+    if (status.state === 'platform_setup') {
+      if (name === 'return' || name === 'enter') onSelectProvider('platform')
+      return
+    }
+    if (status.state === 'error' && status.canRetry) {
+      if (name === 'return' || name === 'enter') onRetry()
+      return
+    }
+  })
+
+  useEffect(() => {
+    if (mode === 'setup-token' && status.state === 'success') {
+      const id = setTimeout(onDone, 500)
+      return () => clearTimeout(id)
+    }
+  }, [mode, status.state, onDone])
+
+  let body: React.ReactNode = null
+  switch (status.state) {
+    case 'idle':
+      body = <IdleView startingMessage={startingMessage} onSelect={onSelectProvider} />
+      break
+    case 'platform_setup':
+      body = <PlatformSetupView />
+      break
+    case 'provider_form':
+      body = <ProviderFormView status={status} />
+      break
+    case 'ready_to_start':
+      body = (
+        <box flexDirection="row">
+          <Spinner label="Starting OAuth flow\u2026" />
+        </box>
+      )
+      break
+    case 'waiting_for_login':
+      body = (
+        <WaitingForLoginView
+          status={status}
+          forcedMethodMessage={forcedMethodMessage}
+          onCopyUrl={onCopyUrl}
+          onSubmitManualCode={onSubmitManualCode}
+        />
+      )
+      break
+    case 'creating_api_key':
+      body = (
+        <box flexDirection="row">
+          <Spinner label="Creating API key for Claude Code\u2026" />
+        </box>
+      )
+      break
+    case 'about_to_retry':
+      body = <text fg={c.warning}>Retrying\u2026</text>
+      break
+    case 'success':
+      body = <SuccessView status={status} mode={mode} />
+      break
+    case 'error':
+      body = <ErrorView status={status} />
+      break
+  }
+
+  return (
+    <box flexDirection="column" gap={1} paddingX={1}>
+      {body}
+    </box>
+  )
+}

--- a/ui/src/components/ContextSuggestions.tsx
+++ b/ui/src/components/ContextSuggestions.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import { c } from '../theme.js'
+import { formatTokens } from '../utils.js'
+
+/**
+ * Inline context-health recommendations ("try /compact", "keep fewer
+ * tabs open", etc).
+ *
+ * OpenTUI-native port of the upstream `ContextSuggestions`
+ * (`ui/examples/upstream-patterns/src/components/ContextSuggestions.tsx`).
+ * Upstream wrapped Ink's `StatusIcon` and imported the `figures` npm
+ * module. The Lite port inlines tiny severity glyphs and renders with
+ * OpenTUI's `<text>`/`<box>` elements instead.
+ */
+
+export type ContextSuggestionSeverity = 'info' | 'warning' | 'error' | 'success'
+
+export type ContextSuggestion = {
+  title: string
+  detail: string
+  severity: ContextSuggestionSeverity
+  savingsTokens?: number
+}
+
+const SEVERITY_GLYPH: Record<ContextSuggestionSeverity, string> = {
+  info: '\u2139',
+  warning: '\u26A0',
+  error: '\u2716',
+  success: '\u2713',
+}
+
+const SEVERITY_COLOR: Record<ContextSuggestionSeverity, string> = {
+  info: c.info,
+  warning: c.warning,
+  error: c.error,
+  success: c.success,
+}
+
+type Props = {
+  suggestions: ContextSuggestion[]
+}
+
+export function ContextSuggestions({ suggestions }: Props) {
+  if (suggestions.length === 0) return null
+  return (
+    <box flexDirection="column" marginTop={1}>
+      <text>
+        <strong>Suggestions</strong>
+      </text>
+      {suggestions.map((s, i) => {
+        const glyph = SEVERITY_GLYPH[s.severity] ?? SEVERITY_GLYPH.info
+        const glyphColor = SEVERITY_COLOR[s.severity] ?? c.info
+        return (
+          <box
+            key={`${s.title}-${i}`}
+            flexDirection="column"
+            marginTop={i === 0 ? 0 : 1}
+          >
+            <text>
+              <span fg={glyphColor}>{glyph} </span>
+              <strong>{s.title}</strong>
+              {s.savingsTokens !== undefined && s.savingsTokens > 0 && (
+                <span fg={c.dim}>
+                  {` \u2192 save ~${formatTokens(s.savingsTokens)}`}
+                </span>
+              )}
+            </text>
+            <box marginLeft={2}>
+              <text fg={c.dim}>{s.detail}</text>
+            </box>
+          </box>
+        )
+      })}
+    </box>
+  )
+}

--- a/ui/src/components/ContextVisualization.tsx
+++ b/ui/src/components/ContextVisualization.tsx
@@ -1,0 +1,436 @@
+import React from 'react'
+import { c } from '../theme.js'
+import { formatTokens } from '../utils.js'
+import {
+  ContextSuggestions,
+  type ContextSuggestion,
+} from './ContextSuggestions.js'
+
+/**
+ * `/context` visualization \u2014 token grid + legend + per-source
+ * breakdowns (memory files, MCP tools, agents, skills).
+ *
+ * OpenTUI-native port of the upstream `ContextVisualization`
+ * (`ui/examples/upstream-patterns/src/components/ContextVisualization.tsx`).
+ * Upstream depended on `analyzeContext`, `generateContextSuggestions`,
+ * the `bun:bundle` feature gate, and the settings-source display
+ * helpers. The Lite port keeps the same visual shape but expects the
+ * caller to hand in a pre-computed `ContextVisualizationData` object.
+ */
+
+const RESERVED_CATEGORY_NAME = 'Autocompact buffer'
+
+export type ContextGridSquare = {
+  categoryName: string
+  color?: string
+  squareFullness: number
+}
+
+export type ContextCategory = {
+  name: string
+  color?: string
+  tokens: number
+  isDeferred?: boolean
+}
+
+export type ContextMcpTool = {
+  name: string
+  tokens: number
+  isLoaded: boolean
+}
+
+export type ContextAgent = {
+  agentType: string
+  source: string
+  tokens: number
+}
+
+export type ContextMemoryFile = {
+  path: string
+  displayPath?: string
+  tokens: number
+}
+
+export type ContextSkill = {
+  name: string
+  source: string
+  tokens: number
+}
+
+export type ContextVisualizationData = {
+  model: string
+  categories: ContextCategory[]
+  totalTokens: number
+  rawMaxTokens: number
+  percentage: number
+  gridRows: ContextGridSquare[][]
+  mcpTools: ContextMcpTool[]
+  deferredBuiltinTools?: Array<{ name: string; tokens: number; isLoaded: boolean }>
+  systemTools?: Array<{ name: string; tokens: number }>
+  systemPromptSections?: Array<{ name: string; tokens: number }>
+  agents: ContextAgent[]
+  skills?: { tokens: number; skillFrontmatter: ContextSkill[] }
+  memoryFiles: ContextMemoryFile[]
+  messageBreakdown?: {
+    toolCallTokens: number
+    toolResultTokens: number
+    attachmentTokens: number
+    assistantMessageTokens: number
+    userMessageTokens: number
+    toolCallsByType: Array<{ name: string; callTokens: number; resultTokens: number }>
+    attachmentsByType: Array<{ name: string; tokens: number }>
+  }
+  suggestions?: ContextSuggestion[]
+  /** Set to 'ant' to include the upstream ANT-only sections. */
+  userType?: string
+}
+
+const SOURCE_DISPLAY_ORDER = ['Project', 'User', 'Managed', 'Plugin', 'Built-in']
+
+function groupBySource<T extends { source: string; tokens: number }>(
+  items: T[],
+): Map<string, T[]> {
+  const groups = new Map<string, T[]>()
+  for (const item of items) {
+    const existing = groups.get(item.source) ?? []
+    existing.push(item)
+    groups.set(item.source, existing)
+  }
+  for (const [key, group] of groups.entries()) {
+    groups.set(key, [...group].sort((a, b) => b.tokens - a.tokens))
+  }
+  const ordered = new Map<string, T[]>()
+  for (const source of SOURCE_DISPLAY_ORDER) {
+    const group = groups.get(source)
+    if (group) ordered.set(source, group)
+  }
+  for (const [key, group] of groups.entries()) {
+    if (!ordered.has(key)) ordered.set(key, group)
+  }
+  return ordered
+}
+
+type Props = {
+  data: ContextVisualizationData
+}
+
+export function ContextVisualization({ data }: Props) {
+  const {
+    categories,
+    totalTokens,
+    rawMaxTokens,
+    percentage,
+    gridRows,
+    model,
+    memoryFiles,
+    mcpTools,
+    deferredBuiltinTools = [],
+    systemTools,
+    systemPromptSections,
+    agents,
+    skills,
+    messageBreakdown,
+    userType,
+    suggestions = [],
+  } = data
+
+  const visibleCategories = categories.filter(
+    cat =>
+      cat.tokens > 0 &&
+      cat.name !== 'Free space' &&
+      cat.name !== RESERVED_CATEGORY_NAME &&
+      !cat.isDeferred,
+  )
+  const hasDeferredMcpTools = categories.some(
+    cat => cat.isDeferred && cat.name.includes('MCP'),
+  )
+  const hasDeferredBuiltinTools = deferredBuiltinTools.length > 0
+  const autocompactCategory = categories.find(
+    cat => cat.name === RESERVED_CATEGORY_NAME,
+  )
+  const freeSpace = categories.find(c => c.name === 'Free space')
+  const isAnt = userType === 'ant'
+
+  return (
+    <box flexDirection="column" paddingLeft={1}>
+      <text>
+        <strong>Context Usage</strong>
+      </text>
+      <box flexDirection="row" gap={2}>
+        <box flexDirection="column" flexShrink={0}>
+          {gridRows.map((row, rowIndex) => (
+            <box key={rowIndex} flexDirection="row">
+              {row.map((square, colIndex) => {
+                if (square.categoryName === 'Free space') {
+                  return (
+                    <text key={colIndex} fg={c.dim}>
+                      {'\u26F6 '}
+                    </text>
+                  )
+                }
+                if (square.categoryName === RESERVED_CATEGORY_NAME) {
+                  return (
+                    <text key={colIndex} fg={square.color}>
+                      {'\u26DD '}
+                    </text>
+                  )
+                }
+                return (
+                  <text key={colIndex} fg={square.color}>
+                    {square.squareFullness >= 0.7 ? '\u26C1 ' : '\u26C0 '}
+                  </text>
+                )
+              })}
+            </box>
+          ))}
+        </box>
+        <box flexDirection="column" flexShrink={0}>
+          <text fg={c.dim}>
+            {model} \u00B7 {formatTokens(totalTokens)}/{formatTokens(rawMaxTokens)} tokens ({percentage}%)
+          </text>
+          <text>{' '}</text>
+          <text>
+            <em>
+              <span fg={c.dim}>Estimated usage by category</span>
+            </em>
+          </text>
+          {visibleCategories.map((cat, index) => {
+            const tokenDisplay = formatTokens(cat.tokens)
+            const percentDisplay = cat.isDeferred
+              ? 'N/A'
+              : `${((cat.tokens / rawMaxTokens) * 100).toFixed(1)}%`
+            const isReserved = cat.name === RESERVED_CATEGORY_NAME
+            const symbol = cat.isDeferred ? ' ' : isReserved ? '\u26DD' : '\u26C1'
+            return (
+              <box key={`${cat.name}-${index}`} flexDirection="row">
+                <text fg={cat.color}>{symbol}</text>
+                <text>{` ${cat.name}: `}</text>
+                <text fg={c.dim}>{tokenDisplay} tokens ({percentDisplay})</text>
+              </box>
+            )
+          })}
+          {(freeSpace?.tokens ?? 0) > 0 && freeSpace && (
+            <box flexDirection="row">
+              <text fg={c.dim}>\u26F6</text>
+              <text>{` Free space: `}</text>
+              <text fg={c.dim}>
+                {formatTokens(freeSpace.tokens)} (
+                {((freeSpace.tokens / rawMaxTokens) * 100).toFixed(1)}%)
+              </text>
+            </box>
+          )}
+          {autocompactCategory && autocompactCategory.tokens > 0 && (
+            <box flexDirection="row">
+              <text fg={autocompactCategory.color}>\u26DD</text>
+              <text fg={c.dim}>{` ${autocompactCategory.name}: `}</text>
+              <text fg={c.dim}>
+                {formatTokens(autocompactCategory.tokens)} tokens (
+                {((autocompactCategory.tokens / rawMaxTokens) * 100).toFixed(1)}%)
+              </text>
+            </box>
+          )}
+        </box>
+      </box>
+
+      <box flexDirection="column">
+        {mcpTools.length > 0 && (
+          <box flexDirection="column" marginTop={1}>
+            <text>
+              <strong>MCP tools</strong>
+              <span fg={c.dim}>
+                {` \u00B7 /mcp${hasDeferredMcpTools ? ' (loaded on-demand)' : ''}`}
+              </span>
+            </text>
+            {mcpTools.some(t => t.isLoaded) && (
+              <box flexDirection="column" marginTop={1}>
+                <text fg={c.dim}>Loaded</text>
+                {mcpTools
+                  .filter(t => t.isLoaded)
+                  .map((tool, i) => (
+                    <box key={`loaded-${i}`} flexDirection="row">
+                      <text>\u2514 {tool.name}: </text>
+                      <text fg={c.dim}>{formatTokens(tool.tokens)} tokens</text>
+                    </box>
+                  ))}
+              </box>
+            )}
+            {hasDeferredMcpTools && mcpTools.some(t => !t.isLoaded) && (
+              <box flexDirection="column" marginTop={1}>
+                <text fg={c.dim}>Available</text>
+                {mcpTools
+                  .filter(t => !t.isLoaded)
+                  .map((tool, i) => (
+                    <box key={`avail-${i}`} flexDirection="row">
+                      <text fg={c.dim}>\u2514 {tool.name}</text>
+                    </box>
+                  ))}
+              </box>
+            )}
+            {!hasDeferredMcpTools &&
+              mcpTools.map((tool, i) => (
+                <box key={`all-${i}`} flexDirection="row">
+                  <text>\u2514 {tool.name}: </text>
+                  <text fg={c.dim}>{formatTokens(tool.tokens)} tokens</text>
+                </box>
+              ))}
+          </box>
+        )}
+
+        {isAnt && ((systemTools && systemTools.length > 0) || hasDeferredBuiltinTools) && (
+          <box flexDirection="column" marginTop={1}>
+            <text>
+              <strong>[ANT-ONLY] System tools</strong>
+              {hasDeferredBuiltinTools && (
+                <span fg={c.dim}> (some loaded on-demand)</span>
+              )}
+            </text>
+            <box flexDirection="column" marginTop={1}>
+              <text fg={c.dim}>Loaded</text>
+              {systemTools?.map((tool, i) => (
+                <box key={`sys-${i}`} flexDirection="row">
+                  <text>\u2514 {tool.name}: </text>
+                  <text fg={c.dim}>{formatTokens(tool.tokens)} tokens</text>
+                </box>
+              ))}
+              {deferredBuiltinTools
+                .filter(t => t.isLoaded)
+                .map((tool, i) => (
+                  <box key={`def-loaded-${i}`} flexDirection="row">
+                    <text>\u2514 {tool.name}: </text>
+                    <text fg={c.dim}>{formatTokens(tool.tokens)} tokens</text>
+                  </box>
+                ))}
+            </box>
+            {hasDeferredBuiltinTools &&
+              deferredBuiltinTools.some(t => !t.isLoaded) && (
+                <box flexDirection="column" marginTop={1}>
+                  <text fg={c.dim}>Available</text>
+                  {deferredBuiltinTools
+                    .filter(t => !t.isLoaded)
+                    .map((tool, i) => (
+                      <box key={`def-avail-${i}`} flexDirection="row">
+                        <text fg={c.dim}>\u2514 {tool.name}</text>
+                      </box>
+                    ))}
+                </box>
+              )}
+          </box>
+        )}
+
+        {isAnt && systemPromptSections && systemPromptSections.length > 0 && (
+          <box flexDirection="column" marginTop={1}>
+            <text>
+              <strong>[ANT-ONLY] System prompt sections</strong>
+            </text>
+            {systemPromptSections.map((section, i) => (
+              <box key={`sp-${i}`} flexDirection="row">
+                <text>\u2514 {section.name}: </text>
+                <text fg={c.dim}>{formatTokens(section.tokens)} tokens</text>
+              </box>
+            ))}
+          </box>
+        )}
+
+        {agents.length > 0 && (
+          <box flexDirection="column" marginTop={1}>
+            <text>
+              <strong>Custom agents</strong>
+              <span fg={c.dim}> \u00B7 /agents</span>
+            </text>
+            {Array.from(groupBySource(agents).entries()).map(
+              ([sourceDisplay, sourceAgents]) => (
+                <box key={sourceDisplay} flexDirection="column" marginTop={1}>
+                  <text fg={c.dim}>{sourceDisplay}</text>
+                  {sourceAgents.map((agent, i) => (
+                    <box key={`agent-${i}`} flexDirection="row">
+                      <text>\u2514 {agent.agentType}: </text>
+                      <text fg={c.dim}>{formatTokens(agent.tokens)} tokens</text>
+                    </box>
+                  ))}
+                </box>
+              ),
+            )}
+          </box>
+        )}
+
+        {memoryFiles.length > 0 && (
+          <box flexDirection="column" marginTop={1}>
+            <text>
+              <strong>Memory files</strong>
+              <span fg={c.dim}> \u00B7 /memory</span>
+            </text>
+            {memoryFiles.map((file, i) => (
+              <box key={`mem-${i}`} flexDirection="row">
+                <text>\u2514 {file.displayPath ?? file.path}: </text>
+                <text fg={c.dim}>{formatTokens(file.tokens)} tokens</text>
+              </box>
+            ))}
+          </box>
+        )}
+
+        {skills && skills.tokens > 0 && (
+          <box flexDirection="column" marginTop={1}>
+            <text>
+              <strong>Skills</strong>
+              <span fg={c.dim}> \u00B7 /skills</span>
+            </text>
+            {Array.from(groupBySource(skills.skillFrontmatter).entries()).map(
+              ([sourceDisplay, sourceSkills]) => (
+                <box key={sourceDisplay} flexDirection="column" marginTop={1}>
+                  <text fg={c.dim}>{sourceDisplay}</text>
+                  {sourceSkills.map((skill, i) => (
+                    <box key={`skill-${i}`} flexDirection="row">
+                      <text>\u2514 {skill.name}: </text>
+                      <text fg={c.dim}>{formatTokens(skill.tokens)} tokens</text>
+                    </box>
+                  ))}
+                </box>
+              ),
+            )}
+          </box>
+        )}
+
+        {isAnt && messageBreakdown && (
+          <box flexDirection="column" marginTop={1}>
+            <text>
+              <strong>[ANT-ONLY] Message breakdown</strong>
+            </text>
+            <box flexDirection="column" marginLeft={1}>
+              <text>Tool calls: <span fg={c.dim}>{formatTokens(messageBreakdown.toolCallTokens)} tokens</span></text>
+              <text>Tool results: <span fg={c.dim}>{formatTokens(messageBreakdown.toolResultTokens)} tokens</span></text>
+              <text>Attachments: <span fg={c.dim}>{formatTokens(messageBreakdown.attachmentTokens)} tokens</span></text>
+              <text>Assistant messages (non-tool): <span fg={c.dim}>{formatTokens(messageBreakdown.assistantMessageTokens)} tokens</span></text>
+              <text>User messages (non-tool-result): <span fg={c.dim}>{formatTokens(messageBreakdown.userMessageTokens)} tokens</span></text>
+            </box>
+            {messageBreakdown.toolCallsByType.length > 0 && (
+              <box flexDirection="column" marginTop={1}>
+                <text><strong>[ANT-ONLY] Top tools</strong></text>
+                {messageBreakdown.toolCallsByType.slice(0, 5).map((tool, i) => (
+                  <box key={`tool-${i}`} marginLeft={1} flexDirection="row">
+                    <text>\u2514 {tool.name}: </text>
+                    <text fg={c.dim}>
+                      calls {formatTokens(tool.callTokens)}, results {formatTokens(tool.resultTokens)}
+                    </text>
+                  </box>
+                ))}
+              </box>
+            )}
+            {messageBreakdown.attachmentsByType.length > 0 && (
+              <box flexDirection="column" marginTop={1}>
+                <text><strong>[ANT-ONLY] Top attachments</strong></text>
+                {messageBreakdown.attachmentsByType.slice(0, 5).map((att, i) => (
+                  <box key={`att-${i}`} marginLeft={1} flexDirection="row">
+                    <text>\u2514 {att.name}: </text>
+                    <text fg={c.dim}>{formatTokens(att.tokens)} tokens</text>
+                  </box>
+                ))}
+              </box>
+            )}
+          </box>
+        )}
+      </box>
+
+      <ContextSuggestions suggestions={suggestions} />
+    </box>
+  )
+}

--- a/ui/src/components/CoordinatorAgentStatus.tsx
+++ b/ui/src/components/CoordinatorAgentStatus.tsx
@@ -1,0 +1,208 @@
+import React, { useEffect, useState } from 'react'
+import { c } from '../theme.js'
+import { formatNumber } from '../utils.js'
+import { formatDuration } from './shell/format.js'
+
+/**
+ * Coordinator panel \u2014 steerable list of local agent tasks shown below
+ * the prompt input footer when any `local_agent` tasks exist.
+ *
+ * OpenTUI-native port of the upstream `CoordinatorAgentStatus`
+ * (`ui/examples/upstream-patterns/src/components/CoordinatorAgentStatus.tsx`).
+ * Upstream pulled state from a task framework this repo doesn't ship
+ * (`tasks/LocalAgentTask`), so this port accepts `CoordinatorTask`s
+ * and a selected-index directly \u2014 parity with the upstream visual
+ * contract, no hidden dependency on the teammate-view helpers.
+ */
+
+const BLACK_CIRCLE = '\u25CF'
+const CIRCLE = '\u25CB'
+const POINTER = '\u276F'
+const PLAY_ICON = '\u25B6'
+const PAUSE_ICON = '\u23F8'
+const ARROW_UP = '\u2191'
+const ARROW_DOWN = '\u2193'
+
+export type CoordinatorTaskStatus = 'running' | 'paused' | 'completed' | 'failed'
+
+export type CoordinatorTask = {
+  id: string
+  name?: string
+  description: string
+  status: CoordinatorTaskStatus
+  startTime: number
+  endTime?: number
+  totalPausedMs?: number
+  progress?: {
+    summary?: string
+    tokenCount?: number
+    lastActivity?: 'input' | 'output'
+  }
+  pendingMessages?: Array<unknown>
+  evictAfter?: number
+}
+
+type Props = {
+  tasks: CoordinatorTask[]
+  /**
+   * Index into the logical list starting with the synthetic "main" row
+   * at `0`. Pass `undefined` to render without any highlight.
+   */
+  selectedIndex?: number
+  /** The task ID currently being viewed (drives the `BLACK_CIRCLE` bullet). */
+  viewingTaskId?: string
+  onSelectMain?: () => void
+  onSelectTask?: (task: CoordinatorTask) => void
+}
+
+function isRunning(status: CoordinatorTaskStatus): boolean {
+  return status === 'running' || status === 'paused'
+}
+
+function useNowTick(shouldTick: boolean): void {
+  const [, setTick] = useState(0)
+  useEffect(() => {
+    if (!shouldTick) return
+    const id = setInterval(() => setTick(t => t + 1), 1000)
+    return () => clearInterval(id)
+  }, [shouldTick])
+}
+
+export function CoordinatorAgentStatus({
+  tasks,
+  selectedIndex,
+  viewingTaskId,
+  onSelectMain,
+  onSelectTask,
+}: Props) {
+  const hasRunning = tasks.some(t => isRunning(t.status))
+  useNowTick(hasRunning)
+
+  const visibleTasks = tasks.filter(t => t.evictAfter !== 0)
+  if (visibleTasks.length === 0) return null
+
+  return (
+    <box flexDirection="column" marginTop={1}>
+      <MainLine
+        isSelected={selectedIndex === 0}
+        isViewed={viewingTaskId === undefined}
+        onClick={onSelectMain}
+      />
+      {visibleTasks.map((task, i) => (
+        <AgentLine
+          key={task.id}
+          task={task}
+          isSelected={selectedIndex === i + 1}
+          isViewed={viewingTaskId === task.id}
+          onClick={onSelectTask ? () => onSelectTask(task) : undefined}
+        />
+      ))}
+    </box>
+  )
+}
+
+function MainLine({
+  isSelected,
+  isViewed,
+  onClick,
+}: {
+  isSelected?: boolean
+  isViewed?: boolean
+  onClick?: () => void
+}) {
+  const bullet = isViewed ? BLACK_CIRCLE : CIRCLE
+  const prefix = isSelected ? `${POINTER} ` : '  '
+  const dim = !isSelected && !isViewed
+  const content = (
+    <text fg={dim ? c.dim : undefined}>
+      {isViewed ? (
+        <strong>
+          {prefix}
+          {bullet} main
+        </strong>
+      ) : (
+        <>
+          {prefix}
+          {bullet} main
+        </>
+      )}
+    </text>
+  )
+  if (!onClick) return content
+  return <box>{content}</box>
+}
+
+function AgentLine({
+  task,
+  isSelected,
+  isViewed,
+  onClick,
+}: {
+  task: CoordinatorTask
+  isSelected?: boolean
+  isViewed?: boolean
+  onClick?: () => void
+}) {
+  const running = isRunning(task.status)
+  const pausedMs = task.totalPausedMs ?? 0
+  const elapsedMs = Math.max(
+    0,
+    running
+      ? Date.now() - task.startTime - pausedMs
+      : (task.endTime ?? task.startTime) - task.startTime - pausedMs,
+  )
+  const elapsed = formatDuration(elapsedMs)
+  const tokenCount = task.progress?.tokenCount
+  const lastActivity = task.progress?.lastActivity
+  const arrow = lastActivity === 'output' ? ARROW_DOWN : ARROW_UP
+  const tokenText =
+    tokenCount !== undefined && tokenCount > 0
+      ? ` \u00B7 ${arrow} ${formatNumber(tokenCount)} tokens`
+      : ''
+  const queuedCount = task.pendingMessages?.length ?? 0
+  const queuedText = queuedCount > 0 ? ` \u00B7 ${queuedCount} queued` : ''
+  const displayDescription = task.progress?.summary || task.description
+  const bullet = isViewed ? BLACK_CIRCLE : CIRCLE
+  const prefix = isSelected ? `${POINTER} ` : '  '
+  const sep = task.status === 'paused' ? PAUSE_ICON : running ? PLAY_ICON : BLACK_CIRCLE
+  const dim = !isSelected && !isViewed
+  const hint =
+    isSelected && !isViewed
+      ? ` \u00B7 x to ${running ? 'stop' : 'clear'}`
+      : ''
+
+  const content = (
+    <text fg={dim ? c.dim : undefined}>
+      {isViewed ? (
+        <strong>
+          {prefix}
+          {bullet}{' '}
+          {task.name && (
+            <>
+              <span>{task.name}</span>
+              {': '}
+            </>
+          )}
+          {displayDescription} {sep} {elapsed}
+        </strong>
+      ) : (
+        <>
+          {prefix}
+          {bullet}{' '}
+          {task.name && (
+            <strong>
+              <span>{task.name}: </span>
+            </strong>
+          )}
+          {displayDescription} {sep} {elapsed}
+        </>
+      )}
+      {tokenText}
+      {queuedCount > 0 && <span fg={c.warning}>{queuedText}</span>}
+      {hint && <span fg={c.dim}>{hint}</span>}
+    </text>
+  )
+
+  if (!onClick) return content
+  return <box>{content}</box>
+}

--- a/ui/src/components/CostThresholdDialog.tsx
+++ b/ui/src/components/CostThresholdDialog.tsx
@@ -1,0 +1,78 @@
+import React from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../theme.js'
+
+/**
+ * "You've spent $X on the Anthropic API this session." notice.
+ *
+ * OpenTUI-native port of the upstream `CostThresholdDialog`
+ * (`ui/examples/upstream-patterns/src/components/CostThresholdDialog.tsx`).
+ * Single-action acknowledgement \u2014 any confirming keypress resolves
+ * via `onDone`.
+ */
+
+type Props = {
+  onDone: () => void
+  /**
+   * Accumulated session cost in USD. Upstream hard-coded "$5"; this port
+   * accepts it so the caller can pick the threshold (the cost-tracker
+   * lives in the Rust backend). Falls back to "$5" when omitted.
+   */
+  amountUsd?: number
+}
+
+const DOCS_URL = 'https://docs.claude.com/en/docs/claude-code/costs'
+
+function formatUsd(amount: number): string {
+  if (amount >= 10) return `$${amount.toFixed(0)}`
+  return `$${amount.toFixed(2)}`
+}
+
+export function CostThresholdDialog({ onDone, amountUsd }: Props) {
+  const amountLabel = amountUsd !== undefined ? formatUsd(amountUsd) : '$5'
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    if (
+      event.name === 'return' ||
+      event.name === 'enter' ||
+      event.name === 'escape' ||
+      event.name === 'space'
+    ) {
+      onDone()
+    }
+  })
+
+  return (
+    <box
+      position="absolute"
+      bottom={3}
+      left={1}
+      right={1}
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.warning}
+      title={`You've spent ${amountLabel} on the Anthropic API this session.`}
+      titleAlignment="center"
+      paddingX={2}
+      paddingY={1}
+    >
+      <text>Learn more about how to monitor your spending:</text>
+      <box marginTop={1}>
+        <text fg={c.info}>{DOCS_URL}</text>
+      </box>
+      <box marginTop={1}>
+        <text>
+          <strong>
+            <span fg={c.bg} bg={c.textBright}>{' Got it, thanks! '}</span>
+          </strong>
+        </text>
+      </box>
+      <box marginTop={1}>
+        <text fg={c.dim}>
+          Press <strong>Enter</strong> to continue\u2026
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/CtrlOToExpand.tsx
+++ b/ui/src/components/CtrlOToExpand.tsx
@@ -1,0 +1,67 @@
+import React, { createContext, useContext } from 'react'
+import { c } from '../theme.js'
+import { shortcutLabel } from '../keybindings.js'
+import { useAppState } from '../store/app-store.js'
+
+/**
+ * Tiny "`(ctrl+o to expand)`" affordance rendered under compact /
+ * collapsed messages in the live prompt view.
+ *
+ * OpenTUI-native port of the upstream `CtrlOToExpand`
+ * (`ui/examples/upstream-patterns/src/components/CtrlOToExpand.tsx`).
+ * Upstream also exported a `chalk`-flavoured plain-string variant for
+ * inline composition; the Lite port keeps that surface as
+ * `ctrlOToExpand(config)` but returns raw text \u2014 OpenTUI renders
+ * ANSI-free strings and styles via JSX.
+ *
+ * `SubAgentContext` + `InVirtualListContext` are honoured so the same
+ * hint doesn't stack up for every sub-agent output chunk inside the
+ * transcript or virtualised scrollers.
+ */
+
+const SubAgentContext = createContext<boolean>(false)
+const InVirtualListContext = createContext<boolean>(false)
+
+export function SubAgentProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <SubAgentContext.Provider value={true}>{children}</SubAgentContext.Provider>
+  )
+}
+
+export function InVirtualListProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <InVirtualListContext.Provider value={true}>{children}</InVirtualListContext.Provider>
+  )
+}
+
+export function CtrlOToExpand() {
+  const isInSubAgent = useContext(SubAgentContext)
+  const inVirtualList = useContext(InVirtualListContext)
+  const { keybindingConfig } = useAppState()
+
+  if (isInSubAgent || inVirtualList) return null
+
+  const chord =
+    shortcutLabel('app:toggleTranscript', {
+      context: 'Global',
+      config: keybindingConfig ?? null,
+    }) || 'ctrl+o'
+
+  return (
+    <text fg={c.dim}>{`(${chord} to expand)`}</text>
+  )
+}
+
+/**
+ * Non-component variant returning plain text so callers can compose it
+ * inside a larger `<text>` node. The upstream version returns a chalk
+ * dimmed string; OpenTUI handles styling via JSX, so we return the raw
+ * label and let the caller wrap it in a dim `<span>` if needed.
+ */
+export function ctrlOToExpand(config?: Parameters<typeof shortcutLabel>[1]): string {
+  const chord = shortcutLabel('app:toggleTranscript', {
+    context: 'Global',
+    ...config,
+  }) || 'ctrl+o'
+  return `(${chord} to expand)`
+}

--- a/ui/src/utils.ts
+++ b/ui/src/utils.ts
@@ -22,3 +22,13 @@ export function truncate(text: string, maxLen: number): string {
   if (text.length <= maxLen) return text
   return text.slice(0, maxLen - 1) + '\u2026'
 }
+
+/**
+ * Format an integer count with thousands separators. Mirrors the
+ * upstream `formatNumber` helper (`ui/examples/upstream-patterns/src/
+ * utils/format.ts`) used by progress line / coordinator panels.
+ */
+export function formatNumber(count: number): string {
+  if (!Number.isFinite(count)) return '0'
+  return Math.round(count).toLocaleString('en-US')
+}


### PR DESCRIPTION
## Summary

Ports the A\u2013C batch of upstream Ink components from
`ui/examples/upstream-patterns/src/components/` into the active OpenTUI
tree at `ui/src/components/`. Each file was either missing from the
active tree or co-located under a nested directory \u2014 this PR lands
them at the top-level path the upstream reference uses so the two trees
stay easy to diff during the full-build migration.

20 components ported: `AgentProgressLine`, `ApproveApiKey`,
`AutoModeOptInDialog`, `BaseTextInput`, `BashModeProgress`,
`BridgeDialog`, `BuiltinStatusLine`, `BypassPermissionsModeDialog`,
`ChannelDowngradeDialog`, `ClaudeInChromeOnboarding`,
`ClaudeMdExternalIncludesDialog`, `ClickableImageRef`, `CompactSummary`,
`ConfigurableShortcutHint`, `ConsoleOAuthFlow`, `ContextSuggestions`,
`ContextVisualization`, `CoordinatorAgentStatus`, `CostThresholdDialog`,
`CtrlOToExpand`.

Also adds `formatNumber()` to `ui/src/utils.ts` for the progress-line and
coordinator panels.

## Port strategy

Each port replaces Ink-specific dependencies with OpenTUI-native
primitives while preserving the upstream UX:

- `@anthropic/ink` `Box`/`Text`/`Dialog`/`Select`/`Link` \u2192 lowercase
  `<box>`/`<text>`/`<span>` with local `c` theme + custom dialog chrome
- `useInput` / `useKeybinding` \u2192 `useKeyboard` from `@opentui/react`
- `KeyboardShortcutHint` \u2192 inline render via `shortcutLabel()` from
  `keybindings.ts`
- `saveGlobalConfig`, `logEvent`, `updateSettingsForSource`,
  `OAuthService`, `installOAuthTokens` \u2192 surfaced through callback
  props so persistence / analytics / token storage stay owned by the
  Rust backend (parity with the rest of the OpenTUI tree)
- `figures` / `chalk` / `qrcode` (Node-only deps) \u2192 inline unicode
  glyphs; QR payload passed in from the caller
- Legally-reviewed copy in `AutoModeOptInDialog.AUTO_MODE_DESCRIPTION`
  was kept byte-for-byte with the upstream constant

`BuiltinStatusLine.tsx` is placed at the top level \u2014 it mirrors the
upstream's rate-limit/context/cost surface, distinct from the existing
`StatusLine/BuiltinStatusLine.tsx` which renders a cwd/model/subsystem
bar and stays in place as the orchestrator's built-in row.

`ConsoleOAuthFlow.tsx` is a presentation-only port: the upstream owns a
9-state machine tied to `OAuthService` / settings writes that live
Rust-side in this tree, so the Lite component takes a `ConsoleOAuthStatus`
and callbacks and the backend drives the actual OAuth dance.

`CoordinatorAgentStatus.tsx` accepts `CoordinatorTask[]` + selection
index directly instead of pulling from a task framework this repo
doesn't ship, keeping the upstream visual contract intact.

## Why

Per `CLAUDE.md`, this branch is in the full-build phase \u2014 the
upstream pattern sample at `ui/examples/upstream-patterns/` is a
reference for porting, not a separate runtime. Landing these files at
their upstream-matching paths lets future PRs diff the two trees
directly and unblocks dependent ports (e.g. `DevBar`, `ExitFlow`,
`GlobalSearchDialog`) that import from this batch.

## Notes for reviewers

- No wiring changes \u2014 components are added but not yet mounted from
  `App.tsx`. Follow-up PRs will route the relevant backend events into
  them.
- Pre-existing TypeScript errors in this worktree
  (`Cannot find module 'react'`, `@opentui/react/jsx-runtime`) affect
  the new files the same way they affect existing ones
  (`LspRecommendationDialog.tsx`, `SubsystemStatus.tsx`) \u2014 this is a
  type-resolution issue in the worktree's node_modules layout, not a
  runtime problem.
- `ClickableImageRef` reuses the existing `osc8Link`/`fileUrl` helpers
  from `FilePathLink.tsx` and takes `imagePath` from the caller rather
  than reaching into a frontend image store.

## Test plan

- [ ] `bun run build` in `ui/` succeeds
- [ ] No import of the new files regresses the existing tree
  (`grep` confirmed \u2014 they are additive)
- [ ] Smoke-test existing dialogs still render after the additive change
  (`LspRecommendationDialog`, permission prompts)

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)