### PR TITLE
feat(ui): port helpv2, highlighted-code, hooks, LogoV2 folders

### DIFF
--- a/ui/src/components/LogoV2/AnimatedAsterisk.tsx
+++ b/ui/src/components/LogoV2/AnimatedAsterisk.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useRef, useState } from 'react'
+
+/**
+ * Color-sweeping teardrop-asterisk glyph used by the notice components
+ * (`VoiceModeNotice`, `Opus1mMergeNotice`).
+ *
+ * OpenTUI-native port of the upstream `LogoV2/AnimatedAsterisk`
+ * (`ui/examples/upstream-patterns/src/components/LogoV2/AnimatedAsterisk.tsx`).
+ * Upstream drove the hue cycle with Ink's `useAnimationFrame` and
+ * exposed a settings-driven `prefersReducedMotion` opt-out. The Lite
+ * port replaces the animation frame source with a 50 ms `setInterval`
+ * and accepts the reduced-motion preference as a prop so it stays
+ * decoupled from the settings stack.
+ */
+
+const SWEEP_DURATION_MS = 1500
+const SWEEP_COUNT = 2
+const TOTAL_ANIMATION_MS = SWEEP_DURATION_MS * SWEEP_COUNT
+const SETTLED_COLOR = '#999999'
+const TEARDROP_ASTERISK = '\u273B'
+
+type Props = {
+  char?: string
+  reducedMotion?: boolean
+}
+
+function hueToRgb(hue: number): string {
+  const h = hue / 60
+  const sector = Math.floor(h) % 6
+  const f = h - Math.floor(h)
+  const q = Math.round((1 - f) * 255)
+  const t = Math.round(f * 255)
+  const components: Record<number, [number, number, number]> = {
+    0: [255, t, 0],
+    1: [q, 255, 0],
+    2: [0, 255, t],
+    3: [0, q, 255],
+    4: [t, 0, 255],
+    5: [255, 0, q],
+  }
+  const [r, g, b] = components[sector] ?? [255, 255, 255]
+  const toHex = (value: number) => value.toString(16).padStart(2, '0')
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`
+}
+
+export function AnimatedAsterisk({
+  char = TEARDROP_ASTERISK,
+  reducedMotion = false,
+}: Props = {}) {
+  const [done, setDone] = useState(reducedMotion)
+  const [now, setNow] = useState(0)
+  const startRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (done) return
+    const begin = Date.now()
+    startRef.current = begin
+    const tick = setInterval(() => setNow(Date.now() - begin), 50)
+    const end = setTimeout(() => {
+      clearInterval(tick)
+      setDone(true)
+    }, TOTAL_ANIMATION_MS)
+    return () => {
+      clearInterval(tick)
+      clearTimeout(end)
+    }
+  }, [done])
+
+  if (done) {
+    return <text fg={SETTLED_COLOR}>{char}</text>
+  }
+
+  const hue = ((now / SWEEP_DURATION_MS) * 360) % 360
+  const fg = hueToRgb(hue)
+  return <text fg={fg}>{char}</text>
+}

--- a/ui/src/components/LogoV2/AnimatedClawd.tsx
+++ b/ui/src/components/LogoV2/AnimatedClawd.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { Clawd, type ClawdPose } from './Clawd.js'
+
+/**
+ * `<Clawd>` with click-triggered micro-animations.
+ *
+ * OpenTUI-native port of the upstream `LogoV2/AnimatedClawd`
+ * (`ui/examples/upstream-patterns/src/components/LogoV2/AnimatedClawd.tsx`).
+ * The upstream registered mouse-click intents to trigger jump-wave /
+ * look-around sequences. OpenTUI doesn't surface box-level `onClick`
+ * in this project today, so the Lite port ships the animation engine
+ * and starts sequences on mount (optional \u2014 caller can opt out) and
+ * exposes `playSequence()` through a ref for host-driven triggers.
+ */
+
+type Frame = { pose: ClawdPose; offset: number }
+
+const FRAME_MS = 60
+const CLAWD_HEIGHT = 3
+
+function hold(pose: ClawdPose, offset: number, frames: number): Frame[] {
+  return Array.from({ length: frames }, () => ({ pose, offset }))
+}
+
+const JUMP_WAVE: Frame[] = [
+  ...hold('default', 1, 2),
+  ...hold('arms-up', 0, 3),
+  ...hold('default', 0, 1),
+  ...hold('default', 1, 2),
+  ...hold('arms-up', 0, 3),
+  ...hold('default', 0, 1),
+]
+
+const LOOK_AROUND: Frame[] = [
+  ...hold('look-right', 0, 5),
+  ...hold('look-left', 0, 5),
+  ...hold('default', 0, 1),
+]
+
+const IDLE: Frame = { pose: 'default', offset: 0 }
+
+export const CLAWD_ANIMATIONS = {
+  jump: JUMP_WAVE,
+  lookAround: LOOK_AROUND,
+}
+
+type Props = {
+  /** Set `false` to freeze on the idle pose (e.g. reduced-motion). */
+  animate?: boolean
+  /** Which sequence to play. Defaults to `'jump'`. */
+  sequence?: keyof typeof CLAWD_ANIMATIONS
+  /** When true, restarts the sequence once the previous one ends. */
+  loop?: boolean
+  /** Forward to `<Clawd>` when the embedder is on Apple Terminal. */
+  appleTerminal?: boolean
+}
+
+export function AnimatedClawd({
+  animate = true,
+  sequence = 'jump',
+  loop = false,
+  appleTerminal = false,
+}: Props = {}) {
+  const frames = CLAWD_ANIMATIONS[sequence]
+  const [frameIndex, setFrameIndex] = useState(animate ? 0 : -1)
+  const loopRef = useRef(loop)
+  loopRef.current = loop
+
+  useEffect(() => {
+    if (!animate) return
+    setFrameIndex(0)
+  }, [animate, sequence])
+
+  useEffect(() => {
+    if (frameIndex === -1) return
+    if (frameIndex >= frames.length) {
+      if (loopRef.current) {
+        const restart = setTimeout(() => setFrameIndex(0), FRAME_MS * 3)
+        return () => clearTimeout(restart)
+      }
+      setFrameIndex(-1)
+      return
+    }
+    const timer = setTimeout(() => setFrameIndex(prev => prev + 1), FRAME_MS)
+    return () => clearTimeout(timer)
+  }, [frameIndex, frames.length])
+
+  const current = frameIndex >= 0 && frameIndex < frames.length ? frames[frameIndex]! : IDLE
+
+  return (
+    <box height={CLAWD_HEIGHT} flexDirection="column">
+      <box marginTop={current.offset} flexShrink={0}>
+        <Clawd pose={current.pose} appleTerminal={appleTerminal} />
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/LogoV2/ChannelsNotice.tsx
+++ b/ui/src/components/LogoV2/ChannelsNotice.tsx
@@ -1,0 +1,107 @@
+import React from 'react'
+import { c } from '../../theme.js'
+
+/**
+ * "Listening for channel messages from\u2026" notice shown when the user
+ * launched with `--channels` (KAIROS feature).
+ *
+ * OpenTUI-native port of the upstream `LogoV2/ChannelsNotice`
+ * (`ui/examples/upstream-patterns/src/components/LogoV2/ChannelsNotice.tsx`).
+ * The upstream component inspected bootstrap state, GrowthBook flags,
+ * MCP configs, and installed plugins to decide which of four branches
+ * to render. The Lite port accepts a flat `ChannelsNoticeStatus` so the
+ * Rust backend produces the snapshot once (KAIROS lives Rust-side) and
+ * the UI stays a pure renderer.
+ */
+
+export type ChannelEntryDisplay = {
+  kind: 'plugin' | 'server'
+  name: string
+  /** Required for `kind === 'plugin'`. */
+  marketplace?: string
+  dev?: boolean
+}
+
+export type ChannelsNoticeUnmatched = {
+  entry: ChannelEntryDisplay
+  why: string
+}
+
+export type ChannelsNoticeStatus =
+  | { state: 'hidden' }
+  | {
+      state: 'disabled' | 'noAuth' | 'policyBlocked' | 'listening'
+      channels: ChannelEntryDisplay[]
+      flag: string
+      unmatched?: ChannelsNoticeUnmatched[]
+    }
+
+function formatEntry(entry: ChannelEntryDisplay): string {
+  return entry.kind === 'plugin'
+    ? `plugin:${entry.name}@${entry.marketplace ?? ''}`
+    : `server:${entry.name}`
+}
+
+export function ChannelsNotice({
+  status,
+}: {
+  status: ChannelsNoticeStatus
+}) {
+  if (status.state === 'hidden') return null
+  const list = status.channels.map(formatEntry).join(', ')
+  const flag = status.flag
+
+  if (status.state === 'disabled') {
+    return (
+      <box paddingLeft={2} flexDirection="column">
+        <text fg={c.error}>{`${flag} ignored (${list})`}</text>
+        <text fg={c.dim}>Channels are not currently available</text>
+      </box>
+    )
+  }
+
+  if (status.state === 'noAuth') {
+    return (
+      <box paddingLeft={2} flexDirection="column">
+        <text fg={c.error}>{`${flag} ignored (${list})`}</text>
+        <text fg={c.dim}>
+          Channels require claude.ai authentication \u00B7 run /login, then restart
+        </text>
+      </box>
+    )
+  }
+
+  if (status.state === 'policyBlocked') {
+    return (
+      <box paddingLeft={2} flexDirection="column">
+        <text fg={c.error}>{`${flag} blocked by org policy (${list})`}</text>
+        <text fg={c.dim}>Inbound messages will be silently dropped</text>
+        <text fg={c.dim}>
+          Have an administrator set channelsEnabled: true in managed settings to
+          enable
+        </text>
+        {status.unmatched?.map((u, i) => (
+          <text key={`u-${i}`} fg={c.warning}>
+            {`${formatEntry(u.entry)} \u00B7 ${u.why}`}
+          </text>
+        ))}
+      </box>
+    )
+  }
+
+  return (
+    <box paddingLeft={2} flexDirection="column">
+      <text fg={c.error}>{`Listening for channel messages from: ${list}`}</text>
+      <text fg={c.dim}>
+        Experimental \u00B7 inbound messages will be pushed into this session,
+        this carries prompt injection risks. Restart Claude Code without {flag}{' '}
+        to disable.
+      </text>
+      {status.unmatched?.map((u, i) => (
+        <text key={`u-${i}`} fg={c.warning}>
+          {`${formatEntry(u.entry)} \u00B7 ${u.why}`}
+        </text>
+      ))}
+    </box>
+  )
+}

--- a/ui/src/components/LogoV2/Clawd.tsx
+++ b/ui/src/components/LogoV2/Clawd.tsx
@@ -1,0 +1,89 @@
+import React from 'react'
+
+/**
+ * "Clawd" ASCII mascot, shown inside the LogoV2 frame.
+ *
+ * OpenTUI-native port of the upstream `LogoV2/Clawd`
+ * (`ui/examples/upstream-patterns/src/components/LogoV2/Clawd.tsx`).
+ * Upstream used two themed Ink colors (`clawd_body`, `clawd_background`)
+ * and selectively fell back to a background-fill rendering on Apple
+ * Terminal because Terminal.app adds line spacing between regular
+ * characters but not between background runs. The Lite port keeps the
+ * same pose fragments and the Apple-Terminal alternate; colors are
+ * pinned to OpenTUI theme slots.
+ */
+
+export type ClawdPose = 'default' | 'arms-up' | 'look-left' | 'look-right'
+
+type Props = {
+  pose?: ClawdPose
+  /** Override for the "Apple Terminal" alternate render \u2014 useful when
+   *  the embedder detects a terminal where per-cell line spacing would
+   *  break the standard render. Defaults to `false`. */
+  appleTerminal?: boolean
+}
+
+type Segments = {
+  r1L: string
+  r1E: string
+  r1R: string
+  r2L: string
+  r2R: string
+}
+
+const POSES: Record<ClawdPose, Segments> = {
+  default: { r1L: ' \u2590', r1E: '\u259B\u2588\u2588\u2588\u259C', r1R: '\u258C', r2L: '\u259D\u259C', r2R: '\u259B\u2598' },
+  'look-left': { r1L: ' \u2590', r1E: '\u259F\u2588\u2588\u2588\u259F', r1R: '\u258C', r2L: '\u259D\u259C', r2R: '\u259B\u2598' },
+  'look-right': { r1L: ' \u2590', r1E: '\u2599\u2588\u2588\u2588\u2599', r1R: '\u258C', r2L: '\u259D\u259C', r2R: '\u259B\u2598' },
+  'arms-up': { r1L: '\u2597\u259F', r1E: '\u259B\u2588\u2588\u2588\u259C', r1R: '\u2599\u2596', r2L: ' \u259C', r2R: '\u259B ' },
+}
+
+const APPLE_EYES: Record<ClawdPose, string> = {
+  default: ' \u2597   \u2596 ',
+  'look-left': ' \u2598   \u2598 ',
+  'look-right': ' \u259D   \u259D ',
+  'arms-up': ' \u2597   \u2596 ',
+}
+
+const BODY = '#CC6B2D'
+const BACKGROUND = '#FFE3D0'
+
+export function Clawd({ pose = 'default', appleTerminal = false }: Props = {}) {
+  if (appleTerminal) {
+    return (
+      <box flexDirection="column" alignItems="center">
+        <text>
+          <span fg={BODY}>\u2597</span>
+          <span fg={BACKGROUND} bg={BODY}>{APPLE_EYES[pose]}</span>
+          <span fg={BODY}>\u2596</span>
+        </text>
+        <text bg={BODY}>{'       '}</text>
+        <text fg={BODY}>{'\u2598\u2598 \u259D\u259D'}</text>
+      </box>
+    )
+  }
+
+  const p = POSES[pose]
+  return (
+    <box flexDirection="column">
+      <text>
+        <span fg={BODY}>{p.r1L}</span>
+        <span fg={BODY} bg={BACKGROUND}>{p.r1E}</span>
+        <span fg={BODY}>{p.r1R}</span>
+      </text>
+      <text>
+        <span fg={BODY}>{p.r2L}</span>
+        <span fg={BODY} bg={BACKGROUND}>{'\u2588\u2588\u2588\u2588\u2588'}</span>
+        <span fg={BODY}>{p.r2R}</span>
+      </text>
+      <text fg={BODY}>{'  \u2598\u2598 \u259D\u259D  '}</text>
+    </box>
+  )
+}
+
+/** Exposed so downstream animators can reuse the theme slots if they
+ *  build their own palette. */
+export const CLAWD_COLORS = {
+  body: BODY,
+  background: BACKGROUND,
+}

--- a/ui/src/components/LogoV2/CondensedLogo.tsx
+++ b/ui/src/components/LogoV2/CondensedLogo.tsx
@@ -1,0 +1,123 @@
+import React from 'react'
+import { c } from '../../theme.js'
+import { truncate } from '../../utils.js'
+import { stringWidth } from '../string-width.js'
+import { Clawd } from './Clawd.js'
+import { AnimatedClawd } from './AnimatedClawd.js'
+import { GuestPassesUpsell } from './GuestPassesUpsell.js'
+import { OverageCreditUpsell } from './OverageCreditUpsell.js'
+
+/**
+ * Compact header shown when there is nothing new to surface (no release
+ * notes, no onboarding): a Clawd + three-line info block.
+ *
+ * OpenTUI-native port of the upstream `LogoV2/CondensedLogo`
+ * (`ui/examples/upstream-patterns/src/components/LogoV2/CondensedLogo.tsx`).
+ * Upstream read the full terminal size, main-loop model, billing type,
+ * agent name, and upsell eligibility from reactive hooks. The Lite
+ * port takes a `CondensedLogoData` snapshot so the Rust backend owns
+ * the data flow.
+ */
+
+export type CondensedLogoData = {
+  version: string
+  cwd: string
+  modelDisplayName: string
+  billingType: string
+  agentName?: string | null
+  /** Available column width. Defaults to 80 for wiring tests. */
+  columns?: number
+  /** Opt into the animated Clawd (only safe in fullscreen terminals). */
+  animated?: boolean
+  appleTerminal?: boolean
+  /** When set, renders the guest-passes upsell below the info block. */
+  guestPasses?: { reward?: string | null }
+  /** When set, renders the overage-credit upsell below the info block. */
+  overageCredit?: { amount?: string | null }
+}
+
+function formatModelAndBilling(
+  model: string,
+  billing: string,
+  textWidth: number,
+): { shouldSplit: boolean; truncatedModel: string; truncatedBilling: string } {
+  const combined = `${model} \u00B7 ${billing}`
+  if (combined.length <= textWidth) {
+    return { shouldSplit: false, truncatedModel: model, truncatedBilling: billing }
+  }
+  return {
+    shouldSplit: true,
+    truncatedModel: truncate(model, textWidth),
+    truncatedBilling: truncate(billing, textWidth),
+  }
+}
+
+function truncatePath(path: string, width: number): string {
+  if (path.length <= width) return path
+  const keep = Math.max(3, width - 1)
+  return '\u2026' + path.slice(path.length - keep)
+}
+
+export function CondensedLogo({ data }: { data: CondensedLogoData }) {
+  const {
+    version,
+    cwd,
+    modelDisplayName,
+    billingType,
+    agentName,
+    columns = 80,
+    animated = false,
+    appleTerminal = false,
+    guestPasses,
+    overageCredit,
+  } = data
+
+  const textWidth = Math.max(columns - 15, 20)
+  const versionPrefix = 'Claude Code v'
+  const truncatedVersion = truncate(
+    version,
+    Math.max(textWidth - versionPrefix.length, 6),
+  )
+
+  const { shouldSplit, truncatedModel, truncatedBilling } = formatModelAndBilling(
+    modelDisplayName,
+    billingType,
+    textWidth,
+  )
+
+  const separator = ' \u00B7 '
+  const atPrefix = '@'
+  const cwdAvailableWidth = agentName
+    ? textWidth - atPrefix.length - stringWidth(agentName) - separator.length
+    : textWidth
+  const truncatedCwd = truncatePath(cwd, Math.max(cwdAvailableWidth, 10))
+
+  return (
+    <box flexDirection="row" alignItems="center">
+      {animated ? <AnimatedClawd appleTerminal={appleTerminal} /> : <Clawd appleTerminal={appleTerminal} />}
+      <box flexDirection="column" marginLeft={2}>
+        <text>
+          <strong>Claude Code</strong>{' '}
+          <span fg={c.dim}>v{truncatedVersion}</span>
+        </text>
+        {shouldSplit ? (
+          <>
+            <text fg={c.dim}>{truncatedModel}</text>
+            <text fg={c.dim}>{truncatedBilling}</text>
+          </>
+        ) : (
+          <text fg={c.dim}>
+            {truncatedModel} \u00B7 {truncatedBilling}
+          </text>
+        )}
+        <text fg={c.dim}>
+          {agentName ? `@${agentName} \u00B7 ${truncatedCwd}` : truncatedCwd}
+        </text>
+        {guestPasses && <GuestPassesUpsell reward={guestPasses.reward} />}
+        {!guestPasses && overageCredit && (
+          <OverageCreditUpsell amount={overageCredit.amount} maxWidth={textWidth} twoLine />
+        )}
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/LogoV2/EmergencyTip.tsx
+++ b/ui/src/components/LogoV2/EmergencyTip.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { c } from '../../theme.js'
+
+/**
+ * "Tip of the feed" one-liner shown at the top of the home screen.
+ *
+ * OpenTUI-native port of the upstream `LogoV2/EmergencyTip`
+ * (`ui/examples/upstream-patterns/src/components/LogoV2/EmergencyTip.tsx`).
+ * Upstream fetched the tip from GrowthBook dynamic config
+ * (`tengu-top-of-feed-tip`) and tracked a per-user "last shown" marker
+ * in global config. The Lite port takes the tip via props; the Rust
+ * backend decides when / whether to supply one and when to stop.
+ */
+
+export type EmergencyTipColor = 'dim' | 'warning' | 'error'
+
+type Props = {
+  tip?: string | null
+  color?: EmergencyTipColor
+}
+
+function tipFg(color: EmergencyTipColor | undefined): string | undefined {
+  switch (color) {
+    case 'warning':
+      return c.warning
+    case 'error':
+      return c.error
+    case 'dim':
+    default:
+      return c.dim
+  }
+}
+
+export function EmergencyTip({ tip, color = 'dim' }: Props) {
+  if (!tip) return null
+  return (
+    <box paddingLeft={2} flexDirection="column">
+      <text fg={tipFg(color)}>{tip}</text>
+    </box>
+  )
+}

--- a/ui/src/components/LogoV2/ExperimentEnrollmentNotice.tsx
+++ b/ui/src/components/LogoV2/ExperimentEnrollmentNotice.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+/**
+ * Internal-only component. Upstream shows experiment enrollment status
+ * for `USER_TYPE === 'ant'` builds; the Lite build doesn't track
+ * experiments frontend-side, so this is a `null`-returning stub kept
+ * so the LogoV2 shell can import it unconditionally.
+ */
+export function ExperimentEnrollmentNotice(): React.ReactNode {
+  return null
+}

--- a/ui/src/components/LogoV2/Feed.tsx
+++ b/ui/src/components/LogoV2/Feed.tsx
@@ -1,0 +1,128 @@
+import React from 'react'
+import { c } from '../../theme.js'
+import { stringWidth, truncateToWidth } from '../string-width.js'
+
+/**
+ * Single "feed" block inside the LogoV2 right column (Recent activity,
+ * What's new, guest passes, etc.).
+ *
+ * OpenTUI-native port of the upstream `LogoV2/Feed`
+ * (`ui/examples/upstream-patterns/src/components/LogoV2/Feed.tsx`).
+ * The upstream used Ink's `stringWidth`; the Lite port reuses the
+ * local `string-width` helper for the same width-aware math.
+ */
+
+export type FeedLine = {
+  text: string
+  timestamp?: string
+}
+
+export type FeedConfig = {
+  title: string
+  lines: FeedLine[]
+  footer?: string
+  emptyMessage?: string
+  customContent?: { content: React.ReactNode; width: number }
+}
+
+type FeedProps = {
+  config: FeedConfig
+  actualWidth: number
+}
+
+function truncate(text: string, width: number): string {
+  if (width <= 0) return ''
+  if (stringWidth(text) <= width) return text
+  return truncateToWidth(text, Math.max(0, width - 1)) + '\u2026'
+}
+
+export function calculateFeedWidth(config: FeedConfig): number {
+  const { title, lines, footer, emptyMessage, customContent } = config
+  let maxWidth = stringWidth(title)
+
+  if (customContent !== undefined) {
+    maxWidth = Math.max(maxWidth, customContent.width)
+  } else if (lines.length === 0 && emptyMessage) {
+    maxWidth = Math.max(maxWidth, stringWidth(emptyMessage))
+  } else {
+    const gap = '  '
+    const maxTimestampWidth = Math.max(
+      0,
+      ...lines.map(line => (line.timestamp ? stringWidth(line.timestamp) : 0)),
+    )
+    for (const line of lines) {
+      const timestampWidth = maxTimestampWidth > 0 ? maxTimestampWidth : 0
+      const lineWidth =
+        stringWidth(line.text) +
+        (timestampWidth > 0 ? timestampWidth + gap.length : 0)
+      maxWidth = Math.max(maxWidth, lineWidth)
+    }
+  }
+  if (footer) {
+    maxWidth = Math.max(maxWidth, stringWidth(footer))
+  }
+  return maxWidth
+}
+
+export function Feed({ config, actualWidth }: FeedProps) {
+  const { title, lines, footer, emptyMessage, customContent } = config
+  const gap = '  '
+  const maxTimestampWidth = Math.max(
+    0,
+    ...lines.map(line => (line.timestamp ? stringWidth(line.timestamp) : 0)),
+  )
+
+  return (
+    <box flexDirection="column" width={actualWidth}>
+      <text>
+        <strong>
+          <span fg={c.accent}>{title}</span>
+        </strong>
+      </text>
+      {customContent ? (
+        <>
+          {customContent.content}
+          {footer && (
+            <text>
+              <em>
+                <span fg={c.dim}>{truncate(footer, actualWidth)}</span>
+              </em>
+            </text>
+          )}
+        </>
+      ) : lines.length === 0 && emptyMessage ? (
+        <text fg={c.dim}>{truncate(emptyMessage, actualWidth)}</text>
+      ) : (
+        <>
+          {lines.map((line, index) => {
+            const textWidth = Math.max(
+              10,
+              actualWidth -
+                (maxTimestampWidth > 0 ? maxTimestampWidth + gap.length : 0),
+            )
+            return (
+              <text key={index}>
+                {maxTimestampWidth > 0 && (
+                  <>
+                    <span fg={c.dim}>
+                      {(line.timestamp || '').padEnd(maxTimestampWidth)}
+                    </span>
+                    {gap}
+                  </>
+                )}
+                <span>{truncate(line.text, textWidth)}</span>
+              </text>
+            )
+          })}
+          {footer && (
+            <text>
+              <em>
+                <span fg={c.dim}>{truncate(footer, actualWidth)}</span>
+              </em>
+            </text>
+          )}
+        </>
+      )}
+    </box>
+  )
+}

--- a/ui/src/components/LogoV2/FeedColumn.tsx
+++ b/ui/src/components/LogoV2/FeedColumn.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { c } from '../../theme.js'
+import { calculateFeedWidth, Feed, type FeedConfig } from './Feed.js'
+
+/**
+ * Vertical column of `Feed` blocks with thin dividers between them.
+ *
+ * OpenTUI-native port of the upstream `LogoV2/FeedColumn`
+ * (`ui/examples/upstream-patterns/src/components/LogoV2/FeedColumn.tsx`).
+ * Upstream used Ink's `<Divider>`. OpenTUI has no direct equivalent, so
+ * the Lite port renders a box with only a top border at the accent
+ * color as the separator.
+ */
+
+type FeedColumnProps = {
+  feeds: FeedConfig[]
+  maxWidth: number
+}
+
+export function FeedColumn({ feeds, maxWidth }: FeedColumnProps) {
+  const feedWidths = feeds.map(feed => calculateFeedWidth(feed))
+  const maxOfAllFeeds = Math.max(0, ...feedWidths)
+  const actualWidth = Math.min(maxOfAllFeeds, maxWidth)
+
+  return (
+    <box flexDirection="column">
+      {feeds.map((feed, index) => (
+        <React.Fragment key={index}>
+          <Feed config={feed} actualWidth={actualWidth} />
+          {index < feeds.length - 1 && (
+            <box
+              width={actualWidth}
+              border={['top']}
+              borderStyle="single"
+              borderColor={c.accent}
+            />
+          )}
+        </React.Fragment>
+      ))}
+    </box>
+  )
+}

--- a/ui/src/components/LogoV2/GateOverridesWarning.tsx
+++ b/ui/src/components/LogoV2/GateOverridesWarning.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+/**
+ * Internal-only component. Upstream displays a warning when feature-gate
+ * overrides (`CLAUDE_INTERNAL_FC_OVERRIDES`) are active. Stubbed in the
+ * Lite build \u2014 the Rust backend doesn't ship the feature-gate override
+ * plumbing, so this always renders `null`.
+ *
+ * Kept as a named export so the LogoV2 shell can import it
+ * unconditionally without a `USER_TYPE` branch.
+ */
+export function GateOverridesWarning(): React.ReactNode {
+  return null
+}

--- a/ui/src/components/LogoV2/GuestPassesUpsell.tsx
+++ b/ui/src/components/LogoV2/GuestPassesUpsell.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { c } from '../../theme.js'
+
+/**
+ * Compact guest-passes upsell row rendered inside the condensed logo.
+ *
+ * OpenTUI-native port of the upstream `LogoV2/GuestPassesUpsell`
+ * (`ui/examples/upstream-patterns/src/components/LogoV2/GuestPassesUpsell.tsx`).
+ * Upstream exposed `useShowGuestPassesUpsell()` and
+ * `incrementGuestPassesSeenCount()` helpers that talked directly to
+ * global config and the referral cache. The Lite port leaves eligibility
+ * and impression-count side effects Rust-side and renders only when the
+ * caller hands it a `visible` prop.
+ */
+
+type Props = {
+  visible?: boolean
+  /** Referrer reward copy, e.g. "$10" or `null` if not eligible yet. */
+  reward?: string | null
+}
+
+export function GuestPassesUpsell({ visible = true, reward }: Props = {}) {
+  if (!visible) return null
+  const suffix = reward
+    ? `Share Claude Code and earn ${reward} of extra usage \u00B7 /passes`
+    : '3 guest passes at /passes'
+  return (
+    <text fg={c.dim}>
+      <span fg={c.accent}>[\u273B]</span> <span fg={c.accent}>[\u273B]</span>{' '}
+      <span fg={c.accent}>[\u273B]</span> \u00B7 {suffix}
+    </text>
+  )
+}

--- a/ui/src/components/LogoV2/LogoV2.tsx
+++ b/ui/src/components/LogoV2/LogoV2.tsx
@@ -1,0 +1,336 @@
+import React from 'react'
+import { c } from '../../theme.js'
+import { truncate } from '../../utils.js'
+import { stringWidth } from '../string-width.js'
+import { CondensedLogo } from './CondensedLogo.js'
+import { Clawd } from './Clawd.js'
+import { EmergencyTip } from './EmergencyTip.js'
+import { VoiceModeNotice } from './VoiceModeNotice.js'
+import { Opus1mMergeNotice } from './Opus1mMergeNotice.js'
+import { GateOverridesWarning } from './GateOverridesWarning.js'
+import { ExperimentEnrollmentNotice } from './ExperimentEnrollmentNotice.js'
+import { ChannelsNotice, type ChannelsNoticeStatus } from './ChannelsNotice.js'
+import { FeedColumn } from './FeedColumn.js'
+import type { FeedConfig } from './Feed.js'
+
+/**
+ * Top-of-conversation welcome frame \u2014 bordered Claude Code card with
+ * Clawd on the left, info on the right, and a rotating feed column on
+ * the far right when there is screen space.
+ *
+ * OpenTUI-native port of the upstream `LogoV2/LogoV2`
+ * (`ui/examples/upstream-patterns/src/components/LogoV2/LogoV2.tsx`).
+ * Upstream combined ~20 cross-module reads (global config, main-loop
+ * model, bootstrap state, GrowthBook flags, sandbox, debug mode, tmux
+ * env, announcement rotation, KAIROS channel allowlist, voice mode,
+ * Opus-1m promo, feed builders). The Lite port takes a flat
+ * `LogoV2ViewData` snapshot; the Rust backend assembles the data and
+ * the UI stays presentational.
+ */
+
+const LEFT_PANEL_MAX_WIDTH = 50
+
+export type LogoV2LayoutMode = 'horizontal' | 'vertical' | 'compact'
+
+export type LogoV2ViewData = {
+  version: string
+  cwd: string
+  username?: string
+  modelDisplayName: string
+  billingType: string
+  organizationName?: string | null
+  agentName?: string | null
+  columns: number
+  /** Pre-computed layout mode from `getLayoutMode()` in upstream. */
+  layoutMode: LogoV2LayoutMode
+  /** When true, render the condensed header instead of the full card. */
+  condensed: boolean
+  /** Right-column feed (recent activity / what's new / upsells). */
+  feeds?: FeedConfig[]
+  /** Status for the KAIROS channels notice. */
+  channels?: ChannelsNoticeStatus
+  voiceMode?: { visible: boolean; reducedMotion?: boolean }
+  opus1mMerge?: { visible: boolean; reducedMotion?: boolean }
+  /** GrowthBook-driven tip of the feed. */
+  emergencyTip?: {
+    tip: string
+    color?: 'dim' | 'warning' | 'error'
+  }
+  debug?: {
+    enabled: boolean
+    /** Display path for the debug log. */
+    logPath?: string
+    toStderr?: boolean
+  }
+  tmux?: {
+    session: string
+    detachHint: string
+  }
+  announcement?: string | null
+  showSandboxStatus?: boolean
+  guestPasses?: { reward?: string | null }
+  overageCredit?: { amount?: string | null }
+  appleTerminal?: boolean
+  animated?: boolean
+  /** When true, expose the ANT-only notices (gate overrides, enrollment). */
+  showAntOnly?: boolean
+}
+
+function formatWelcomeMessage(username?: string): string {
+  return username ? `Welcome back, ${username}!` : 'Welcome to Claude Code'
+}
+
+function truncatePath(path: string, width: number): string {
+  if (path.length <= width) return path
+  return '\u2026' + path.slice(path.length - Math.max(0, width - 1))
+}
+
+function calculateLayoutDimensions(
+  columns: number,
+  layoutMode: LogoV2LayoutMode,
+  optimalLeftWidth: number,
+): { leftWidth: number; rightWidth: number } {
+  if (layoutMode !== 'horizontal') {
+    return { leftWidth: columns - 4, rightWidth: 0 }
+  }
+  const left = Math.min(optimalLeftWidth, LEFT_PANEL_MAX_WIDTH)
+  const right = Math.max(10, columns - left - 5)
+  return { leftWidth: left, rightWidth: right }
+}
+
+function calculateOptimalLeftWidth(
+  welcome: string,
+  cwdLine: string,
+  modelLine: string,
+): number {
+  return (
+    Math.min(
+      LEFT_PANEL_MAX_WIDTH,
+      Math.max(stringWidth(welcome), stringWidth(cwdLine), stringWidth(modelLine)) + 4,
+    ) + 2
+  )
+}
+
+export function LogoV2({ data }: { data: LogoV2ViewData }) {
+  const {
+    version,
+    cwd,
+    username,
+    modelDisplayName,
+    billingType,
+    organizationName,
+    agentName,
+    columns,
+    layoutMode,
+    condensed,
+    feeds = [],
+    channels,
+    voiceMode,
+    opus1mMerge,
+    emergencyTip,
+    debug,
+    tmux,
+    announcement,
+    showSandboxStatus,
+    guestPasses,
+    overageCredit,
+    appleTerminal,
+    animated,
+    showAntOnly,
+  } = data
+
+  const condensedData = {
+    version,
+    cwd,
+    modelDisplayName,
+    billingType,
+    agentName,
+    columns,
+    animated,
+    appleTerminal,
+    guestPasses,
+    overageCredit,
+  }
+
+  if (condensed) {
+    return (
+      <>
+        <CondensedLogo data={condensedData} />
+        {voiceMode && <VoiceModeNotice {...voiceMode} />}
+        {opus1mMerge && <Opus1mMergeNotice {...opus1mMerge} />}
+        {channels && <ChannelsNotice status={channels} />}
+        {debug?.enabled && (
+          <box paddingLeft={2} flexDirection="column">
+            <text fg={c.warning}>Debug mode enabled</text>
+            <text fg={c.dim}>
+              Logging to: {debug.toStderr ? 'stderr' : debug.logPath ?? '<unknown>'}
+            </text>
+          </box>
+        )}
+        {emergencyTip && (
+          <EmergencyTip tip={emergencyTip.tip} color={emergencyTip.color} />
+        )}
+        {tmux && (
+          <box paddingLeft={2} flexDirection="column">
+            <text fg={c.dim}>tmux session: {tmux.session}</text>
+            <text fg={c.dim}>{tmux.detachHint}</text>
+          </box>
+        )}
+        {announcement && (
+          <box paddingLeft={2} flexDirection="column">
+            {organizationName && (
+              <text fg={c.dim}>Message from {organizationName}:</text>
+            )}
+            <text>{announcement}</text>
+          </box>
+        )}
+        {showAntOnly && <GateOverridesWarning />}
+        {showAntOnly && <ExperimentEnrollmentNotice />}
+      </>
+    )
+  }
+
+  const welcomeMessage = formatWelcomeMessage(username)
+  const modelLine = organizationName
+    ? `${modelDisplayName} \u00B7 ${billingType} \u00B7 ${organizationName}`
+    : `${modelDisplayName} \u00B7 ${billingType}`
+  const separator = ' \u00B7 '
+  const atPrefix = '@'
+  const cwdAvailableWidth = agentName
+    ? LEFT_PANEL_MAX_WIDTH - atPrefix.length - stringWidth(agentName) - separator.length
+    : LEFT_PANEL_MAX_WIDTH
+  const truncatedCwd = truncatePath(cwd, Math.max(cwdAvailableWidth, 10))
+  const cwdLine = agentName ? `@${agentName} \u00B7 ${truncatedCwd}` : truncatedCwd
+  const optimalLeftWidth = calculateOptimalLeftWidth(welcomeMessage, cwdLine, modelLine)
+  const { leftWidth, rightWidth } = calculateLayoutDimensions(
+    columns,
+    layoutMode,
+    optimalLeftWidth,
+  )
+
+  if (layoutMode === 'compact') {
+    const displayModel = truncate(modelDisplayName, leftWidth)
+    return (
+      <>
+        <box
+          flexDirection="column"
+          borderStyle="rounded"
+          borderColor={c.accent}
+          title="Claude Code"
+          titleAlignment="left"
+          paddingX={1}
+          paddingY={1}
+          alignItems="center"
+          width={columns}
+        >
+          <text>
+            <strong>{welcomeMessage}</strong>
+          </text>
+          <box marginTop={1} marginBottom={1}>
+            <Clawd appleTerminal={appleTerminal} />
+          </box>
+          <text fg={c.dim}>{displayModel}</text>
+          <text fg={c.dim}>{billingType}</text>
+          <text fg={c.dim}>{cwdLine}</text>
+        </box>
+        {voiceMode && <VoiceModeNotice {...voiceMode} />}
+        {opus1mMerge && <Opus1mMergeNotice {...opus1mMerge} />}
+        {channels && <ChannelsNotice status={channels} />}
+        {showSandboxStatus && (
+          <box marginTop={1}>
+            <text fg={c.warning}>
+              Your bash commands will be sandboxed. Disable with /sandbox.
+            </text>
+          </box>
+        )}
+        {showAntOnly && <GateOverridesWarning />}
+        {showAntOnly && <ExperimentEnrollmentNotice />}
+      </>
+    )
+  }
+
+  return (
+    <>
+      <box
+        flexDirection="column"
+        borderStyle="rounded"
+        borderColor={c.accent}
+        title={`Claude Code v${version}`}
+        titleAlignment="left"
+      >
+        <box
+          flexDirection={layoutMode === 'horizontal' ? 'row' : 'column'}
+          paddingX={1}
+          gap={1}
+        >
+          <box
+            flexDirection="column"
+            width={leftWidth}
+            justifyContent="space-between"
+            alignItems="center"
+            minHeight={9}
+          >
+            <box marginTop={1}>
+              <text>
+                <strong>{welcomeMessage}</strong>
+              </text>
+            </box>
+            <Clawd appleTerminal={appleTerminal} />
+            <box flexDirection="column" alignItems="center">
+              <text fg={c.dim}>{modelLine}</text>
+              <text fg={c.dim}>{cwdLine}</text>
+            </box>
+          </box>
+          {layoutMode === 'horizontal' && (
+            <>
+              <box
+                flexDirection="column"
+                border={['left']}
+                borderStyle="single"
+                borderColor={c.accent}
+              />
+              <FeedColumn feeds={feeds} maxWidth={rightWidth} />
+            </>
+          )}
+        </box>
+      </box>
+      {voiceMode && <VoiceModeNotice {...voiceMode} />}
+      {opus1mMerge && <Opus1mMergeNotice {...opus1mMerge} />}
+      {channels && <ChannelsNotice status={channels} />}
+      {debug?.enabled && (
+        <box paddingLeft={2} flexDirection="column">
+          <text fg={c.warning}>Debug mode enabled</text>
+          <text fg={c.dim}>
+            Logging to: {debug.toStderr ? 'stderr' : debug.logPath ?? '<unknown>'}
+          </text>
+        </box>
+      )}
+      {emergencyTip && (
+        <EmergencyTip tip={emergencyTip.tip} color={emergencyTip.color} />
+      )}
+      {tmux && (
+        <box paddingLeft={2} flexDirection="column">
+          <text fg={c.dim}>tmux session: {tmux.session}</text>
+          <text fg={c.dim}>{tmux.detachHint}</text>
+        </box>
+      )}
+      {announcement && (
+        <box paddingLeft={2} flexDirection="column">
+          {organizationName && (
+            <text fg={c.dim}>Message from {organizationName}:</text>
+          )}
+          <text>{announcement}</text>
+        </box>
+      )}
+      {showSandboxStatus && (
+        <box paddingLeft={2}>
+          <text fg={c.warning}>
+            Your bash commands will be sandboxed. Disable with /sandbox.
+          </text>
+        </box>
+      )}
+      {showAntOnly && <GateOverridesWarning />}
+      {showAntOnly && <ExperimentEnrollmentNotice />}
+    </>
+  )
+}

--- a/ui/src/components/LogoV2/Opus1mMergeNotice.tsx
+++ b/ui/src/components/LogoV2/Opus1mMergeNotice.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { c } from '../../theme.js'
+import { AnimatedAsterisk } from './AnimatedAsterisk.js'
+
+/**
+ * "Opus now defaults to 1M context" promotional line.
+ *
+ * OpenTUI-native port of the upstream `LogoV2/Opus1mMergeNotice`
+ * (`ui/examples/upstream-patterns/src/components/LogoV2/Opus1mMergeNotice.tsx`).
+ * Upstream read `isOpus1mMergeEnabled()` + a per-user impression count
+ * (max 6) from global config. The Lite port accepts `visible` so the
+ * Rust backend keeps authority over eligibility and impression tracking.
+ */
+
+const UP_ARROW = '\u2191'
+
+type Props = {
+  visible?: boolean
+  reducedMotion?: boolean
+}
+
+export function Opus1mMergeNotice({
+  visible = false,
+  reducedMotion,
+}: Props = {}) {
+  if (!visible) return null
+  return (
+    <box paddingLeft={2} flexDirection="row">
+      <AnimatedAsterisk char={UP_ARROW} reducedMotion={reducedMotion} />
+      <text fg={c.dim}>
+        {' Opus now defaults to 1M context \u00B7 5x more room, same pricing'}
+      </text>
+    </box>
+  )
+}
+
+/**
+ * Mirror of the upstream `shouldShowOpus1mMergeNotice()` helper \u2014
+ * the Lite port keeps it as a pure function the backend can call.
+ */
+export function shouldShowOpus1mMergeNotice(
+  opts: { enabled: boolean; seenCount: number } = { enabled: false, seenCount: 0 },
+): boolean {
+  const MAX_SHOW_COUNT = 6
+  return opts.enabled && opts.seenCount < MAX_SHOW_COUNT
+}

--- a/ui/src/components/LogoV2/OverageCreditUpsell.tsx
+++ b/ui/src/components/LogoV2/OverageCreditUpsell.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { c } from '../../theme.js'
+import { truncate } from '../../utils.js'
+
+/**
+ * Condensed upsell row advertising the overage-credit grant.
+ *
+ * OpenTUI-native port of the upstream `LogoV2/OverageCreditUpsell`
+ * (`ui/examples/upstream-patterns/src/components/LogoV2/OverageCreditUpsell.tsx`).
+ * Upstream read the grant from a cached `/overage_credit_grant`
+ * response and tracked impressions in global config. The Lite port
+ * receives `amount` as a prop; eligibility, impression caps, and
+ * background refresh are Rust-side concerns.
+ */
+
+const FEED_SUBTITLE = 'On us. Works on third-party apps \u00B7 /extra-usage'
+
+type Props = {
+  /** Formatted amount (e.g. "$5"). If null / empty, nothing renders. */
+  amount?: string | null
+  maxWidth?: number
+  /** When true, render as a two-line title + subtitle block. */
+  twoLine?: boolean
+}
+
+function getFeedTitle(amount: string): string {
+  return `${amount} in extra usage`
+}
+
+function getUsageText(amount: string): string {
+  return `${amount} in extra usage for third-party apps \u00B7 /extra-usage`
+}
+
+export function OverageCreditUpsell({ amount, maxWidth, twoLine }: Props) {
+  if (!amount) return null
+  if (twoLine) {
+    const title = getFeedTitle(amount)
+    return (
+      <>
+        <text fg={c.accent}>{maxWidth ? truncate(title, maxWidth) : title}</text>
+        <text fg={c.dim}>
+          {maxWidth ? truncate(FEED_SUBTITLE, maxWidth) : FEED_SUBTITLE}
+        </text>
+      </>
+    )
+  }
+
+  const text = getUsageText(amount)
+  const display = maxWidth ? truncate(text, maxWidth) : text
+  const highlightLen = Math.min(getFeedTitle(amount).length, display.length)
+
+  return (
+    <text fg={c.dim}>
+      <span fg={c.accent}>{display.slice(0, highlightLen)}</span>
+      {display.slice(highlightLen)}
+    </text>
+  )
+}

--- a/ui/src/components/LogoV2/VoiceModeNotice.tsx
+++ b/ui/src/components/LogoV2/VoiceModeNotice.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { c } from '../../theme.js'
+import { AnimatedAsterisk } from './AnimatedAsterisk.js'
+
+/**
+ * "Voice mode is now available" promotional line.
+ *
+ * OpenTUI-native port of the upstream `LogoV2/VoiceModeNotice`
+ * (`ui/examples/upstream-patterns/src/components/LogoV2/VoiceModeNotice.tsx`).
+ * Upstream was gated behind the `VOICE_MODE` bundle feature and tracked
+ * an impression count in global config (max 3). The Lite port exposes
+ * a `visible` prop so the Rust backend / host decides whether to show
+ * it \u2014 eligibility and impression accounting live server-side.
+ */
+
+type Props = {
+  visible?: boolean
+  reducedMotion?: boolean
+}
+
+export function VoiceModeNotice({ visible = false, reducedMotion }: Props = {}) {
+  if (!visible) return null
+  return (
+    <box paddingLeft={2} flexDirection="row">
+      <AnimatedAsterisk reducedMotion={reducedMotion} />
+      <text fg={c.dim}> Voice mode is now available \u00B7 /voice to enable</text>
+    </box>
+  )
+}

--- a/ui/src/components/LogoV2/WelcomeV2.tsx
+++ b/ui/src/components/LogoV2/WelcomeV2.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { c } from '../../theme.js'
+
+/**
+ * Decorative "Welcome to Claude Code" banner shown before the user has
+ * any messages. Upstream hand-drew two ASCII variants (light/dark) plus
+ * an Apple-Terminal specialised render.
+ *
+ * OpenTUI-native port of the upstream `LogoV2/WelcomeV2`
+ * (`ui/examples/upstream-patterns/src/components/LogoV2/WelcomeV2.tsx`).
+ * The pixel-perfect banner relies on Ink's `useTheme` + two dozen manually
+ * positioned `<Text>` rows. The Lite port keeps the textual banner \u2014 same
+ * widths so downstream layout math still works \u2014 and drops the per-theme
+ * variants (the OpenTUI palette has a single `c.accent` shade).
+ */
+
+const WELCOME_V2_WIDTH = 58
+const CLAWD_BODY = '#CC6B2D'
+const CLAWD_BACKGROUND = '#FFE3D0'
+
+type Props = {
+  version?: string
+}
+
+export function WelcomeV2({ version }: Props = {}) {
+  const welcomeMessage = 'Welcome to Claude Code'
+  return (
+    <box width={WELCOME_V2_WIDTH} flexDirection="column">
+      <text>
+        <span fg={c.accent}>{welcomeMessage} </span>
+        {version && <span fg={c.dim}>v{version}</span>}
+      </text>
+      <text fg={c.dim}>
+        {'\u2026'.repeat(WELCOME_V2_WIDTH)}
+      </text>
+      <text>{' '.repeat(WELCOME_V2_WIDTH)}</text>
+      <text>{'     *                                       \u2588\u2588\u2588\u2588\u2588\u2593\u2593\u2591     '}</text>
+      <text>{'                                 *         \u2588\u2588\u2588\u2593\u2591     \u2591\u2591   '}</text>
+      <text>{'            \u2591\u2591\u2591\u2591\u2591\u2591                        \u2588\u2588\u2588\u2593\u2591           '}</text>
+      <text>{'    \u2591\u2591\u2591   \u2591\u2591\u2591\u2591\u2591\u2591\u2591\u2591\u2591\u2591                      \u2588\u2588\u2588\u2593\u2591           '}</text>
+      <text>
+        {'   \u2591\u2591\u2591\u2591\u2591\u2591\u2591\u2591\u2591\u2591\u2591\u2591\u2591\u2591\u2591\u2591\u2591\u2591\u2591    '}
+        <strong>*</strong>
+        {'                \u2588\u2588\u2593\u2591\u2591      \u2593   '}
+      </text>
+      <text>{'                                             \u2591\u2593\u2593\u2588\u2588\u2588\u2593\u2593\u2591    '}</text>
+      <text>
+        {'      '}
+        <span fg={CLAWD_BODY}> \u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588 </span>
+        {'                                       '}
+        <span fg={c.dim}>*</span>
+      </text>
+      <text>
+        {'      '}
+        <span fg={CLAWD_BODY} bg={CLAWD_BACKGROUND}>\u2588\u2588\u2584\u2588\u2588\u2588\u2588\u2588\u2584\u2588\u2588</span>
+        <strong>{'                        *               '}</strong>
+      </text>
+      <text>
+        {'      '}
+        <span fg={CLAWD_BODY}> \u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588 </span>
+        {'     *                                   '}
+      </text>
+      <text fg={c.dim}>
+        {'\u2026\u2026\u2026\u2026\u2026\u2026\u2026'}
+        <span fg={CLAWD_BODY}>\u2588 \u2588   \u2588 \u2588</span>
+        {'\u2026\u2026\u2026\u2026\u2026\u2026\u2026\u2026\u2026\u2026\u2026\u2026\u2026\u2026\u2026\u2026\u2026\u2026\u2026\u2026\u2026\u2026\u2026\u2026'}
+      </text>
+    </box>
+  )
+}

--- a/ui/src/components/LogoV2/feedConfigs.tsx
+++ b/ui/src/components/LogoV2/feedConfigs.tsx
@@ -1,0 +1,128 @@
+import React from 'react'
+import { c } from '../../theme.js'
+import type { FeedConfig, FeedLine } from './Feed.js'
+
+/**
+ * Feed-config builders for the LogoV2 welcome screen.
+ *
+ * OpenTUI-native port of the upstream `LogoV2/feedConfigs`
+ * (`ui/examples/upstream-patterns/src/components/LogoV2/feedConfigs.tsx`).
+ * Upstream pulled data from the `LogOption` resume list, the
+ * `projectOnboardingState` machine, and the referral-reward cache. The
+ * Lite port accepts the data already resolved \u2014 the Rust backend owns
+ * the session log / referral / onboarding subsystems.
+ */
+
+const TICK = '\u2713'
+
+export type RecentActivity = {
+  /** Rendered "5m ago" / "yesterday" timestamp. */
+  timestamp: string
+  /** Session / resume summary. */
+  description: string
+}
+
+export function createRecentActivityFeed(
+  activities: RecentActivity[],
+): FeedConfig {
+  const lines: FeedLine[] = activities.map(a => ({
+    text: a.description,
+    timestamp: a.timestamp,
+  }))
+  return {
+    title: 'Recent activity',
+    lines,
+    footer: lines.length > 0 ? '/resume for more' : undefined,
+    emptyMessage: 'No recent activity',
+  }
+}
+
+export function createWhatsNewFeed(
+  releaseNotes: string[],
+  options: { antOnly?: boolean } = {},
+): FeedConfig {
+  const lines: FeedLine[] = releaseNotes.map(note => {
+    if (options.antOnly) {
+      const match = note.match(/^(\d+\s+\w+\s+ago)\s+(.+)$/)
+      if (match) {
+        return { timestamp: match[1], text: match[2] ?? '' }
+      }
+    }
+    return { text: note }
+  })
+
+  const emptyMessage = options.antOnly
+    ? 'Unable to fetch latest claude-cli-internal commits'
+    : 'Check the Claude Code changelog for updates'
+
+  return {
+    title: options.antOnly
+      ? "What's new [ANT-ONLY: Latest CC commits]"
+      : "What's new",
+    lines,
+    footer: lines.length > 0 ? '/release-notes for more' : undefined,
+    emptyMessage,
+  }
+}
+
+export type OnboardingStep = {
+  text: string
+  isEnabled: boolean
+  isComplete: boolean
+}
+
+export function createProjectOnboardingFeed(
+  steps: OnboardingStep[],
+  warningText?: string,
+): FeedConfig {
+  const enabled = steps
+    .filter(s => s.isEnabled)
+    .sort((a, b) => Number(a.isComplete) - Number(b.isComplete))
+  const lines: FeedLine[] = enabled.map(({ text, isComplete }) => ({
+    text: `${isComplete ? `${TICK} ` : ''}${text}`,
+  }))
+  if (warningText) {
+    lines.push({ text: warningText })
+  }
+  return {
+    title: 'Tips for getting started',
+    lines,
+  }
+}
+
+export function createGuestPassesFeed(
+  reward?: string | null,
+): FeedConfig {
+  const subtitle = reward
+    ? `Share Claude Code and earn ${reward} of extra usage`
+    : 'Share Claude Code with friends'
+  return {
+    title: '3 guest passes',
+    lines: [],
+    customContent: {
+      content: (
+        <>
+          <box marginTop={1} marginBottom={1}>
+            <text fg={c.accent}>[\u273B] [\u273B] [\u273B]</text>
+          </box>
+          <text fg={c.dim}>{subtitle}</text>
+        </>
+      ),
+      width: 48,
+    },
+    footer: '/passes',
+  }
+}
+
+export function createOverageCreditFeed(amount?: string | null): FeedConfig {
+  const FEED_SUBTITLE = 'On us. Works on third-party apps \u00B7 /extra-usage'
+  const title = amount ? `${amount} in extra usage` : 'extra usage credit'
+  return {
+    title,
+    lines: [],
+    customContent: {
+      content: <text fg={c.dim}>{FEED_SUBTITLE}</text>,
+      width: Math.max(title.length, FEED_SUBTITLE.length),
+    },
+  }
+}

--- a/ui/src/components/LogoV2/index.ts
+++ b/ui/src/components/LogoV2/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Barrel for the LogoV2 welcome-screen surface. Mirrors the upstream
+ * layout at `ui/examples/upstream-patterns/src/components/LogoV2/` so
+ * downstream imports stay stable during the full-build migration.
+ */
+export { AnimatedAsterisk } from './AnimatedAsterisk.js'
+export { AnimatedClawd, CLAWD_ANIMATIONS } from './AnimatedClawd.js'
+export { ChannelsNotice } from './ChannelsNotice.js'
+export type {
+  ChannelEntryDisplay,
+  ChannelsNoticeStatus,
+  ChannelsNoticeUnmatched,
+} from './ChannelsNotice.js'
+export { Clawd, CLAWD_COLORS } from './Clawd.js'
+export type { ClawdPose } from './Clawd.js'
+export { CondensedLogo } from './CondensedLogo.js'
+export type { CondensedLogoData } from './CondensedLogo.js'
+export { EmergencyTip } from './EmergencyTip.js'
+export type { EmergencyTipColor } from './EmergencyTip.js'
+export { ExperimentEnrollmentNotice } from './ExperimentEnrollmentNotice.js'
+export { Feed, calculateFeedWidth } from './Feed.js'
+export type { FeedConfig, FeedLine } from './Feed.js'
+export { FeedColumn } from './FeedColumn.js'
+export {
+  createGuestPassesFeed,
+  createOverageCreditFeed,
+  createProjectOnboardingFeed,
+  createRecentActivityFeed,
+  createWhatsNewFeed,
+} from './feedConfigs.js'
+export type { OnboardingStep, RecentActivity } from './feedConfigs.js'
+export { GateOverridesWarning } from './GateOverridesWarning.js'
+export { GuestPassesUpsell } from './GuestPassesUpsell.js'
+export { LogoV2 } from './LogoV2.js'
+export type { LogoV2LayoutMode, LogoV2ViewData } from './LogoV2.js'
+export { Opus1mMergeNotice, shouldShowOpus1mMergeNotice } from './Opus1mMergeNotice.js'
+export { OverageCreditUpsell } from './OverageCreditUpsell.js'
+export { VoiceModeNotice } from './VoiceModeNotice.js'
+export { WelcomeV2 } from './WelcomeV2.js'

--- a/ui/src/components/helpv2/Commands.tsx
+++ b/ui/src/components/helpv2/Commands.tsx
@@ -1,0 +1,140 @@
+import React, { useMemo, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../../theme.js'
+import { truncate } from '../../utils.js'
+
+/**
+ * Scrollable list of commands used inside the HelpV2 dialog's Commands /
+ * Custom-commands tabs.
+ *
+ * OpenTUI-native port of the upstream `helpv2/Commands`
+ * (`ui/examples/upstream-patterns/src/components/helpv2/Commands.tsx`).
+ * The upstream component rendered through Ink's `<Select>` with
+ * `layout="compact-vertical"`. The Lite port implements the same
+ * compact two-line layout (`/name` + truncated description) with
+ * selection via `useKeyboard`.
+ */
+
+export type HelpCommandEntry = {
+  name: string
+  description: string
+  /** Optional origin label (e.g. "project", "user"). Appended to desc. */
+  source?: string
+}
+
+type Props = {
+  commands: HelpCommandEntry[]
+  maxHeight: number
+  columns: number
+  title: string
+  emptyMessage?: string
+  onCancel: () => void
+  /** Set when the tab header is focused so the list does not intercept keys. */
+  isDisabled?: boolean
+  /** Called when the user presses Up on the first item so the parent can
+   *  hand focus back to the tab header. */
+  onUpFromFirstItem?: () => void
+}
+
+function formatDescriptionWithSource(entry: HelpCommandEntry): string {
+  if (!entry.source) return entry.description
+  return `${entry.description} (${entry.source})`
+}
+
+export function Commands({
+  commands,
+  maxHeight,
+  columns,
+  title,
+  emptyMessage,
+  onCancel,
+  isDisabled = false,
+  onUpFromFirstItem,
+}: Props) {
+  const maxWidth = Math.max(1, columns - 10)
+  const visibleCount = Math.max(1, Math.floor((maxHeight - 10) / 2))
+
+  const options = useMemo(() => {
+    const seen = new Set<string>()
+    return commands
+      .filter(cmd => {
+        if (seen.has(cmd.name)) return false
+        seen.add(cmd.name)
+        return true
+      })
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map(cmd => ({
+        label: `/${cmd.name}`,
+        value: cmd.name,
+        description: truncate(formatDescriptionWithSource(cmd), maxWidth),
+      }))
+  }, [commands, maxWidth])
+
+  const [cursor, setCursor] = useState(0)
+  const [windowStart, setWindowStart] = useState(0)
+
+  useKeyboard(event => {
+    if (isDisabled || event.eventType === 'release') return
+    const name = event.name
+    const input = event.sequence ?? name ?? ''
+    if (name === 'escape') {
+      onCancel()
+      return
+    }
+    if (name === 'up' || input === 'k') {
+      if (cursor === 0) {
+        onUpFromFirstItem?.()
+        return
+      }
+      const next = cursor - 1
+      setCursor(next)
+      if (next < windowStart) setWindowStart(next)
+      return
+    }
+    if (name === 'down' || input === 'j') {
+      if (cursor === options.length - 1) return
+      const next = cursor + 1
+      setCursor(next)
+      if (next >= windowStart + visibleCount) setWindowStart(next - visibleCount + 1)
+    }
+  })
+
+  if (options.length === 0 && emptyMessage) {
+    return (
+      <box flexDirection="column" paddingY={1}>
+        <text fg={c.dim}>{emptyMessage}</text>
+      </box>
+    )
+  }
+
+  const visible = options.slice(windowStart, windowStart + visibleCount)
+  const hasAbove = windowStart > 0
+  const hasBelow = windowStart + visibleCount < options.length
+
+  return (
+    <box flexDirection="column" paddingY={1}>
+      <text>{title}</text>
+      <box marginTop={1} flexDirection="column">
+        {hasAbove && <text fg={c.dim}>{`\u25B4 ${windowStart} more\u2026`}</text>}
+        {visible.map((opt, i) => {
+          const index = windowStart + i
+          const isSelected = index === cursor
+          return (
+            <box key={opt.value} flexDirection="column">
+              <text
+                fg={isSelected ? c.bg : c.accent}
+                bg={isSelected ? c.textBright : undefined}
+              >
+                <strong>{` ${opt.label} `}</strong>
+              </text>
+              <text fg={c.dim}>{`   ${opt.description}`}</text>
+            </box>
+          )
+        })}
+        {hasBelow && (
+          <text fg={c.dim}>{`\u25BE ${options.length - (windowStart + visibleCount)} more\u2026`}</text>
+        )}
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/helpv2/General.tsx
+++ b/ui/src/components/helpv2/General.tsx
@@ -1,0 +1,99 @@
+import React from 'react'
+import { c } from '../../theme.js'
+import { shortcutLabel } from '../../keybindings.js'
+import { useAppState } from '../../store/app-store.js'
+
+/**
+ * "General" tab body for the HelpV2 dialog.
+ *
+ * OpenTUI-native port of the upstream `helpv2/General`
+ * (`ui/examples/upstream-patterns/src/components/helpv2/General.tsx`).
+ * Upstream delegated to a separate `PromptInputHelpMenu` component;
+ * the Lite port inlines the three-column shortcut grid so the body
+ * depends only on the local keybinding resolver and theme.
+ */
+
+function formatShortcut(shortcut: string): string {
+  return shortcut.replace(/\+/g, ' + ')
+}
+
+function resolveChord(
+  action: Parameters<typeof shortcutLabel>[0],
+  context: string,
+  fallback: string,
+  config: ReturnType<typeof useAppState>['keybindingConfig'],
+): string {
+  const resolved = shortcutLabel(action, { context, config: config ?? null })
+  return formatShortcut(resolved || fallback)
+}
+
+type Row = { key: string; text: string }
+
+function DimList({ rows, width }: { rows: Row[]; width?: number }) {
+  return (
+    <box flexDirection="column" width={width}>
+      {rows.map(row => (
+        <text key={row.key} fg={c.dim}>
+          {row.text}
+        </text>
+      ))}
+    </box>
+  )
+}
+
+export function General() {
+  const { keybindingConfig } = useAppState()
+
+  const cycleMode = resolveChord('chat:cycleMode', 'Chat', 'shift+tab', keybindingConfig)
+  const transcript = resolveChord('app:toggleTranscript', 'Global', 'ctrl+o', keybindingConfig)
+  const todos = resolveChord('app:toggleTodos', 'Global', 'ctrl+t', keybindingConfig)
+  const modelPicker = resolveChord('chat:modelPicker', 'Chat', 'alt+p', keybindingConfig)
+  const fastMode = resolveChord('chat:fastMode', 'Chat', 'alt+o', keybindingConfig)
+  const stash = resolveChord('chat:stash', 'Chat', 'ctrl+s', keybindingConfig)
+  const newline = resolveChord('chat:newline', 'Chat', 'ctrl+j', keybindingConfig)
+  const externalEditor = resolveChord('chat:externalEditor', 'Chat', 'ctrl+g', keybindingConfig)
+  const imagePaste = resolveChord('chat:imagePaste', 'Chat', 'ctrl+v', keybindingConfig)
+
+  const typingRows: Row[] = [
+    { key: 'bash', text: '! for bash mode' },
+    { key: 'cmd', text: '/ for commands' },
+    { key: 'file', text: '@ for file paths' },
+    { key: 'bg', text: '& for background' },
+    { key: 'btw', text: '/btw for side question' },
+  ]
+
+  const editingRows: Row[] = [
+    { key: 'esc', text: 'double tap esc to clear input' },
+    { key: 'cycle', text: `${cycleMode} to auto-accept edits` },
+    { key: 'transcript', text: `${transcript} for verbose output` },
+    { key: 'todos', text: `${todos} to toggle tasks` },
+    { key: 'newline', text: `${newline} for newline` },
+  ]
+
+  const toolsRows: Row[] = [
+    { key: 'model', text: `${modelPicker} to switch model` },
+    { key: 'fast', text: `${fastMode} to toggle fast mode` },
+    { key: 'stash', text: `${stash} to stash prompt` },
+    { key: 'editor', text: `${externalEditor} to edit in $EDITOR` },
+    { key: 'image', text: `${imagePaste} to paste images` },
+  ]
+
+  return (
+    <box flexDirection="column" paddingY={1}>
+      <text>
+        Claude understands your codebase, makes edits with your permission,
+        and executes commands \u2014 right from your terminal.
+      </text>
+      <box marginTop={1} flexDirection="column">
+        <text>
+          <strong>Shortcuts</strong>
+        </text>
+        <box flexDirection="row" marginTop={1}>
+          <DimList rows={typingRows} width={24} />
+          <DimList rows={editingRows} width={35} />
+          <DimList rows={toolsRows} />
+        </box>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/helpv2/HelpV2.tsx
+++ b/ui/src/components/helpv2/HelpV2.tsx
@@ -1,0 +1,176 @@
+import React, { useMemo, useState } from 'react'
+import { useKeyboard, useTerminalDimensions } from '@opentui/react'
+import { c } from '../../theme.js'
+import { shortcutLabel } from '../../keybindings.js'
+import { useAppState } from '../../store/app-store.js'
+import { Commands, type HelpCommandEntry } from './Commands.js'
+import { General } from './General.js'
+
+/**
+ * Tabbed help overlay (`/help`).
+ *
+ * OpenTUI-native port of the upstream `helpv2/HelpV2`
+ * (`ui/examples/upstream-patterns/src/components/helpv2/HelpV2.tsx`).
+ * Upstream pulled `Pane`, `Tabs`, `Tab`, analytics helpers, and the
+ * legacy `commands` registry through Ink. The Lite port keeps the same
+ * tab taxonomy (general / commands / custom-commands / ant-only) and
+ * the "press Esc to dismiss / ctrl+c twice to exit" gesture, but expects
+ * the caller to hand in a flat `HelpCommandEntry` list \u2014 the Rust
+ * backend owns the command registry.
+ */
+
+type TabId = 'general' | 'commands' | 'custom-commands' | 'ant-only'
+
+type HelpTab = {
+  id: TabId
+  title: string
+  emptyMessage?: string
+  commands?: HelpCommandEntry[]
+  heading?: string
+}
+
+type Props = {
+  onClose: () => void
+  /** Built-in commands (shown under the "commands" tab). */
+  builtinCommands: HelpCommandEntry[]
+  /** Project / user / plugin commands (shown under "custom-commands"). */
+  customCommands?: HelpCommandEntry[]
+  /** ANT-only commands (only rendered when `showAntOnly` is true). */
+  antOnlyCommands?: HelpCommandEntry[]
+  /** When true, expose the `[ant-only]` tab. Defaults to `false`. */
+  showAntOnly?: boolean
+  /** Version string shown in the frame title. */
+  version?: string
+}
+
+const DOCS_URL = 'https://docs.claude.com/en/docs/claude-code/overview'
+
+export function HelpV2({
+  onClose,
+  builtinCommands,
+  customCommands = [],
+  antOnlyCommands = [],
+  showAntOnly = false,
+  version,
+}: Props) {
+  const { width: columns, height: rows } = useTerminalDimensions()
+  const maxHeight = Math.max(20, Math.floor(rows / 2))
+  const { keybindingConfig } = useAppState()
+
+  const dismissShortcut =
+    shortcutLabel('help:dismiss', { context: 'Help', config: keybindingConfig ?? null }) ||
+    'esc'
+
+  const tabs = useMemo<HelpTab[]>(() => {
+    const list: HelpTab[] = [
+      { id: 'general', title: 'general' },
+      {
+        id: 'commands',
+        title: 'commands',
+        heading: 'Browse default commands:',
+        commands: builtinCommands,
+      },
+      {
+        id: 'custom-commands',
+        title: 'custom-commands',
+        heading: 'Browse custom commands:',
+        commands: customCommands,
+        emptyMessage: 'No custom commands found',
+      },
+    ]
+    if (showAntOnly && antOnlyCommands.length > 0) {
+      list.push({
+        id: 'ant-only',
+        title: '[ant-only]',
+        heading: 'Browse ant-only commands:',
+        commands: antOnlyCommands,
+      })
+    }
+    return list
+  }, [antOnlyCommands, builtinCommands, customCommands, showAntOnly])
+
+  const [activeIndex, setActiveIndex] = useState(0)
+  const [headerFocused, setHeaderFocused] = useState(true)
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    if (name === 'escape') {
+      onClose()
+      return
+    }
+    if (!headerFocused) return
+    if (name === 'tab' || name === 'right') {
+      setActiveIndex(prev => (prev + 1) % tabs.length)
+      return
+    }
+    if (name === 'left') {
+      setActiveIndex(prev => (prev - 1 + tabs.length) % tabs.length)
+      return
+    }
+    if (name === 'down') {
+      setHeaderFocused(false)
+    }
+  })
+
+  const activeTab = tabs[activeIndex]!
+  const title = version ? `Claude Code v${version}` : '/help'
+
+  return (
+    <box
+      position="absolute"
+      top={2}
+      left={2}
+      right={2}
+      bottom={2}
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.info}
+      title={title}
+      titleAlignment="left"
+      paddingX={2}
+      paddingY={1}
+    >
+      <box flexDirection="row" gap={1}>
+        {tabs.map((tab, i) => {
+          const isActive = i === activeIndex
+          return (
+            <text
+              key={tab.id}
+              fg={isActive ? c.bg : c.dim}
+              bg={isActive ? c.info : undefined}
+            >
+              <strong>{` ${tab.title} `}</strong>
+            </text>
+          )
+        })}
+      </box>
+      <box marginTop={1} flexGrow={1} flexDirection="column">
+        {activeTab.id === 'general' ? (
+          <General />
+        ) : (
+          <Commands
+            commands={activeTab.commands ?? []}
+            maxHeight={maxHeight}
+            columns={columns}
+            title={activeTab.heading ?? ''}
+            emptyMessage={activeTab.emptyMessage}
+            onCancel={onClose}
+            isDisabled={headerFocused}
+            onUpFromFirstItem={() => setHeaderFocused(true)}
+          />
+        )}
+      </box>
+      <box marginTop={1} flexDirection="column">
+        <text>
+          For more help: <span fg={c.info}>{DOCS_URL}</span>
+        </text>
+        <text>
+          <em>
+            <span fg={c.dim}>{`${dismissShortcut} to cancel`}</span>
+          </em>
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/helpv2/index.ts
+++ b/ui/src/components/helpv2/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Barrel for the HelpV2 overlay. Mirrors the upstream layout at
+ * `ui/examples/upstream-patterns/src/components/helpv2/` so downstream
+ * imports stay stable during the full-build migration.
+ */
+export { Commands } from './Commands.js'
+export type { HelpCommandEntry } from './Commands.js'
+export { General } from './General.js'
+export { HelpV2 } from './HelpV2.js'

--- a/ui/src/components/highlighted-code/Fallback.tsx
+++ b/ui/src/components/highlighted-code/Fallback.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { extname } from 'path'
+import { c } from '../../theme.js'
+
+/**
+ * No-syntax-highlighter fallback renderer for code blocks.
+ *
+ * OpenTUI-native port of the upstream `highlighted-code/Fallback`
+ * (`ui/examples/upstream-patterns/src/components/highlighted-code/Fallback.tsx`).
+ * Upstream streamed the code through `getCliHighlightPromise()` and an
+ * ANSI-capable `<Ansi>` node; the Lite port is OpenTUI-native — OpenTUI
+ * `<text>` nodes do not interpret embedded ANSI escapes, so we render
+ * the raw source with leading tabs converted to spaces and let the
+ * caller pick up syntax coloring from a higher-level surface once a
+ * highlighter is wired in.
+ *
+ * Upstream's "hl.highlight()" cache was a hot-path optimization for
+ * virtual-scroll remounts. With the OpenTUI diff renderer the cost
+ * profile is different and a plain render is enough for the fallback
+ * path. If a highlighter lands, re-introduce caching keyed by
+ * `hashPair(language, code)` as upstream did.
+ */
+
+type Props = {
+  code: string
+  filePath: string
+  dim?: boolean
+  /** Skip the language detection entirely \u2014 mirrors upstream prop. */
+  skipColoring?: boolean
+}
+
+/** Replace leading tabs in every line with two spaces each. */
+export function convertLeadingTabsToSpaces(code: string): string {
+  return code.replace(/^\t+/gm, m => '  '.repeat(m.length))
+}
+
+export function HighlightedCodeFallback({
+  code,
+  filePath,
+  dim = false,
+  skipColoring: _skipColoring = false,
+}: Props) {
+  const rendered = convertLeadingTabsToSpaces(code)
+  // `filePath` is retained so consumers that later gain a syntax
+  // highlighter can derive the language without changing the call site.
+  void filePath
+  void extname
+  const fg = dim ? c.dim : undefined
+  return <text fg={fg}>{rendered}</text>
+}

--- a/ui/src/components/highlighted-code/index.ts
+++ b/ui/src/components/highlighted-code/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Barrel for the `highlighted-code` folder. Mirrors the upstream
+ * layout at `ui/examples/upstream-patterns/src/components/highlighted-code/`.
+ *
+ * Until a full OpenTUI-native syntax highlighter lands, the top-level
+ * `HighlightedCode` surface is supplied by `components/HighlightedCode.tsx`
+ * (see the Rust-side highlighter wiring). The fallback renderer lives
+ * here so both the top-level and future sub-surfaces can reuse it.
+ */
+export {
+  HighlightedCodeFallback,
+  convertLeadingTabsToSpaces,
+} from './Fallback.js'

--- a/ui/src/components/hooks/HooksConfigMenu.tsx
+++ b/ui/src/components/hooks/HooksConfigMenu.tsx
@@ -1,0 +1,247 @@
+import React, { useMemo, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../../theme.js'
+import type {
+  HookEvent,
+  HookEventMetadata,
+  IndividualHookConfig,
+} from './types.js'
+import { plural } from './types.js'
+import { SelectEventMode } from './SelectEventMode.js'
+import { SelectHookMode } from './SelectHookMode.js'
+import { SelectMatcherMode } from './SelectMatcherMode.js'
+import { ViewHookMode } from './ViewHookMode.js'
+
+/**
+ * Orchestrator for the `/hooks` read-only configuration browser.
+ *
+ * OpenTUI-native port of the upstream `hooks/HooksConfigMenu`
+ * (`ui/examples/upstream-patterns/src/components/hooks/HooksConfigMenu.tsx`).
+ * Upstream pulled live state from `AppState`, settings readers, the
+ * `hooksConfigManager` grouping helpers, and `useSettingsChange`. The
+ * Lite port takes a flat `HooksSnapshot` from the caller \u2014 the Rust
+ * backend builds the snapshot from policy / user / project / local /
+ * plugin settings and ships it through IPC.
+ *
+ * The machine has four modes (select-event \u2192 select-matcher \u2192
+ * select-hook \u2192 view-hook) with Esc routing back up. When all hooks
+ * are disabled via `settings.disableAllHooks`, a single informational
+ * frame is rendered instead.
+ */
+
+export type HooksSnapshot = {
+  /** Fully-expanded hook list \u2014 one entry per configured hook. */
+  hooks: IndividualHookConfig[]
+  /** Metadata per event, includes `matcherMetadata` for tool-matcher events. */
+  eventMetadata: Record<HookEvent, HookEventMetadata>
+  /** Combined tool name list (builtin + MCP). Kept for
+   *  `getMatcherMetadata`-style lookups. */
+  toolNames: string[]
+  /** True when `settings.disableAllHooks === true`. */
+  hooksDisabled: boolean
+  /** True when a managed policy set `disableAllHooks`. */
+  disabledByPolicy: boolean
+  /** True when a managed policy enabled `allowManagedHooksOnly`. */
+  restrictedByPolicy: boolean
+}
+
+type ModeState =
+  | { mode: 'select-event' }
+  | { mode: 'select-matcher'; event: HookEvent }
+  | { mode: 'select-hook'; event: HookEvent; matcher: string }
+  | { mode: 'view-hook'; event: HookEvent; hook: IndividualHookConfig }
+
+type Props = {
+  snapshot: HooksSnapshot
+  onExit: () => void
+}
+
+function groupHooks(
+  hooks: IndividualHookConfig[],
+): Record<HookEvent, Record<string, IndividualHookConfig[]>> {
+  const grouped: Partial<Record<HookEvent, Record<string, IndividualHookConfig[]>>> = {}
+  for (const hook of hooks) {
+    const byEvent = grouped[hook.event] ?? {}
+    const matcherKey = hook.matcher ?? ''
+    const list = byEvent[matcherKey] ?? []
+    list.push(hook)
+    byEvent[matcherKey] = list
+    grouped[hook.event] = byEvent
+  }
+  return grouped as Record<HookEvent, Record<string, IndividualHookConfig[]>>
+}
+
+function sortedMatchersFor(
+  grouped: Record<HookEvent, Record<string, IndividualHookConfig[]>>,
+  event: HookEvent,
+): string[] {
+  const byMatcher = grouped[event] ?? {}
+  return Object.keys(byMatcher).sort((a, b) => {
+    if (a === '' && b !== '') return -1
+    if (a !== '' && b === '') return 1
+    return a.localeCompare(b)
+  })
+}
+
+export function HooksConfigMenu({ snapshot, onExit }: Props) {
+  const [modeState, setModeState] = useState<ModeState>({ mode: 'select-event' })
+
+  const grouped = useMemo(() => groupHooks(snapshot.hooks), [snapshot.hooks])
+
+  const { hooksByEvent, totalHooksCount } = useMemo(() => {
+    const byEvent: Partial<Record<HookEvent, number>> = {}
+    let total = 0
+    for (const [event, matchers] of Object.entries(grouped) as Array<
+      [HookEvent, Record<string, IndividualHookConfig[]>]
+    >) {
+      const count = Object.values(matchers).reduce((sum, list) => sum + list.length, 0)
+      byEvent[event] = count
+      total += count
+    }
+    return { hooksByEvent: byEvent, totalHooksCount: total }
+  }, [grouped])
+
+  const selectedEvent = 'event' in modeState ? modeState.event : 'PreToolUse'
+  const selectedMatcher = 'matcher' in modeState ? modeState.matcher : null
+
+  const sortedMatchers = useMemo(
+    () => sortedMatchersFor(grouped, selectedEvent),
+    [grouped, selectedEvent],
+  )
+
+  const hooksForSelectedMatcher = useMemo(() => {
+    if (selectedMatcher === null) return []
+    return grouped[selectedEvent]?.[selectedMatcher] ?? []
+  }, [grouped, selectedEvent, selectedMatcher])
+
+  // The disabled-by-policy screen has its own Esc handling; wire the rest
+  // here so the mode machine stays in one place.
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    if (!snapshot.hooksDisabled) return
+    if (event.name === 'escape' || event.name === 'enter' || event.name === 'return') {
+      onExit()
+    }
+  })
+
+  if (snapshot.hooksDisabled) {
+    return (
+      <box
+        position="absolute"
+        top={2}
+        left={2}
+        right={2}
+        bottom={2}
+        flexDirection="column"
+        borderStyle="rounded"
+        borderColor={c.warning}
+        title="Hook Configuration \u00B7 Disabled"
+        titleAlignment="left"
+        paddingX={2}
+        paddingY={1}
+      >
+        <text>
+          All hooks are currently <strong>disabled</strong>
+          {snapshot.disabledByPolicy && ' by a managed settings file'}. You have{' '}
+          <strong>{totalHooksCount}</strong> configured {plural(totalHooksCount, 'hook')} that{' '}
+          {plural(totalHooksCount, 'is', 'are')} not running.
+        </text>
+        <box marginTop={1} flexDirection="column">
+          <text fg={c.dim}>When hooks are disabled:</text>
+          <text fg={c.dim}>\u00B7 No hook commands will execute</text>
+          <text fg={c.dim}>\u00B7 StatusLine will not be displayed</text>
+          <text fg={c.dim}>\u00B7 Tool operations will proceed without hook validation</text>
+        </box>
+        {!snapshot.disabledByPolicy && (
+          <box marginTop={1}>
+            <text fg={c.dim}>
+              To re-enable hooks, remove &quot;disableAllHooks&quot; from settings.json or ask
+              Claude.
+            </text>
+          </box>
+        )}
+        <box marginTop={1}>
+          <text fg={c.dim}>Esc to close</text>
+        </box>
+      </box>
+    )
+  }
+
+  switch (modeState.mode) {
+    case 'select-event':
+      return (
+        <SelectEventMode
+          hookEventMetadata={snapshot.eventMetadata}
+          hooksByEvent={hooksByEvent}
+          totalHooksCount={totalHooksCount}
+          restrictedByPolicy={snapshot.restrictedByPolicy}
+          onSelectEvent={event => {
+            const hasMatchers =
+              snapshot.eventMetadata[event]?.matcherMetadata !== undefined
+            if (hasMatchers) {
+              setModeState({ mode: 'select-matcher', event })
+            } else {
+              setModeState({ mode: 'select-hook', event, matcher: '' })
+            }
+          }}
+          onCancel={onExit}
+        />
+      )
+    case 'select-matcher':
+      return (
+        <SelectMatcherMode
+          selectedEvent={modeState.event}
+          matchersForSelectedEvent={sortedMatchers}
+          hooksByEventAndMatcher={grouped}
+          eventDescription={snapshot.eventMetadata[modeState.event]?.description ?? ''}
+          onSelect={matcher => {
+            setModeState({
+              mode: 'select-hook',
+              event: modeState.event,
+              matcher,
+            })
+          }}
+          onCancel={() => setModeState({ mode: 'select-event' })}
+        />
+      )
+    case 'select-hook':
+      return (
+        <SelectHookMode
+          selectedEvent={modeState.event}
+          selectedMatcher={modeState.matcher}
+          hooksForSelectedMatcher={hooksForSelectedMatcher}
+          hookEventMetadata={snapshot.eventMetadata[modeState.event]!}
+          onSelect={hook => {
+            setModeState({ mode: 'view-hook', event: modeState.event, hook })
+          }}
+          onCancel={() => {
+            const hasMatchers =
+              snapshot.eventMetadata[modeState.event]?.matcherMetadata !== undefined
+            if (hasMatchers) {
+              setModeState({ mode: 'select-matcher', event: modeState.event })
+            } else {
+              setModeState({ mode: 'select-event' })
+            }
+          }}
+        />
+      )
+    case 'view-hook': {
+      const { event, hook } = modeState
+      const eventSupportsMatcher =
+        snapshot.eventMetadata[event]?.matcherMetadata !== undefined
+      return (
+        <ViewHookMode
+          selectedHook={hook}
+          eventSupportsMatcher={eventSupportsMatcher}
+          onCancel={() => {
+            setModeState({
+              mode: 'select-hook',
+              event,
+              matcher: hook.matcher || '',
+            })
+          }}
+        />
+      )
+    }
+  }
+}

--- a/ui/src/components/hooks/PromptDialog.tsx
+++ b/ui/src/components/hooks/PromptDialog.tsx
@@ -1,0 +1,117 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../../theme.js'
+import type { PromptHookRequest } from './types.js'
+
+/**
+ * Interactive prompt spawned by a prompt-type hook (e.g. a tool-call
+ * confirmation routed through a hook).
+ *
+ * OpenTUI-native port of the upstream `hooks/PromptDialog`
+ * (`ui/examples/upstream-patterns/src/components/hooks/PromptDialog.tsx`).
+ * Upstream wrapped `<PermissionDialog>` + `<Select>`; the Lite port
+ * renders the same list of labelled options and respects `app:interrupt`
+ * (Ctrl+C) by calling `onAbort`.
+ */
+
+type Props = {
+  title: string
+  toolInputSummary?: string | null
+  request: PromptHookRequest
+  onRespond: (key: string) => void
+  onAbort: () => void
+}
+
+export function PromptDialog({
+  title,
+  toolInputSummary,
+  request,
+  onRespond,
+  onAbort,
+}: Props) {
+  const options = request.options
+  const [cursor, setCursor] = useState(0)
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const input = event.sequence ?? name ?? ''
+    if (event.ctrl && input === 'c') {
+      onAbort()
+      return
+    }
+    if (name === 'escape') {
+      onAbort()
+      return
+    }
+    if (options.length === 0) return
+    if (name === 'up' || input === 'k') {
+      setCursor(prev => Math.max(0, prev - 1))
+      return
+    }
+    if (name === 'down' || input === 'j') {
+      setCursor(prev => Math.min(options.length - 1, prev + 1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      const selected = options[cursor]
+      if (selected) onRespond(selected.key)
+      return
+    }
+    if (input && input.length === 1) {
+      const match = options.findIndex(opt => opt.key === input)
+      if (match >= 0) {
+        onRespond(options[match]!.key)
+      }
+    }
+  })
+
+  return (
+    <box
+      position="absolute"
+      bottom={3}
+      left={1}
+      right={1}
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.warning}
+      title={title}
+      titleAlignment="center"
+      paddingX={2}
+      paddingY={1}
+    >
+      <box flexDirection="row" justifyContent="space-between">
+        <text>{request.title ?? 'Hook prompt'}</text>
+        {toolInputSummary && <text fg={c.dim}>{toolInputSummary}</text>}
+      </box>
+      <box marginTop={1}>
+        <text>{request.message}</text>
+      </box>
+      <box marginTop={1} flexDirection="column">
+        {options.map((opt, i) => {
+          const isSelected = i === cursor
+          return (
+            <box key={opt.key} flexDirection="column">
+              <text
+                fg={isSelected ? c.bg : undefined}
+                bg={isSelected ? c.textBright : undefined}
+              >
+                <strong>{` ${opt.label} `}</strong>
+                <span fg={isSelected ? c.bg : c.dim}>{` (${opt.key})`}</span>
+              </text>
+              {opt.description && (
+                <text fg={c.dim}>{`   ${opt.description}`}</text>
+              )}
+            </box>
+          )
+        })}
+      </box>
+      <box marginTop={1}>
+        <text fg={c.dim}>
+          Up/Down to move \u00B7 Enter to select \u00B7 hotkey matches \u00B7
+          Ctrl+C to abort
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/hooks/SelectEventMode.tsx
+++ b/ui/src/components/hooks/SelectEventMode.tsx
@@ -1,0 +1,117 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../../theme.js'
+import type { HookEvent, HookEventMetadata } from './types.js'
+import { plural } from './types.js'
+
+/**
+ * Entry view for `/hooks` \u2014 pick a hook event to drill into.
+ *
+ * OpenTUI-native port of the upstream `hooks/SelectEventMode`
+ * (`ui/examples/upstream-patterns/src/components/hooks/SelectEventMode.tsx`).
+ * The menu is read-only: selecting an event lets you browse its
+ * configured hooks but not modify them.
+ */
+
+const DOCS_URL = 'https://docs.claude.com/en/docs/claude-code/hooks'
+
+type Props = {
+  hookEventMetadata: Record<HookEvent, HookEventMetadata>
+  hooksByEvent: Partial<Record<HookEvent, number>>
+  totalHooksCount: number
+  restrictedByPolicy: boolean
+  onSelectEvent: (event: HookEvent) => void
+  onCancel: () => void
+}
+
+export function SelectEventMode({
+  hookEventMetadata,
+  hooksByEvent,
+  totalHooksCount,
+  restrictedByPolicy,
+  onSelectEvent,
+  onCancel,
+}: Props) {
+  const events = Object.keys(hookEventMetadata) as HookEvent[]
+  const [cursor, setCursor] = useState(0)
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const input = event.sequence ?? name ?? ''
+    if (name === 'escape') {
+      onCancel()
+      return
+    }
+    if (name === 'up' || input === 'k') {
+      setCursor(prev => Math.max(0, prev - 1))
+      return
+    }
+    if (name === 'down' || input === 'j') {
+      setCursor(prev => Math.min(events.length - 1, prev + 1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      const selected = events[cursor]
+      if (selected) onSelectEvent(selected)
+    }
+  })
+
+  const subtitle = `${totalHooksCount} ${plural(totalHooksCount, 'hook')} configured`
+
+  return (
+    <box
+      position="absolute"
+      top={2}
+      left={2}
+      right={2}
+      bottom={2}
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.warning}
+      title={`Hooks \u00B7 ${subtitle}`}
+      titleAlignment="left"
+      paddingX={2}
+      paddingY={1}
+    >
+      {restrictedByPolicy && (
+        <box flexDirection="column" marginBottom={1}>
+          <text fg={c.warning}>\u2139 Hooks Restricted by Policy</text>
+          <text fg={c.dim}>
+            Only hooks from managed settings can run. User-defined hooks from
+            ~/.claude/settings.json, .claude/settings.json, and
+            .claude/settings.local.json are blocked.
+          </text>
+        </box>
+      )}
+      <box marginBottom={1}>
+        <text fg={c.dim}>
+          \u2139 This menu is read-only. To add or modify hooks, edit
+          settings.json directly or ask Claude. <span fg={c.info}>{DOCS_URL}</span>
+        </text>
+      </box>
+      <box flexDirection="column">
+        {events.map((name, i) => {
+          const isSelected = i === cursor
+          const count = hooksByEvent[name] ?? 0
+          const metadata = hookEventMetadata[name]
+          return (
+            <box key={name} flexDirection="column">
+              <text
+                fg={isSelected ? c.bg : undefined}
+                bg={isSelected ? c.textBright : undefined}
+              >
+                <strong>{` ${name} `}</strong>
+                {count > 0 && <span fg={isSelected ? c.bg : c.info}>{` (${count})`}</span>}
+              </text>
+              <text fg={c.dim}>{`   ${metadata.summary}`}</text>
+            </box>
+          )
+        })}
+      </box>
+      <box marginTop={1}>
+        <text fg={c.dim}>Up/Down to move \u00B7 Enter to open \u00B7 Esc to close</text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/hooks/SelectHookMode.tsx
+++ b/ui/src/components/hooks/SelectHookMode.tsx
@@ -1,0 +1,139 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../../theme.js'
+import type {
+  HookEvent,
+  HookEventMetadata,
+  IndividualHookConfig,
+} from './types.js'
+import { getHookDisplayText, hookSourceHeaderDisplayString } from './types.js'
+
+/**
+ * Final read-only list of hooks for a chosen event+matcher.
+ *
+ * OpenTUI-native port of the upstream `hooks/SelectHookMode`
+ * (`ui/examples/upstream-patterns/src/components/hooks/SelectHookMode.tsx`).
+ * Selecting a hook shows its details via `ViewHookMode`.
+ */
+
+type Props = {
+  selectedEvent: HookEvent
+  selectedMatcher: string | null
+  hooksForSelectedMatcher: IndividualHookConfig[]
+  hookEventMetadata: HookEventMetadata
+  onSelect: (hook: IndividualHookConfig) => void
+  onCancel: () => void
+}
+
+export function SelectHookMode({
+  selectedEvent,
+  selectedMatcher,
+  hooksForSelectedMatcher,
+  hookEventMetadata,
+  onSelect,
+  onCancel,
+}: Props) {
+  const [cursor, setCursor] = useState(0)
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const input = event.sequence ?? name ?? ''
+    if (name === 'escape') {
+      onCancel()
+      return
+    }
+    if (hooksForSelectedMatcher.length === 0) return
+    if (name === 'up' || input === 'k') {
+      setCursor(prev => Math.max(0, prev - 1))
+      return
+    }
+    if (name === 'down' || input === 'j') {
+      setCursor(prev => Math.min(hooksForSelectedMatcher.length - 1, prev + 1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      const selected = hooksForSelectedMatcher[cursor]
+      if (selected) onSelect(selected)
+    }
+  })
+
+  const title =
+    hookEventMetadata.matcherMetadata !== undefined
+      ? `${selectedEvent} \u00B7 Matcher: ${selectedMatcher || '(all)'}`
+      : selectedEvent
+
+  if (hooksForSelectedMatcher.length === 0) {
+    return (
+      <box
+        position="absolute"
+        top={2}
+        left={2}
+        right={2}
+        bottom={2}
+        flexDirection="column"
+        borderStyle="rounded"
+        borderColor={c.warning}
+        title={title}
+        titleAlignment="left"
+        paddingX={2}
+        paddingY={1}
+      >
+        <text fg={c.dim}>{hookEventMetadata.description}</text>
+        <box marginTop={1} flexDirection="column">
+          <text fg={c.dim}>No hooks configured for this event.</text>
+          <text fg={c.dim}>
+            To add hooks, edit settings.json directly or ask Claude.
+          </text>
+        </box>
+        <box marginTop={1}>
+          <text fg={c.dim}>Esc to go back</text>
+        </box>
+      </box>
+    )
+  }
+
+  return (
+    <box
+      position="absolute"
+      top={2}
+      left={2}
+      right={2}
+      bottom={2}
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.warning}
+      title={title}
+      titleAlignment="left"
+      paddingX={2}
+      paddingY={1}
+    >
+      <text fg={c.dim}>{hookEventMetadata.description}</text>
+      <box marginTop={1} flexDirection="column">
+        {hooksForSelectedMatcher.map((hook, i) => {
+          const isSelected = i === cursor
+          const typeLabel = hook.config.type
+          const displayText = getHookDisplayText(hook.config)
+          const sourceLabel =
+            hook.source === 'pluginHook' && hook.pluginName
+              ? `${hookSourceHeaderDisplayString(hook.source)} (${hook.pluginName})`
+              : hookSourceHeaderDisplayString(hook.source)
+          return (
+            <box key={`hook-${i}`} flexDirection="column">
+              <text
+                fg={isSelected ? c.bg : undefined}
+                bg={isSelected ? c.textBright : undefined}
+              >
+                <strong>{` [${typeLabel}] ${displayText} `}</strong>
+              </text>
+              <text fg={c.dim}>{`   ${sourceLabel}`}</text>
+            </box>
+          )
+        })}
+      </box>
+      <box marginTop={1}>
+        <text fg={c.dim}>Up/Down to move \u00B7 Enter for details \u00B7 Esc to go back</text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/hooks/SelectMatcherMode.tsx
+++ b/ui/src/components/hooks/SelectMatcherMode.tsx
@@ -1,0 +1,151 @@
+import React, { useMemo, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../../theme.js'
+import type { HookEvent, HookSource, IndividualHookConfig } from './types.js'
+import { hookSourceInlineDisplayString, plural } from './types.js'
+
+/**
+ * Matcher picker for a selected hook event.
+ *
+ * OpenTUI-native port of the upstream `hooks/SelectMatcherMode`
+ * (`ui/examples/upstream-patterns/src/components/hooks/SelectMatcherMode.tsx`).
+ * Read-only: selecting a matcher drills into the list of individual
+ * hooks configured for that event+matcher pair.
+ */
+
+type MatcherWithSource = {
+  matcher: string
+  sources: HookSource[]
+  hookCount: number
+}
+
+type Props = {
+  selectedEvent: HookEvent
+  matchersForSelectedEvent: string[]
+  hooksByEventAndMatcher: Record<HookEvent, Record<string, IndividualHookConfig[]>>
+  eventDescription: string
+  onSelect: (matcher: string) => void
+  onCancel: () => void
+}
+
+export function SelectMatcherMode({
+  selectedEvent,
+  matchersForSelectedEvent,
+  hooksByEventAndMatcher,
+  eventDescription,
+  onSelect,
+  onCancel,
+}: Props) {
+  const matchersWithSources: MatcherWithSource[] = useMemo(() => {
+    return matchersForSelectedEvent.map(matcher => {
+      const hooks = hooksByEventAndMatcher[selectedEvent]?.[matcher] ?? []
+      const sources = Array.from(new Set(hooks.map(h => h.source)))
+      return {
+        matcher,
+        sources,
+        hookCount: hooks.length,
+      }
+    })
+  }, [matchersForSelectedEvent, hooksByEventAndMatcher, selectedEvent])
+
+  const [cursor, setCursor] = useState(0)
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const input = event.sequence ?? name ?? ''
+    if (name === 'escape') {
+      onCancel()
+      return
+    }
+    if (matchersWithSources.length === 0) return
+    if (name === 'up' || input === 'k') {
+      setCursor(prev => Math.max(0, prev - 1))
+      return
+    }
+    if (name === 'down' || input === 'j') {
+      setCursor(prev => Math.min(matchersWithSources.length - 1, prev + 1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      const selected = matchersWithSources[cursor]
+      if (selected) onSelect(selected.matcher)
+    }
+  })
+
+  const title = `${selectedEvent} \u00B7 Matchers`
+
+  if (matchersForSelectedEvent.length === 0) {
+    return (
+      <box
+        position="absolute"
+        top={2}
+        left={2}
+        right={2}
+        bottom={2}
+        flexDirection="column"
+        borderStyle="rounded"
+        borderColor={c.warning}
+        title={title}
+        titleAlignment="left"
+        paddingX={2}
+        paddingY={1}
+      >
+        <text fg={c.dim}>{eventDescription}</text>
+        <box marginTop={1} flexDirection="column">
+          <text fg={c.dim}>No hooks configured for this event.</text>
+          <text fg={c.dim}>
+            To add hooks, edit settings.json directly or ask Claude.
+          </text>
+        </box>
+        <box marginTop={1}>
+          <text fg={c.dim}>Esc to go back</text>
+        </box>
+      </box>
+    )
+  }
+
+  return (
+    <box
+      position="absolute"
+      top={2}
+      left={2}
+      right={2}
+      bottom={2}
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.warning}
+      title={title}
+      titleAlignment="left"
+      paddingX={2}
+      paddingY={1}
+    >
+      <text fg={c.dim}>{eventDescription}</text>
+      <box marginTop={1} flexDirection="column">
+        {matchersWithSources.map((item, i) => {
+          const isSelected = i === cursor
+          const sourceText = item.sources
+            .map(hookSourceInlineDisplayString)
+            .join(', ')
+          const matcherLabel = item.matcher || '(all)'
+          return (
+            <box key={`${item.matcher}-${i}`} flexDirection="column">
+              <text
+                fg={isSelected ? c.bg : undefined}
+                bg={isSelected ? c.textBright : undefined}
+              >
+                <strong>{` [${sourceText}] ${matcherLabel} `}</strong>
+              </text>
+              <text fg={c.dim}>
+                {`   ${item.hookCount} ${plural(item.hookCount, 'hook')}`}
+              </text>
+            </box>
+          )
+        })}
+      </box>
+      <box marginTop={1}>
+        <text fg={c.dim}>Up/Down to move \u00B7 Enter to open \u00B7 Esc to go back</text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/hooks/ViewHookMode.tsx
+++ b/ui/src/components/hooks/ViewHookMode.tsx
@@ -1,0 +1,133 @@
+import React from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../../theme.js'
+import type { IndividualHookConfig, HookConfigPayload } from './types.js'
+import { hookSourceDescriptionDisplayString } from './types.js'
+
+/**
+ * Read-only detail view for a single configured hook.
+ *
+ * OpenTUI-native port of the upstream `hooks/ViewHookMode`
+ * (`ui/examples/upstream-patterns/src/components/hooks/ViewHookMode.tsx`).
+ */
+
+type Props = {
+  selectedHook: IndividualHookConfig
+  eventSupportsMatcher: boolean
+  onCancel: () => void
+}
+
+function getContentFieldLabel(config: HookConfigPayload): string {
+  switch (config.type) {
+    case 'command':
+      return 'Command'
+    case 'prompt':
+    case 'agent':
+      return 'Prompt'
+    case 'http':
+      return 'URL'
+  }
+}
+
+function getContentFieldValue(config: HookConfigPayload): string {
+  switch (config.type) {
+    case 'command':
+      return config.command
+    case 'prompt':
+    case 'agent':
+      return config.prompt
+    case 'http':
+      return config.url
+  }
+}
+
+export function ViewHookMode({
+  selectedHook,
+  eventSupportsMatcher,
+  onCancel,
+}: Props) {
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    if (
+      event.name === 'escape' ||
+      event.name === 'return' ||
+      event.name === 'enter'
+    ) {
+      onCancel()
+    }
+  })
+
+  const statusMessage =
+    selectedHook.config.statusMessage && selectedHook.config.statusMessage.length > 0
+      ? selectedHook.config.statusMessage
+      : null
+
+  return (
+    <box
+      position="absolute"
+      top={2}
+      left={2}
+      right={2}
+      bottom={2}
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.warning}
+      title="Hook details"
+      titleAlignment="left"
+      paddingX={2}
+      paddingY={1}
+    >
+      <box flexDirection="column">
+        <text>
+          Event: <strong>{selectedHook.event}</strong>
+        </text>
+        {eventSupportsMatcher && (
+          <text>
+            Matcher: <strong>{selectedHook.matcher || '(all)'}</strong>
+          </text>
+        )}
+        <text>
+          Type: <strong>{selectedHook.config.type}</strong>
+        </text>
+        <text>
+          Source:{' '}
+          <span fg={c.dim}>
+            {hookSourceDescriptionDisplayString(selectedHook.source)}
+          </span>
+        </text>
+        {selectedHook.pluginName && (
+          <text>
+            Plugin: <span fg={c.dim}>{selectedHook.pluginName}</span>
+          </text>
+        )}
+      </box>
+      <box marginTop={1} flexDirection="column">
+        <text fg={c.dim}>{getContentFieldLabel(selectedHook.config)}:</text>
+        <box
+          marginTop={0}
+          borderStyle="single"
+          borderColor={c.dim}
+          paddingX={1}
+        >
+          <text>{getContentFieldValue(selectedHook.config)}</text>
+        </box>
+      </box>
+      {statusMessage && (
+        <box marginTop={1}>
+          <text>
+            Status message: <span fg={c.dim}>{statusMessage}</span>
+          </text>
+        </box>
+      )}
+      <box marginTop={1}>
+        <text fg={c.dim}>
+          To modify or remove this hook, edit settings.json directly or ask
+          Claude to help.
+        </text>
+      </box>
+      <box marginTop={1}>
+        <text fg={c.dim}>Esc / Enter to go back</text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/hooks/index.ts
+++ b/ui/src/components/hooks/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Barrel for the `/hooks` menu. Mirrors the upstream layout at
+ * `ui/examples/upstream-patterns/src/components/hooks/`.
+ */
+export { HooksConfigMenu } from './HooksConfigMenu.js'
+export type { HooksSnapshot } from './HooksConfigMenu.js'
+export { PromptDialog } from './PromptDialog.js'
+export { SelectEventMode } from './SelectEventMode.js'
+export { SelectHookMode } from './SelectHookMode.js'
+export { SelectMatcherMode } from './SelectMatcherMode.js'
+export { ViewHookMode } from './ViewHookMode.js'
+export type {
+  HookConfigPayload,
+  HookConfigType,
+  HookEvent,
+  HookEventMetadata,
+  HookSource,
+  IndividualHookConfig,
+  PromptHookRequest,
+} from './types.js'
+export {
+  getHookDisplayText,
+  hookSourceDescriptionDisplayString,
+  hookSourceHeaderDisplayString,
+  hookSourceInlineDisplayString,
+  plural,
+} from './types.js'

--- a/ui/src/components/hooks/types.ts
+++ b/ui/src/components/hooks/types.ts
@@ -1,0 +1,134 @@
+/**
+ * Shared types for the `/hooks` read-only configuration menu.
+ *
+ * OpenTUI-native port of the upstream hook UI types that in the
+ * upstream tree are split across
+ * `src/utils/hooks/hooksConfigManager.ts`,
+ * `src/utils/hooks/hooksSettings.ts`, `src/types/hooks.ts`,
+ * and `src/entrypoints/agentSdkTypes.ts`.
+ *
+ * The Lite port consolidates just the shapes the UI needs so each
+ * component stays self-contained and the Rust backend can produce a
+ * flat snapshot without replicating the upstream type tree.
+ */
+
+export type HookEvent =
+  | 'PreToolUse'
+  | 'PostToolUse'
+  | 'UserPromptSubmit'
+  | 'Notification'
+  | 'Stop'
+  | 'SubagentStop'
+  | 'PreCompact'
+  | 'SessionStart'
+  | 'SessionEnd'
+  | 'StatusLine'
+
+export type HookSource =
+  | 'userSettings'
+  | 'projectSettings'
+  | 'localSettings'
+  | 'policySettings'
+  | 'pluginHook'
+
+export type HookConfigType = 'command' | 'prompt' | 'agent' | 'http'
+
+export type HookConfigPayload =
+  | { type: 'command'; command: string; statusMessage?: string }
+  | { type: 'prompt'; prompt: string; statusMessage?: string }
+  | { type: 'agent'; prompt: string; statusMessage?: string }
+  | { type: 'http'; url: string; statusMessage?: string }
+
+export type IndividualHookConfig = {
+  event: HookEvent
+  matcher?: string
+  source: HookSource
+  pluginName?: string
+  config: HookConfigPayload
+}
+
+export type HookEventMetadata = {
+  description: string
+  summary: string
+  /** Populated only for events that accept tool-name matchers. */
+  matcherMetadata?: {
+    description: string
+    placeholder?: string
+  }
+}
+
+/**
+ * Prompt-style hook request (for the `PromptDialog` view) \u2014 matches the
+ * upstream `PromptRequest` shape without pulling in the Rust-side union.
+ */
+export type PromptHookRequest = {
+  title?: string
+  message: string
+  options: Array<{
+    key: string
+    label: string
+    description?: string
+  }>
+}
+
+export function hookSourceInlineDisplayString(source: HookSource): string {
+  switch (source) {
+    case 'userSettings':
+      return 'user'
+    case 'projectSettings':
+      return 'project'
+    case 'localSettings':
+      return 'local'
+    case 'policySettings':
+      return 'managed'
+    case 'pluginHook':
+      return 'plugin'
+  }
+}
+
+export function hookSourceHeaderDisplayString(source: HookSource): string {
+  switch (source) {
+    case 'userSettings':
+      return 'User settings'
+    case 'projectSettings':
+      return 'Project settings'
+    case 'localSettings':
+      return 'Local settings'
+    case 'policySettings':
+      return 'Managed settings'
+    case 'pluginHook':
+      return 'Plugin'
+  }
+}
+
+export function hookSourceDescriptionDisplayString(source: HookSource): string {
+  switch (source) {
+    case 'userSettings':
+      return 'from ~/.claude/settings.json'
+    case 'projectSettings':
+      return 'from .claude/settings.json'
+    case 'localSettings':
+      return 'from .claude/settings.local.json'
+    case 'policySettings':
+      return 'from managed policy settings'
+    case 'pluginHook':
+      return 'provided by a plugin'
+  }
+}
+
+export function getHookDisplayText(config: HookConfigPayload): string {
+  switch (config.type) {
+    case 'command':
+      return config.command
+    case 'prompt':
+    case 'agent':
+      return config.prompt
+    case 'http':
+      return config.url
+  }
+}
+
+export function plural(n: number, singular: string, pluralForm?: string): string {
+  if (n === 1) return singular
+  return pluralForm ?? `${singular}s`
+}


### PR DESCRIPTION
## Summary

Second batch of upstream \u2192 OpenTUI folder ports, continuing the
full-build migration started in #113. Four folders land at their
upstream-matching paths under `ui/src/components/` so downstream imports
stay stable during the migration:

- **`helpv2/`** \u2014 `Commands`, `General`, `HelpV2` (+ barrel). Four-tab
  help overlay (`general` / `commands` / `custom-commands` / `[ant-only]`)
  with the upstream "Esc to cancel" gesture and `shortcutLabel()`-driven
  chord display.
- **`highlighted-code/`** \u2014 `Fallback` (+ barrel). Plain-text renderer
  with `convertLeadingTabsToSpaces` exported for the top-level
  `HighlightedCode.tsx`.
- **`hooks/`** \u2014 `HooksConfigMenu` orchestrator + the four mode
  components (`SelectEventMode`, `SelectMatcherMode`, `SelectHookMode`,
  `ViewHookMode`), the standalone `PromptDialog` used by prompt-type
  hooks, and a shared `types.ts` (+ barrel).
- **`LogoV2/`** \u2014 all 17 upstream files: `Clawd`, `AnimatedClawd`,
  `AnimatedAsterisk`, `LogoV2`, `CondensedLogo`, `WelcomeV2`,
  `ChannelsNotice`, `Feed`/`FeedColumn`/`feedConfigs`, `EmergencyTip`,
  `VoiceModeNotice`, `Opus1mMergeNotice`, `OverageCreditUpsell`,
  `GuestPassesUpsell`, plus `GateOverridesWarning` /
  `ExperimentEnrollmentNotice` as null-returning stubs kept so the shell
  can import them unconditionally.

32 files, +3019 lines.

## Port strategy

Same as #113: Ink primitives (`Dialog`/`Select`/`Pane`/`Tabs`/`Link`/
`KeyboardShortcutHint`) \u2192 OpenTUI `<box>`/`<text>` + local
`useKeyboard`; state-heavy upstream reads (global config writes,
GrowthBook flags, bootstrap state, `AppState` slices, `OAuthService`,
impression counters, settings walks) \u2192 props-driven so each component
is a pure renderer from a snapshot the Rust backend assembles.

Notable parity decisions:

- **`HelpV2`** accepts a flat `HelpCommandEntry[]` list instead of
  reading the legacy `commands` registry; the Rust backend owns the
  source of truth for command listings.
- **`HooksConfigMenu`** takes a flat `HooksSnapshot` (`hooks`,
  `eventMetadata`, `toolNames`, policy flags) instead of reading from
  `AppState` + multiple settings sources. The 4-mode state machine
  (select-event \u2192 select-matcher \u2192 select-hook \u2192 view-hook) with Esc
  routing back up matches upstream.
- **`LogoV2`** is driven by a single `LogoV2ViewData` view-model that
  bundles every upstream data source (version, cwd, model, billing,
  organization, agent, layout mode, feeds, channels status, voice /
  opus-1m visibility, emergency tip, debug info, tmux session,
  announcement, sandbox, upsells). The Rust backend composes the
  snapshot once; UI stays presentational.
- **`highlighted-code/Fallback`** is a plain-text renderer for now.
  The upstream `hl.highlight()` cache keyed by `hashPair(language, code)`
  is left out until an OpenTUI-native syntax highlighter is wired in
  (tracked separately). `HighlightedCode.tsx` was already a top-level
  file in this tree, so the new sub-folder only houses the fallback
  to match the upstream path.
- **`AnimatedAsterisk`** replaces Ink's `useAnimationFrame` with a
  50 ms `setInterval` hue sweep; `reducedMotion` is now a prop so the
  component stays decoupled from the settings stack.
- **`AnimatedClawd`** retains the upstream jump-wave / look-around
  frame sequences and exposes them via `CLAWD_ANIMATIONS` for host-
  driven triggers (OpenTUI doesn't surface box-level `onClick` in this
  project today, so the mouse-click entry is out of scope).
- **`Clawd`** keeps the Apple-Terminal alternate render as a prop
  (`appleTerminal`) so the embedder detects the host and passes it in;
  upstream used the `env.terminal` global.
- **`Feed`/`FeedColumn`** reuse the existing local `string-width`
  helper for width-aware math; Ink's `<Divider>` is replaced by a
  top-bordered box at the accent color.

## Why

Same motivation as #113 \u2014 `CLAUDE.md` marks this branch as the
full-build phase, and landing these folders at their upstream-matching
paths lets future PRs diff the two trees directly and unblocks
dependent ports (upstream files like `Onboarding.tsx`,
`PromptInput/PromptInputHelpMenu.tsx`, `mcp/*`, `permissions/*` that
import from here).

## Notes for reviewers

- No wiring changes \u2014 components are added but not yet mounted from
  `App.tsx`. Follow-up PRs will route backend events into them.
- Pre-existing TypeScript errors in this worktree
  (`Cannot find module 'react'`, `@opentui/react/jsx-runtime`,
  implicit-any on `useKeyboard` callbacks) affect the new files the
  same way they affect existing ones
  (`LspRecommendationDialog.tsx`, `SubsystemStatus.tsx`). This is a
  type-resolution issue in the worktree's node_modules layout, not a
  runtime problem.
- `GateOverridesWarning` and `ExperimentEnrollmentNotice` are
  intentional stubs \u2014 the Rust backend doesn't ship the feature-gate
  override / experiment enrollment plumbing.
- `ChannelsNotice` takes a pre-computed `ChannelsNoticeStatus` so
  KAIROS-specific reads (MCP scope walks, allowlist evaluation,
  GrowthBook flag) stay Rust-side, where KAIROS already lives.

## Test plan

- [ ] `bun run build` in `ui/` succeeds
- [ ] `grep` confirms nothing imports the new folders yet (additive change)
- [ ] Existing dialog surfaces continue rendering after the additive change
  (`LspRecommendationDialog`, permission prompts)

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)