### PR TITLE
feat(ui): port 5 upstream-pattern folders (LSP / memory / sandbox / Settings)

### DIFF
--- a/ui/src/components/LspRecommendation/LspRecommendationMenu.tsx
+++ b/ui/src/components/LspRecommendation/LspRecommendationMenu.tsx
@@ -1,0 +1,168 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../../theme.js'
+
+/**
+ * Lite-native port of
+ * `ui/examples/upstream-patterns/src/components/LspRecommendation/LspRecommendationMenu.tsx`.
+ *
+ * Upstream uses this menu inside a `PermissionDialog` and drives
+ * selection through the Ink `<Select>` primitive. cc-rust already
+ * ships a wired dialog (`components/LspRecommendationDialog.tsx`) that
+ * binds the same four decisions to the `LspEvent::recommendation_request`
+ * IPC flow. This component is the presentational layer of that dialog
+ * — the parent passes the plugin metadata + a callback, the menu draws
+ * the four options and handles keyboard + the 30-second auto-dismiss
+ * timer upstream also uses.
+ *
+ * The 30-second auto-dismiss mirrors upstream exactly — treating no
+ * response as an implicit `'no'` keeps us aligned with the server's
+ * recommendation-response contract.
+ */
+
+type Decision = 'yes' | 'no' | 'never' | 'disable'
+
+type Props = {
+  pluginName: string
+  pluginDescription?: string
+  fileExtension: string
+  languageId?: string
+  onResponse: (response: Decision) => void
+  /** Override the dismiss timer — defaults to 30 000 ms. Pass `0` to
+   *  disable. */
+  autoDismissMs?: number
+}
+
+type Option = {
+  value: Decision
+  label: string
+  hotkey: string
+}
+
+const AUTO_DISMISS_MS = 30_000
+
+function buildOptions(pluginName: string): Option[] {
+  return [
+    { value: 'yes', label: `Yes, install ${pluginName}`, hotkey: 'y' },
+    { value: 'no', label: 'No, not now', hotkey: 'n' },
+    { value: 'never', label: `Never for ${pluginName}`, hotkey: 'x' },
+    { value: 'disable', label: 'Disable all LSP recommendations', hotkey: 'd' },
+  ]
+}
+
+export function LspRecommendationMenu({
+  pluginName,
+  pluginDescription,
+  fileExtension,
+  languageId,
+  onResponse,
+  autoDismissMs = AUTO_DISMISS_MS,
+}: Props) {
+  const [selected, setSelected] = useState(0)
+  const options = useMemo(() => buildOptions(pluginName), [pluginName])
+  const safeIndex = Math.max(0, Math.min(selected, options.length - 1))
+
+  // `useRef` + write-on-render keeps the timeout stable across renders —
+  // matches upstream's "latest ref" pattern.
+  const onResponseRef = useRef(onResponse)
+  onResponseRef.current = onResponse
+
+  useEffect(() => {
+    if (!Number.isFinite(autoDismissMs) || autoDismissMs <= 0) return undefined
+    const timer = setTimeout(() => onResponseRef.current('no'), autoDismissMs)
+    return () => clearTimeout(timer)
+  }, [autoDismissMs])
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const input = (event.sequence ?? (name?.length === 1 ? name : '') ?? '').toLowerCase()
+
+    if (input) {
+      const match = options.findIndex(opt => opt.hotkey === input)
+      if (match >= 0) {
+        onResponseRef.current(options[match]!.value)
+        return
+      }
+    }
+
+    if (name === 'escape') {
+      onResponseRef.current('no')
+      return
+    }
+    if (name === 'up' || input === 'k') {
+      setSelected(Math.max(0, safeIndex - 1))
+      return
+    }
+    if (name === 'down' || input === 'j') {
+      setSelected(Math.min(options.length - 1, safeIndex + 1))
+      return
+    }
+    if (name === 'tab') {
+      setSelected((safeIndex + 1) % options.length)
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      onResponseRef.current(options[safeIndex]!.value)
+    }
+  })
+
+  const triggerLabel = languageId
+    ? `${fileExtension} (${languageId})`
+    : fileExtension
+
+  return (
+    <box
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.warning}
+      title="LSP Plugin Recommendation"
+      titleAlignment="center"
+      paddingX={2}
+      paddingY={1}
+    >
+      <text fg={c.dim}>
+        LSP provides code intelligence like go-to-definition and error checking.
+      </text>
+      <box marginTop={1} flexDirection="column">
+        <text>
+          <span fg={c.dim}>Plugin: </span>
+          <strong>{pluginName}</strong>
+        </text>
+        {pluginDescription && (
+          <text fg={c.dim}>{pluginDescription}</text>
+        )}
+        <text>
+          <span fg={c.dim}>Triggered by: </span>
+          <span>{triggerLabel} files</span>
+        </text>
+      </box>
+      <box marginTop={1}>
+        <text>Would you like to install this LSP plugin?</text>
+      </box>
+      <box marginTop={1} flexDirection="column">
+        {options.map((opt, i) => {
+          const isSelected = i === safeIndex
+          return (
+            <box key={opt.value} flexDirection="row">
+              <text fg={isSelected ? c.bg : undefined} bg={isSelected ? c.textBright : undefined}>
+                <strong>{` ${opt.label} `}</strong>
+              </text>
+              <text fg={c.dim}> ({opt.hotkey})</text>
+            </box>
+          )
+        })}
+      </box>
+      <box marginTop={1}>
+        <text>
+          <em>
+            <span fg={c.dim}>
+              Up/Down · Enter to confirm · y/n/x/d hotkeys · Esc = No ·
+              auto-dismiss in {Math.round(autoDismissMs / 1000)}s
+            </span>
+          </em>
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/ManagedSettingsSecurityDialog/ManagedSettingsSecurityDialog.tsx
+++ b/ui/src/components/ManagedSettingsSecurityDialog/ManagedSettingsSecurityDialog.tsx
@@ -1,0 +1,154 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../../theme.js'
+import {
+  extractDangerousSettings,
+  formatDangerousSettingsList,
+  type SettingsLike,
+} from './utils.js'
+
+/**
+ * Lite-native port of
+ * `ui/examples/upstream-patterns/src/components/ManagedSettingsSecurityDialog/ManagedSettingsSecurityDialog.tsx`.
+ *
+ * Upstream wraps this in a `PermissionDialog` and uses Ink's `<Select>`.
+ * cc-rust renders it as an absolutely-positioned warning dialog — same
+ * visual weight as the LSP recommendation dialog and the permission
+ * dialog — and handles keyboard selection inline. The caller provides
+ * the settings payload; `onAccept` proceeds with loading managed
+ * settings, `onReject` exits Claude Code.
+ *
+ * The two list-visual utilities are re-exported from `./utils.js` so
+ * host code can check `hasDangerousSettingsChanged` without pulling in
+ * this React component.
+ */
+
+type Decision = 'accept' | 'reject'
+
+type Option = {
+  value: Decision
+  label: string
+  hotkey: string
+}
+
+const OPTIONS: Option[] = [
+  { value: 'accept', label: 'Yes, I trust these settings', hotkey: 'y' },
+  { value: 'reject', label: 'No, exit Claude Code', hotkey: 'n' },
+]
+
+type Props = {
+  settings: SettingsLike | null | undefined
+  onAccept: () => void
+  onReject: () => void
+}
+
+export function ManagedSettingsSecurityDialog({
+  settings,
+  onAccept,
+  onReject,
+}: Props) {
+  const dangerous = extractDangerousSettings(settings)
+  const settingsList = formatDangerousSettingsList(dangerous)
+
+  const [selected, setSelected] = useState(0)
+  const safeIndex = Math.max(0, Math.min(selected, OPTIONS.length - 1))
+
+  const decide = (decision: Decision) => {
+    if (decision === 'accept') onAccept()
+    else onReject()
+  }
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const input = (event.sequence ?? (name?.length === 1 ? name : '') ?? '').toLowerCase()
+
+    if (input === 'y') {
+      decide('accept')
+      return
+    }
+    if (input === 'n' || name === 'escape') {
+      decide('reject')
+      return
+    }
+    if (name === 'up' || input === 'k') {
+      setSelected(Math.max(0, safeIndex - 1))
+      return
+    }
+    if (name === 'down' || input === 'j') {
+      setSelected(Math.min(OPTIONS.length - 1, safeIndex + 1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      decide(OPTIONS[safeIndex]!.value)
+    }
+  })
+
+  return (
+    <box
+      position="absolute"
+      bottom={3}
+      left={1}
+      right={1}
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.warning}
+      title="Managed settings require approval"
+      titleAlignment="center"
+      paddingX={2}
+      paddingY={1}
+    >
+      <box flexDirection="column" gap={1}>
+        <text selectable>
+          Your organization has configured managed settings that could allow
+          execution of arbitrary code or interception of your prompts and
+          responses.
+        </text>
+
+        <box flexDirection="column">
+          <text fg={c.dim}>Settings requiring approval:</text>
+          {settingsList.length === 0 ? (
+            <box paddingLeft={2}>
+              <text fg={c.dim}>
+                <em>(none flagged — dialog opened manually)</em>
+              </text>
+            </box>
+          ) : (
+            settingsList.map(item => (
+              <box key={item} paddingLeft={2} flexDirection="row">
+                <text fg={c.dim}>· </text>
+                <text selectable>{item}</text>
+              </box>
+            ))
+          )}
+        </box>
+
+        <text selectable>
+          Only accept if you trust your organization's IT administration
+          and expect these settings to be configured.
+        </text>
+
+        <box flexDirection="column">
+          {OPTIONS.map((opt, i) => {
+            const isSelected = i === safeIndex
+            return (
+              <box key={opt.value} flexDirection="row">
+                <text fg={isSelected ? c.bg : undefined} bg={isSelected ? c.textBright : undefined}>
+                  <strong>{` ${opt.label} `}</strong>
+                </text>
+                <text fg={c.dim}> ({opt.hotkey})</text>
+              </box>
+            )
+          })}
+        </box>
+
+        <text fg={c.dim}>
+          <em>Enter to confirm · Esc to exit</em>
+        </text>
+      </box>
+    </box>
+  )
+}
+
+export { extractDangerousSettings, formatDangerousSettingsList } from './utils.js'
+export type { DangerousSettings, SettingsLike } from './utils.js'

--- a/ui/src/components/ManagedSettingsSecurityDialog/utils.ts
+++ b/ui/src/components/ManagedSettingsSecurityDialog/utils.ts
@@ -1,0 +1,161 @@
+/**
+ * Lite-native port of
+ * `ui/examples/upstream-patterns/src/components/ManagedSettingsSecurityDialog/utils.ts`.
+ *
+ * Upstream reads the authoritative `DANGEROUS_SHELL_SETTINGS` and
+ * `SAFE_ENV_VARS` lists from `utils/managedEnvConstants.js`. cc-rust
+ * does not yet pull managed-settings state through to the frontend, so
+ * we mirror the same lists locally. Update them in lockstep whenever
+ * the upstream set changes — the values here drive what the dialog
+ * flags as "requires approval".
+ */
+
+/** Settings fields that can execute arbitrary code or intercept
+ *  transcripts — matches upstream `DANGEROUS_SHELL_SETTINGS`. */
+export const DANGEROUS_SHELL_SETTINGS = [
+  'apiKeyHelper',
+  'awsAuthRefresh',
+  'awsCredentialExport',
+  'shellIntegration',
+  'statusLine',
+] as const
+
+export type DangerousShellSetting = (typeof DANGEROUS_SHELL_SETTINGS)[number]
+
+/** Env vars considered safe to be set by managed settings. Any `env.*`
+ *  entry NOT in this set counts as dangerous. Matches upstream
+ *  `SAFE_ENV_VARS` (all keys upper-cased). */
+export const SAFE_ENV_VARS: ReadonlySet<string> = new Set([
+  'NO_COLOR',
+  'FORCE_COLOR',
+  'ANTHROPIC_LOG',
+  'CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC',
+  'CLAUDE_CODE_DISABLE_TELEMETRY',
+  'CLAUDE_CODE_ENABLE_TELEMETRY',
+  'CLAUDE_CODE_USE_BEDROCK',
+  'CLAUDE_CODE_USE_VERTEX',
+  'DISABLE_TELEMETRY',
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'NO_PROXY',
+  'AWS_REGION',
+])
+
+/**
+ * Shape the dialog consumes. Keep structurally identical to the
+ * upstream `DangerousSettings` type so consumers don't need to switch
+ * on the Lite variant.
+ */
+export interface DangerousSettings {
+  shellSettings: Partial<Record<DangerousShellSetting, string>>
+  envVars: Record<string, string>
+  hasHooks: boolean
+  hooks?: unknown
+}
+
+/**
+ * Minimal settings shape the extractor reads. We keep it open (indexed
+ * signature) so callers can pass the raw managed-settings JSON without
+ * needing to import a full `SettingsJson` definition.
+ */
+export type SettingsLike = {
+  env?: Record<string, unknown> | null
+  hooks?: unknown
+  [key: string]: unknown
+}
+
+export function extractDangerousSettings(
+  settings: SettingsLike | null | undefined,
+): DangerousSettings {
+  if (!settings) {
+    return { shellSettings: {}, envVars: {}, hasHooks: false }
+  }
+
+  const shellSettings: Partial<Record<DangerousShellSetting, string>> = {}
+  for (const key of DANGEROUS_SHELL_SETTINGS) {
+    const value = settings[key]
+    if (typeof value === 'string' && value.length > 0) {
+      shellSettings[key] = value
+    }
+  }
+
+  const envVars: Record<string, string> = {}
+  if (settings.env && typeof settings.env === 'object') {
+    for (const [key, value] of Object.entries(settings.env)) {
+      if (typeof value === 'string' && value.length > 0) {
+        if (!SAFE_ENV_VARS.has(key.toUpperCase())) {
+          envVars[key] = value
+        }
+      }
+    }
+  }
+
+  const hasHooks =
+    settings.hooks !== undefined &&
+    settings.hooks !== null &&
+    typeof settings.hooks === 'object' &&
+    Object.keys(settings.hooks as Record<string, unknown>).length > 0
+
+  return {
+    shellSettings,
+    envVars,
+    hasHooks,
+    hooks: hasHooks ? settings.hooks : undefined,
+  }
+}
+
+export function hasDangerousSettings(dangerous: DangerousSettings): boolean {
+  return (
+    Object.keys(dangerous.shellSettings).length > 0 ||
+    Object.keys(dangerous.envVars).length > 0 ||
+    dangerous.hasHooks
+  )
+}
+
+/**
+ * Compare old and new settings and return `true` when the dangerous
+ * slice has changed or gained entries. Drives whether the dialog
+ * should appear on reload.
+ */
+export function hasDangerousSettingsChanged(
+  oldSettings: SettingsLike | null | undefined,
+  newSettings: SettingsLike | null | undefined,
+): boolean {
+  const oldDangerous = extractDangerousSettings(oldSettings)
+  const newDangerous = extractDangerousSettings(newSettings)
+
+  if (!hasDangerousSettings(newDangerous)) return false
+  if (!hasDangerousSettings(oldDangerous)) return true
+
+  // Stable stringification — object keys sorted so we don't trip on
+  // insertion order.
+  const serialize = (d: DangerousSettings): string =>
+    JSON.stringify({
+      shellSettings: sortKeys(d.shellSettings as Record<string, unknown>),
+      envVars: sortKeys(d.envVars),
+      hooks: d.hooks,
+    })
+
+  return serialize(oldDangerous) !== serialize(newDangerous)
+}
+
+function sortKeys(obj: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const key of Object.keys(obj).sort()) {
+    out[key] = obj[key]
+  }
+  return out
+}
+
+/** Flatten dangerous settings into a human-readable list of field
+ *  names. Values are intentionally omitted — the dialog only needs to
+ *  reveal what fields are present. */
+export function formatDangerousSettingsList(
+  dangerous: DangerousSettings,
+): string[] {
+  const items: string[] = []
+  for (const key of Object.keys(dangerous.shellSettings)) items.push(key)
+  for (const key of Object.keys(dangerous.envVars)) items.push(key)
+  if (dangerous.hasHooks) items.push('hooks')
+  return items
+}

--- a/ui/src/components/Settings/Config.tsx
+++ b/ui/src/components/Settings/Config.tsx
@@ -1,0 +1,254 @@
+import React, { useCallback, useMemo, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { useAppDispatch, useAppState } from '../../store/app-store.js'
+import { c } from '../../theme.js'
+
+/**
+ * Lite-native port of
+ * `ui/examples/upstream-patterns/src/components/Settings/Config.tsx`.
+ *
+ * Upstream's `Config.tsx` is a 2 000+-line orchestrator that surfaces
+ * every tunable in `settings.json` alongside ~20 pickers
+ * (ThemePicker, ModelPicker, OutputStylePicker, LanguagePicker,
+ * ChannelDowngradeDialog, …). Almost every picker depends on
+ * upstream-only concepts that cc-rust does not model (fast mode,
+ * auto-mode, teammate mode, bridge/channel tooling, billed-as-extra-
+ * usage). Porting it verbatim would require dozens of new IPC
+ * commands.
+ *
+ * This Lite version keeps the *shape* of upstream:
+ *
+ * - A header row + searchable option list.
+ * - Options grouped into "Core" / "Editor" / "View" / "Managed".
+ * - Enter toggles the highlighted option where the store-backed
+ *   state supports it (vim toggle + view mode toggle today); other
+ *   rows render a read-only description that parents can upgrade
+ *   without touching the renderer.
+ *
+ * The component takes `extraOptions` so hosts can feed in sandbox,
+ * MCP toggles, agent-settings entry points, etc. — keeping this file
+ * small until the matching backend IPC lands.
+ */
+
+export interface ConfigOption {
+  /** Stable identifier — used for keyboard navigation + search. */
+  id: string
+  label: string
+  description: string
+  /** Rendered next to the label ("on" / "off" / a model id). */
+  value: string
+  /** When set, Enter calls this callback; otherwise the row is
+   *  read-only and enter is a no-op. */
+  onActivate?: () => void | Promise<void>
+  /** Marks the option as "managed" so it renders in gray and the
+   *  activate handler is ignored. */
+  managed?: boolean
+  /** Optional category label used for the section headings. */
+  section?: 'Core' | 'Editor' | 'View' | 'Managed' | string
+}
+
+type Props = {
+  /** Host-supplied option list appended after the built-in rows. */
+  extraOptions?: ConfigOption[]
+  /** Width override — used inside the settings modal to shrink the
+   *  list. */
+  contentHeight?: number
+  onClose: (result?: string) => void
+}
+
+export function Config({ extraOptions = [], contentHeight, onClose }: Props) {
+  const state = useAppState()
+  const dispatch = useAppDispatch()
+  const [query, setQuery] = useState('')
+  const [cursor, setCursor] = useState(0)
+
+  const builtins: ConfigOption[] = useMemo(() => {
+    return [
+      {
+        id: 'vim',
+        label: 'Vim mode',
+        description: 'Toggle vim-style keybindings for the composer',
+        value: state.vimEnabled ? 'on' : 'off',
+        section: 'Editor',
+        onActivate: () => dispatch({ type: 'TOGGLE_VIM' }),
+      },
+      {
+        id: 'view-mode',
+        label: 'View mode',
+        description:
+          'Switch between the live prompt pane and the scrollable transcript view',
+        value: state.viewMode,
+        section: 'View',
+        onActivate: () => dispatch({ type: 'TOGGLE_VIEW_MODE' }),
+      },
+      {
+        id: 'editor-mode',
+        label: 'Editor mode',
+        description: 'Composer editor mode — reported by the backend',
+        value: state.editorMode,
+        section: 'Editor',
+      },
+      {
+        id: 'model',
+        label: 'Model',
+        description:
+          'Active model for the main conversation loop — change via /model',
+        value: state.model || '—',
+        section: 'Core',
+      },
+      {
+        id: 'session-id',
+        label: 'Session ID',
+        description: 'Unique identifier for the current conversation',
+        value: state.sessionId || '—',
+        section: 'Core',
+        managed: true,
+      },
+      {
+        id: 'cwd',
+        label: 'Working directory',
+        description: 'Filesystem root used by file-scoped tools',
+        value: state.cwd || '—',
+        section: 'Core',
+        managed: true,
+      },
+      {
+        id: 'ide',
+        label: 'IDE integration',
+        description:
+          'Connection state for the active IDE extension — toggle via /ide',
+        value: state.ide.connected ? 'connected' : 'not connected',
+        section: 'View',
+      },
+    ]
+  }, [
+    dispatch,
+    state.cwd,
+    state.editorMode,
+    state.ide.connected,
+    state.model,
+    state.sessionId,
+    state.viewMode,
+    state.vimEnabled,
+  ])
+
+  const allOptions = useMemo(() => [...builtins, ...extraOptions], [builtins, extraOptions])
+
+  const filtered = useMemo(() => {
+    const trimmed = query.trim().toLowerCase()
+    if (!trimmed) return allOptions
+    return allOptions.filter(opt =>
+      `${opt.label} ${opt.description} ${opt.value}`
+        .toLowerCase()
+        .includes(trimmed),
+    )
+  }, [allOptions, query])
+
+  const safeCursor = filtered.length === 0 ? -1 : Math.max(0, Math.min(cursor, filtered.length - 1))
+  const active = safeCursor >= 0 ? filtered[safeCursor] : undefined
+
+  const activateActive = useCallback(() => {
+    if (!active) return
+    if (active.managed) return
+    void active.onActivate?.()
+  }, [active])
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const seq = event.sequence?.length === 1 ? event.sequence : undefined
+
+    if (name === 'escape') {
+      if (query) {
+        setQuery('')
+        return
+      }
+      onClose('Config dismissed')
+      return
+    }
+    if (name === 'up') {
+      setCursor(prev => Math.max(0, prev - 1))
+      return
+    }
+    if (name === 'down') {
+      setCursor(prev => Math.min(filtered.length - 1, prev + 1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      activateActive()
+      return
+    }
+    if (name === 'backspace' || name === 'delete') {
+      setQuery(prev => prev.slice(0, Math.max(0, prev.length - 1)))
+      setCursor(0)
+      return
+    }
+    if (seq && seq.length === 1 && seq.charCodeAt(0) >= 0x20) {
+      setQuery(prev => prev + seq)
+      setCursor(0)
+    }
+  })
+
+  const height = contentHeight && contentHeight > 6 ? contentHeight - 4 : 12
+  const visible = filtered.slice(0, Math.max(1, height))
+
+  return (
+    <box flexDirection="column" paddingY={1} gap={1} width="100%">
+      <box flexDirection="row" gap={1}>
+        <text fg={c.info}>\u25B8</text>
+        <text selectable>
+          {query || <span fg={c.dim}>Search config…</span>}
+        </text>
+      </box>
+
+      {filtered.length === 0 ? (
+        <text fg={c.dim}>
+          <em>No options match "{query}"</em>
+        </text>
+      ) : (
+        <box flexDirection="column">
+          {visible.map((opt, i) => {
+            const isFocused = i === safeCursor
+            return (
+              <box key={opt.id} flexDirection="row" width="100%">
+                <text fg={isFocused ? c.accent : c.dim}>
+                  {isFocused ? '\u203A' : ' '}
+                </text>
+                <box flexDirection="column" paddingLeft={1} width="100%">
+                  <box flexDirection="row" gap={1}>
+                    <text fg={isFocused ? c.textBright : c.text} selectable>
+                      <strong>{opt.label}</strong>
+                    </text>
+                    <text fg={opt.managed ? c.dim : c.info} selectable>
+                      {opt.value}
+                    </text>
+                    {opt.managed && <text fg={c.dim}>(managed)</text>}
+                  </box>
+                  <text fg={c.dim} selectable>
+                    {opt.description}
+                  </text>
+                </box>
+              </box>
+            )
+          })}
+          {filtered.length > visible.length && (
+            <text fg={c.dim}>
+              {'\u2026 +'}
+              {filtered.length - visible.length} more (keep scrolling)
+            </text>
+          )}
+        </box>
+      )}
+
+      {active && !active.managed && active.onActivate && (
+        <text fg={c.dim}>
+          <em>Press Enter to toggle "{active.label}"</em>
+        </text>
+      )}
+
+      <text fg={c.dim}>
+        <em>Type to filter · Up/Down to move · Enter to activate · Esc to close</em>
+      </text>
+    </box>
+  )
+}

--- a/ui/src/components/Settings/Settings.tsx
+++ b/ui/src/components/Settings/Settings.tsx
@@ -1,0 +1,156 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../../theme.js'
+import { Config } from './Config.js'
+import { Status, type Diagnostic, type Property } from './Status.js'
+import { Usage, type Utilization } from './Usage.js'
+
+/**
+ * Lite-native port of
+ * `ui/examples/upstream-patterns/src/components/Settings/Settings.tsx`.
+ *
+ * Upstream's shell renders a `Pane` + `Tabs` container whose children
+ * are the Status / Config / Usage tabs. cc-rust has no Pane/Tabs
+ * primitive; we roll a minimal tab strip that:
+ *
+ * - Starts on `defaultTab` (matching upstream's initial tab rule).
+ * - Cycles with Tab / left / right or numeric keys 1-3.
+ * - Forwards Esc to `onClose` unless a descendant handles it first
+ *   (e.g. `Config` clears the search query on Esc).
+ *
+ * The Status / Usage tabs are pure view components from this folder,
+ * so the shell stays tiny. `context` is kept as an opaque pass-through
+ * so callers that already have a `LocalJSXCommandContext` from
+ * upstream don't have to rewrap.
+ */
+
+type TabKey = 'status' | 'config' | 'usage'
+
+type Props = {
+  defaultTab?: 'Status' | 'Config' | 'Usage'
+  onClose: (result?: string) => void
+  /** Properties passed into the Status tab. */
+  statusExtraSections?: Property[][]
+  statusDiagnostics?: Diagnostic[]
+  statusDiagnosticsLoading?: boolean
+  /** Loader for the Usage tab. */
+  loadUtilization?: () => Promise<Utilization | null>
+  /** Subscriber tier — drives which Usage bars render. */
+  subscriptionType?: 'pro' | 'max' | 'team' | 'free' | null
+}
+
+const TAB_ORDER: TabKey[] = ['status', 'config', 'usage']
+
+function tabKeyFromName(name?: Props['defaultTab']): TabKey {
+  switch (name) {
+    case 'Config':
+      return 'config'
+    case 'Usage':
+      return 'usage'
+    default:
+      return 'status'
+  }
+}
+
+export function Settings({
+  defaultTab = 'Status',
+  onClose,
+  statusExtraSections,
+  statusDiagnostics,
+  statusDiagnosticsLoading,
+  loadUtilization,
+  subscriptionType,
+}: Props) {
+  const [active, setActive] = useState<TabKey>(tabKeyFromName(defaultTab))
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const input = (event.sequence ?? (name?.length === 1 ? name : '') ?? '').toLowerCase()
+
+    if (name === 'tab' || name === 'right' || input === ']') {
+      setActive(prev => {
+        const i = TAB_ORDER.indexOf(prev)
+        return TAB_ORDER[(i + 1) % TAB_ORDER.length]!
+      })
+      return
+    }
+    if (name === 'left' || input === '[') {
+      setActive(prev => {
+        const i = TAB_ORDER.indexOf(prev)
+        return TAB_ORDER[(i - 1 + TAB_ORDER.length) % TAB_ORDER.length]!
+      })
+      return
+    }
+    if (input === '1') setActive('status')
+    else if (input === '2') setActive('config')
+    else if (input === '3') setActive('usage')
+  })
+
+  return (
+    <box
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.accent}
+      title="Settings"
+      titleAlignment="left"
+      paddingX={2}
+      paddingY={1}
+      width="100%"
+    >
+      <box flexDirection="row" gap={2}>
+        {TAB_ORDER.map(key => (
+          <text
+            key={key}
+            fg={key === active ? c.bg : c.dim}
+            bg={key === active ? c.accent : undefined}
+          >
+            <strong>{` ${labelForTab(key)} `}</strong>
+          </text>
+        ))}
+      </box>
+      <box marginTop={1}>
+        {active === 'status' && (
+          <Status
+            extraSections={statusExtraSections}
+            diagnostics={statusDiagnostics}
+            diagnosticsLoading={statusDiagnosticsLoading}
+          />
+        )}
+        {active === 'config' && (
+          <Config onClose={onClose} />
+        )}
+        {active === 'usage' && (
+          <Usage
+            loadUtilization={loadUtilization}
+            subscriptionType={subscriptionType}
+          />
+        )}
+      </box>
+      <box marginTop={1}>
+        <text fg={c.dim}>
+          <em>
+            Tab / ←/→ to switch · 1-3 jump · Esc closes
+          </em>
+        </text>
+      </box>
+    </box>
+  )
+}
+
+function labelForTab(key: TabKey): string {
+  switch (key) {
+    case 'status':
+      return 'Status'
+    case 'config':
+      return 'Config'
+    case 'usage':
+      return 'Usage'
+  }
+}
+
+export { Config } from './Config.js'
+export { Status, buildDefaultDiagnostics } from './Status.js'
+export type { Diagnostic, Property } from './Status.js'
+export { Usage } from './Usage.js'
+export type { RateLimit, Utilization, ExtraUsage } from './Usage.js'

--- a/ui/src/components/Settings/Status.tsx
+++ b/ui/src/components/Settings/Status.tsx
@@ -1,0 +1,170 @@
+import React from 'react'
+import { useAppState } from '../../store/app-store.js'
+import { c } from '../../theme.js'
+
+/**
+ * Lite-native port of
+ * `ui/examples/upstream-patterns/src/components/Settings/Status.tsx`.
+ *
+ * Upstream pulls data from `getSessionId`, `getCwd`, subscriber
+ * helpers, and the `buildXxxProperties(...)` family. cc-rust
+ * consolidates the same information out of the app store (`cwd`,
+ * `model`, `sessionId`, `subsystems`) plus the properties list that
+ * the caller supplies via `extraSections`. Diagnostics are optional —
+ * pass any the backend surfaces (sandbox, auto-updater, memory) and
+ * the component renders them at the bottom.
+ */
+
+export type PropertyValue = string | number | React.ReactNode | string[]
+
+export interface Property {
+  label?: string
+  value: PropertyValue
+}
+
+export interface Diagnostic {
+  message: string
+  /** `error` renders with the error colour + ✗, `warning` with the
+   *  warning colour + ⚠, `info` with a dim `·`. */
+  severity?: 'error' | 'warning' | 'info'
+}
+
+type Props = {
+  /** Caller-provided additional property sections — upstream's
+   *  "IDE / MCP / Sandbox / Setting Sources" blocks come through here
+   *  so this component stays presentational. */
+  extraSections?: Property[][]
+  diagnostics?: Diagnostic[]
+  /** Loading indicator for the Diagnostics list. */
+  diagnosticsLoading?: boolean
+}
+
+export function Status({ extraSections = [], diagnostics, diagnosticsLoading }: Props) {
+  const state = useAppState()
+
+  const primary: Property[] = [
+    { label: 'Session ID', value: state.sessionId || '—' },
+    { label: 'cwd', value: state.cwd || '—' },
+    { label: 'Editor mode', value: state.editorMode },
+    { label: 'Vim', value: state.vimEnabled ? `on (${state.vimMode})` : 'off' },
+    { label: 'View mode', value: state.viewMode },
+  ]
+  const secondary: Property[] = [
+    { label: 'Model', value: state.model || '—' },
+    { label: 'LSP servers', value: String(state.subsystems.lsp.length) },
+    { label: 'MCP servers', value: String(state.subsystems.mcp.length) },
+    { label: 'Plugins', value: String(state.subsystems.plugins.length) },
+    { label: 'Skills', value: String(state.subsystems.skills.length) },
+    { label: 'IDE', value: state.ide.connected ? 'connected' : 'not connected' },
+  ]
+
+  const sections: Property[][] = [primary, secondary, ...extraSections]
+
+  return (
+    <box flexDirection="column" paddingY={1} gap={1}>
+      {sections.map(
+        (properties, i) =>
+          properties.length > 0 && (
+            <box key={i} flexDirection="column">
+              {properties.map(({ label, value }, j) => (
+                <box key={j} flexDirection="row" gap={1}>
+                  {label && (
+                    <text>
+                      <strong>{label}:</strong>
+                    </text>
+                  )}
+                  <PropertyView value={value} />
+                </box>
+              ))}
+            </box>
+          ),
+      )}
+
+      {(diagnosticsLoading || (diagnostics && diagnostics.length > 0)) && (
+        <box flexDirection="column">
+          <text>
+            <strong>System Diagnostics</strong>
+          </text>
+          {diagnosticsLoading && (
+            <text fg={c.dim}>
+              <em>Running diagnostics…</em>
+            </text>
+          )}
+          {!diagnosticsLoading && diagnostics && diagnostics.length === 0 && (
+            <text fg={c.dim}>
+              <em>All checks passed</em>
+            </text>
+          )}
+          {!diagnosticsLoading &&
+            diagnostics &&
+            diagnostics.map((diag, i) => (
+              <box key={i} flexDirection="row" gap={1} paddingX={1}>
+                <text fg={colorForSeverity(diag.severity)}>
+                  {glyphForSeverity(diag.severity)}
+                </text>
+                <text selectable>{diag.message}</text>
+              </box>
+            ))}
+        </box>
+      )}
+
+      <text fg={c.dim}>
+        <em>Esc to cancel</em>
+      </text>
+    </box>
+  )
+}
+
+function PropertyView({ value }: { value: PropertyValue }) {
+  if (Array.isArray(value)) {
+    return (
+      <box flexDirection="row" gap={1}>
+        {value.map((item, i) => (
+          <text key={i} selectable>
+            {item}
+            {i < value.length - 1 ? ',' : ''}
+          </text>
+        ))}
+      </box>
+    )
+  }
+  if (typeof value === 'string' || typeof value === 'number') {
+    return <text selectable>{String(value)}</text>
+  }
+  return <>{value}</>
+}
+
+function colorForSeverity(sev?: Diagnostic['severity']): string {
+  switch (sev) {
+    case 'error':
+      return c.error
+    case 'warning':
+      return c.warning
+    default:
+      return c.dim
+  }
+}
+
+function glyphForSeverity(sev?: Diagnostic['severity']): string {
+  switch (sev) {
+    case 'error':
+      return '\u2717' // ✗
+    case 'warning':
+      return '\u26A0' // ⚠
+    default:
+      return '\u00B7' // ·
+  }
+}
+
+/**
+ * Convenience hook — builds the default diagnostics list from whatever
+ * lives in the store today. Callers can extend with their own backend
+ * diagnostics by concatenating additional entries before passing into
+ * `<Status diagnostics={...}/>`.
+ */
+export function buildDefaultDiagnostics(): Diagnostic[] {
+  // Intentionally empty — cc-rust does not surface installation-health
+  // or memory diagnostics over IPC yet. Host code that wires up the
+  // /doctor backend should supply its own list.
+  return []
+}

--- a/ui/src/components/Settings/Usage.tsx
+++ b/ui/src/components/Settings/Usage.tsx
@@ -1,0 +1,249 @@
+import React, { useEffect, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../../theme.js'
+
+/**
+ * Lite-native port of
+ * `ui/examples/upstream-patterns/src/components/Settings/Usage.tsx`.
+ *
+ * Upstream calls `fetchUtilization()` against the Anthropic API and
+ * paints three rate-limit bars (5-hour, 7-day, 7-day Sonnet) plus an
+ * "Extra usage" section for Pro/Max. cc-rust does not forward
+ * utilization through IPC yet, so this component exposes the same
+ * surface as a pluggable `loadUtilization` prop:
+ *
+ * - Default `loadUtilization` returns `null`, which renders the
+ *   "Usage is only available for subscription plans." placeholder —
+ *   matching upstream's behaviour when the API returns no limits.
+ * - Hosts can swap in a real loader (e.g. via a new IPC command) to
+ *   get the three bars without touching the renderer.
+ *
+ * The progress bar is rendered with a simple `[====    ]` ASCII
+ * widget — OpenTUI doesn't ship Ink's `<ProgressBar>`.
+ */
+
+export interface RateLimit {
+  /** 0-100 — progress bar fill ratio. `null` means the API didn't
+   *  return this limit (e.g. free tier has no Sonnet bar). */
+  utilization: number | null
+  /** ISO-8601 reset timestamp. */
+  resets_at?: string | null
+}
+
+export interface ExtraUsage {
+  is_enabled: boolean
+  monthly_limit: number | null
+  used_credits?: number
+  utilization?: number
+}
+
+export interface Utilization {
+  five_hour: RateLimit | null
+  seven_day: RateLimit | null
+  seven_day_sonnet: RateLimit | null
+  extra_usage?: ExtraUsage | null
+}
+
+type Props = {
+  /** Override the loader. Defaults to a stub that returns `null`. */
+  loadUtilization?: () => Promise<Utilization | null>
+  /** Display-name override — matches upstream's
+   *  `getSubscriptionType()` gating for the Sonnet / Extra rows. */
+  subscriptionType?: 'pro' | 'max' | 'team' | 'free' | null
+}
+
+const DEFAULT_LOAD = async (): Promise<Utilization | null> => null
+
+export function Usage({
+  loadUtilization = DEFAULT_LOAD,
+  subscriptionType = null,
+}: Props = {}) {
+  const [utilization, setUtilization] = useState<Utilization | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+
+  const load = async () => {
+    setIsLoading(true)
+    setError(null)
+    try {
+      const data = await loadUtilization()
+      setUtilization(data)
+    } catch (e) {
+      setError(
+        e instanceof Error ? e.message : 'Failed to load usage data',
+      )
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void load()
+    // The loader is intentionally not listed in the dep array; retry
+    // is driven by the 'r' keyboard handler below, same as upstream.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    if (!error || isLoading) return
+    const name = event.name
+    const input = (event.sequence ?? (name?.length === 1 ? name : '') ?? '').toLowerCase()
+    if (input === 'r') void load()
+  })
+
+  if (error) {
+    return (
+      <box flexDirection="column" gap={1} paddingY={1}>
+        <text fg={c.error} selectable>Error: {error}</text>
+        <text fg={c.dim}>
+          <em>Press `r` to retry · Esc to cancel</em>
+        </text>
+      </box>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <box flexDirection="column" gap={1} paddingY={1}>
+        <text fg={c.dim}>Loading usage data…</text>
+      </box>
+    )
+  }
+
+  if (!utilization) {
+    return (
+      <box flexDirection="column" gap={1} paddingY={1}>
+        <text fg={c.dim}>
+          /usage is only available for subscription plans.
+        </text>
+      </box>
+    )
+  }
+
+  const showSonnetBar =
+    subscriptionType === 'max' ||
+    subscriptionType === 'team' ||
+    subscriptionType === null
+  const limits: Array<{ title: string; limit: RateLimit | null }> = [
+    { title: 'Current session', limit: utilization.five_hour },
+    { title: 'Current week (all models)', limit: utilization.seven_day },
+  ]
+  if (showSonnetBar) {
+    limits.push({
+      title: 'Current week (Sonnet only)',
+      limit: utilization.seven_day_sonnet,
+    })
+  }
+
+  const hasAnyLimit = limits.some(({ limit }) => limit && limit.utilization !== null)
+
+  return (
+    <box flexDirection="column" gap={1} paddingY={1} width="100%">
+      {!hasAnyLimit && (
+        <text fg={c.dim}>/usage is only available for subscription plans.</text>
+      )}
+      {limits.map(({ title, limit }) =>
+        limit && limit.utilization !== null ? (
+          <LimitBar key={title} title={title} limit={limit} />
+        ) : null,
+      )}
+      {utilization.extra_usage &&
+        (subscriptionType === 'pro' || subscriptionType === 'max') && (
+          <ExtraUsageSection extraUsage={utilization.extra_usage} />
+        )}
+      <text fg={c.dim}>
+        <em>Esc to cancel</em>
+      </text>
+    </box>
+  )
+}
+
+function LimitBar({
+  title,
+  limit,
+  extraSubtext,
+}: {
+  title: string
+  limit: RateLimit
+  extraSubtext?: string
+}) {
+  const util = limit.utilization ?? 0
+  const barWidth = 40
+  const filled = Math.max(0, Math.min(barWidth, Math.round((util / 100) * barWidth)))
+  const bar = '\u2588'.repeat(filled) + '\u2591'.repeat(barWidth - filled)
+  const usedText = `${Math.floor(util)}% used`
+  const subtext = buildSubtext(limit.resets_at ?? null, extraSubtext)
+
+  return (
+    <box flexDirection="column">
+      <text>
+        <strong>{title}</strong>
+      </text>
+      <box flexDirection="row" gap={1}>
+        <text fg={util >= 90 ? c.warning : c.accent}>{bar}</text>
+        <text>{usedText}</text>
+      </box>
+      {subtext && <text fg={c.dim}>{subtext}</text>}
+    </box>
+  )
+}
+
+function ExtraUsageSection({ extraUsage }: { extraUsage: ExtraUsage }) {
+  if (!extraUsage.is_enabled) {
+    return (
+      <box flexDirection="column">
+        <text>
+          <strong>Extra usage</strong>
+        </text>
+        <text fg={c.dim}>Extra usage not enabled · /extra-usage to enable</text>
+      </box>
+    )
+  }
+  if (extraUsage.monthly_limit === null) {
+    return (
+      <box flexDirection="column">
+        <text>
+          <strong>Extra usage</strong>
+        </text>
+        <text fg={c.dim}>Unlimited</text>
+      </box>
+    )
+  }
+  if (
+    typeof extraUsage.used_credits !== 'number' ||
+    typeof extraUsage.utilization !== 'number'
+  ) {
+    return null
+  }
+  const used = (extraUsage.used_credits / 100).toFixed(2)
+  const cap = (extraUsage.monthly_limit / 100).toFixed(2)
+  const oneMonthReset = new Date()
+  oneMonthReset.setMonth(oneMonthReset.getMonth() + 1, 1)
+  return (
+    <LimitBar
+      title="Extra usage"
+      limit={{
+        utilization: extraUsage.utilization,
+        resets_at: oneMonthReset.toISOString(),
+      }}
+      extraSubtext={`$${used} / $${cap} spent`}
+    />
+  )
+}
+
+function buildSubtext(resetsAt: string | null, extraSubtext?: string): string | null {
+  const parts: string[] = []
+  if (extraSubtext) parts.push(extraSubtext)
+  if (resetsAt) {
+    try {
+      const reset = new Date(resetsAt)
+      if (!Number.isNaN(reset.getTime())) {
+        parts.push(`Resets ${reset.toLocaleString()}`)
+      }
+    } catch {
+      // Ignore malformed dates from the backend.
+    }
+  }
+  return parts.length > 0 ? parts.join(' · ') : null
+}

--- a/ui/src/components/memory/MemoryFileSelector.tsx
+++ b/ui/src/components/memory/MemoryFileSelector.tsx
@@ -1,0 +1,238 @@
+import React, { useMemo, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../../theme.js'
+
+/**
+ * Lite-native port of
+ * `ui/examples/upstream-patterns/src/components/memory/MemoryFileSelector.tsx`.
+ *
+ * Upstream talks directly to `getMemoryFiles()`, `isAutoMemoryEnabled()`,
+ * `getAutoMemPath()`, and the TEAMMEM + AutoDream helpers — all of which
+ * read disk / remote-config state from the Ink runtime. cc-rust has no
+ * matching frontend helpers; the equivalent data lives behind the
+ * `/memory` backend command. We keep the upstream component shape by
+ * taking the list of memory entries as a prop + three callbacks so the
+ * host can plug in whichever source it has:
+ *
+ * 1. Parents populate `entries` from either the backend's `/memory`
+ *    snapshot or a locally-walked CLAUDE.md list.
+ * 2. `onSelect(path)` fires when the user accepts an entry — the
+ *    parent is responsible for opening the editor / dispatching the
+ *    backend command.
+ * 3. `onOpenFolder(path)` fires for the "Open auto-memory folder"
+ *    options and `onToggleAutoMemory` / `onToggleAutoDream` let the
+ *    host flip the user-settings flags via whatever channel it uses.
+ *
+ * The selector mirrors upstream's visual layout — toggle rows above,
+ * memory list below, "L " indent for nested `@`-imports — without
+ * trying to reimplement upstream's disk walking inside the frontend.
+ */
+
+export interface MemoryEntry {
+  /** Absolute path for file entries. For folder actions use `folder:<path>`. */
+  value: string
+  /** Human-readable label. */
+  label: string
+  /** Secondary line — "Saved in ~/.claude/CLAUDE.md" etc. */
+  description?: string
+  /** `true` when the backend reports the file does not yet exist —
+   *  appended as " (new)" next to the label. */
+  isNew?: boolean
+  /** Indent depth for nested `@`-imports. 0 = top level. */
+  depth?: number
+  /** Kind discriminant used for styling. Folder entries render the
+   *  "Open …" label without the memory gutter. */
+  kind: 'memory' | 'folder'
+}
+
+type Props = {
+  entries: MemoryEntry[]
+  onSelect: (entry: MemoryEntry) => void
+  onCancel: () => void
+  /** Show the "Auto-memory: on/off" row. */
+  autoMemoryOn?: boolean
+  /** Toggle callback — parent persists the user setting. */
+  onToggleAutoMemory?: () => void
+  /** Show the "Auto-dream: on/off" row (defaults to off). */
+  autoDreamOn?: boolean
+  onToggleAutoDream?: () => void
+  /** When auto-dream is configured, an optional status line — "last
+   *  ran 3m ago" / "running" / "never". */
+  dreamStatus?: string
+  /** Pre-select an entry by `value`. */
+  defaultValue?: string
+}
+
+type Focus = 'toggle-auto-memory' | 'toggle-auto-dream' | 'list'
+
+export function MemoryFileSelector({
+  entries,
+  onSelect,
+  onCancel,
+  autoMemoryOn = false,
+  onToggleAutoMemory,
+  autoDreamOn = false,
+  onToggleAutoDream,
+  dreamStatus,
+  defaultValue,
+}: Props) {
+  const showDreamRow = autoDreamOn || Boolean(dreamStatus)
+  const togglesAvailable = useMemo<Focus[]>(() => {
+    const toggles: Focus[] = []
+    if (onToggleAutoMemory) toggles.push('toggle-auto-memory')
+    if (showDreamRow) toggles.push('toggle-auto-dream')
+    return toggles
+  }, [onToggleAutoMemory, showDreamRow])
+
+  const initialListIndex = useMemo(() => {
+    if (!defaultValue) return 0
+    const idx = entries.findIndex(e => e.value === defaultValue)
+    return idx >= 0 ? idx : 0
+  }, [entries, defaultValue])
+
+  const [focus, setFocus] = useState<Focus>('list')
+  const [listIndex, setListIndex] = useState(initialListIndex)
+  const safeListIndex = entries.length === 0 ? -1 : Math.max(0, Math.min(listIndex, entries.length - 1))
+
+  const activateFocusUp = () => {
+    if (focus === 'list') {
+      if (togglesAvailable.length > 0) {
+        setFocus(togglesAvailable[togglesAvailable.length - 1]!)
+      }
+      return
+    }
+    const pos = togglesAvailable.indexOf(focus)
+    if (pos > 0) setFocus(togglesAvailable[pos - 1]!)
+  }
+
+  const activateFocusDown = () => {
+    if (focus === 'list') {
+      setListIndex(prev => Math.min(entries.length - 1, prev + 1))
+      return
+    }
+    const pos = togglesAvailable.indexOf(focus)
+    if (pos >= 0 && pos < togglesAvailable.length - 1) {
+      setFocus(togglesAvailable[pos + 1]!)
+    } else {
+      setFocus('list')
+    }
+  }
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const input = (event.sequence ?? (name?.length === 1 ? name : '') ?? '').toLowerCase()
+
+    if (name === 'escape') {
+      onCancel()
+      return
+    }
+    if (name === 'up' || input === 'k') {
+      if (focus === 'list') {
+        if (safeListIndex > 0) {
+          setListIndex(prev => Math.max(0, prev - 1))
+          return
+        }
+        activateFocusUp()
+        return
+      }
+      activateFocusUp()
+      return
+    }
+    if (name === 'down' || input === 'j') {
+      activateFocusDown()
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      if (focus === 'toggle-auto-memory') {
+        onToggleAutoMemory?.()
+        return
+      }
+      if (focus === 'toggle-auto-dream') {
+        onToggleAutoDream?.()
+        return
+      }
+      const entry = entries[safeListIndex]
+      if (entry) onSelect(entry)
+    }
+  })
+
+  return (
+    <box flexDirection="column" width="100%">
+      <box flexDirection="column" marginBottom={1}>
+        {onToggleAutoMemory && (
+          <ToggleRow
+            focused={focus === 'toggle-auto-memory'}
+            label={`Auto-memory: ${autoMemoryOn ? 'on' : 'off'}`}
+          />
+        )}
+        {showDreamRow && (
+          <ToggleRow
+            focused={focus === 'toggle-auto-dream'}
+            label={`Auto-dream: ${autoDreamOn ? 'on' : 'off'}${dreamStatus ? ` · ${dreamStatus}` : ''}`}
+          />
+        )}
+      </box>
+
+      {entries.length === 0 ? (
+        <text fg={c.dim}>
+          <em>(no memory files discovered)</em>
+        </text>
+      ) : (
+        <box flexDirection="column">
+          {entries.map((entry, i) => {
+            const isFocused = focus === 'list' && i === safeListIndex
+            const indent = entry.depth && entry.depth > 0 ? '  '.repeat(entry.depth - 1) : ''
+            const prefix = entry.kind === 'memory' && entry.depth && entry.depth > 0 ? `${indent}L ` : ''
+            const newSuffix = entry.isNew ? ' (new)' : ''
+            return (
+              <box key={entry.value} flexDirection="row" width="100%">
+                <text fg={isFocused ? c.accent : c.dim}>
+                  {isFocused ? '\u203A' : ' '}
+                </text>
+                <box flexDirection="column" paddingLeft={1}>
+                  <text
+                    fg={isFocused ? c.textBright : c.text}
+                    selectable
+                  >
+                    {prefix}
+                    {entry.label}
+                    {newSuffix}
+                  </text>
+                  {entry.description && (
+                    <text fg={c.dim} selectable>
+                      {entry.description}
+                    </text>
+                  )}
+                </box>
+              </box>
+            )
+          })}
+        </box>
+      )}
+
+      <box marginTop={1}>
+        <text>
+          <em>
+            <span fg={c.dim}>
+              Up/Down to move · Enter to select · Esc to cancel
+            </span>
+          </em>
+        </text>
+      </box>
+    </box>
+  )
+}
+
+function ToggleRow({ focused, label }: { focused: boolean; label: string }) {
+  return (
+    <box flexDirection="row">
+      <text fg={focused ? c.accent : c.dim}>
+        {focused ? '\u203A' : ' '}
+      </text>
+      <text fg={focused ? c.textBright : c.text} paddingLeft={1}>
+        {label}
+      </text>
+    </box>
+  )
+}

--- a/ui/src/components/memory/MemoryUpdateNotification.tsx
+++ b/ui/src/components/memory/MemoryUpdateNotification.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { homedir } from 'node:os'
+import { relative } from 'node:path'
+import { useAppState } from '../../store/app-store.js'
+import { c } from '../../theme.js'
+
+/**
+ * Lite-native port of
+ * `ui/examples/upstream-patterns/src/components/memory/MemoryUpdateNotification.tsx`.
+ *
+ * Upstream reads `getCwd()` from its bootstrap state; cc-rust exposes
+ * the working directory through `state.cwd` on the app store, so the
+ * component subscribes there directly. `getRelativeMemoryPath` is
+ * re-exported so callers that already use it from the sample tree can
+ * swap the import without touching usage.
+ */
+
+export function getRelativeMemoryPath(path: string, cwd: string): string {
+  const home = homedir()
+  const relativeToHome = path.startsWith(home) ? '~' + path.slice(home.length) : null
+  const relativeToCwd = path.startsWith(cwd) ? './' + relative(cwd, path) : null
+
+  if (relativeToHome && relativeToCwd) {
+    return relativeToHome.length <= relativeToCwd.length
+      ? relativeToHome
+      : relativeToCwd
+  }
+  return relativeToHome ?? relativeToCwd ?? path
+}
+
+type Props = {
+  memoryPath: string
+  /** Override the store's cwd — mostly useful in tests. */
+  cwdOverride?: string
+}
+
+export function MemoryUpdateNotification({ memoryPath, cwdOverride }: Props) {
+  const cwd = useAppState().cwd
+  const displayPath = getRelativeMemoryPath(memoryPath, cwdOverride ?? cwd)
+
+  return (
+    <box flexDirection="column">
+      <text fg={c.text} selectable>
+        Memory updated in {displayPath} · /memory to edit
+      </text>
+    </box>
+  )
+}

--- a/ui/src/components/sandbox/SandboxConfigTab.tsx
+++ b/ui/src/components/sandbox/SandboxConfigTab.tsx
@@ -1,0 +1,145 @@
+import React from 'react'
+import { c } from '../../theme.js'
+import {
+  isSandboxingEnabled,
+  shouldAllowManagedSandboxDomainsOnly,
+  useSandboxAdapter,
+} from './sandbox-adapter.js'
+
+/**
+ * Lite-native port of
+ * `ui/examples/upstream-patterns/src/components/sandbox/SandboxConfigTab.tsx`.
+ *
+ * Read-only view of the active sandbox config. Upstream calls into the
+ * singleton `SandboxManager`; we pull the same fields from the
+ * `SandboxAdapterContext` so the component stays pure and parents
+ * decide where the data comes from.
+ */
+
+export function SandboxConfigTab() {
+  const { settings } = useSandboxAdapter()
+  const enabled = isSandboxingEnabled(settings)
+
+  const depCheck = settings.dependencyCheck
+  const warningsNote =
+    depCheck.warnings.length > 0 ? (
+      <box marginTop={1} flexDirection="column">
+        {depCheck.warnings.map((w, i) => (
+          <text key={i} fg={c.dim} selectable>
+            {w}
+          </text>
+        ))}
+      </box>
+    ) : null
+
+  if (!enabled) {
+    return (
+      <box flexDirection="column" paddingY={1}>
+        <text fg={c.dim}>Sandbox is not enabled</text>
+        {warningsNote}
+      </box>
+    )
+  }
+
+  const fsRead = settings.fsRead
+  const fsWrite = settings.fsWrite
+  const network = settings.network
+  const hasNetworkRules =
+    (network.allowedHosts && network.allowedHosts.length > 0) ||
+    (network.deniedHosts && network.deniedHosts.length > 0)
+
+  return (
+    <box flexDirection="column" paddingY={1}>
+      <Section title="Excluded Commands:">
+        <text fg={c.dim} selectable>
+          {settings.excludedCommands.length > 0
+            ? settings.excludedCommands.join(', ')
+            : 'None'}
+        </text>
+      </Section>
+
+      {fsRead.denyOnly.length > 0 && (
+        <Section title="Filesystem Read Restrictions:" marginTop>
+          <text fg={c.dim} selectable>Denied: {fsRead.denyOnly.join(', ')}</text>
+          {fsRead.allowWithinDeny && fsRead.allowWithinDeny.length > 0 && (
+            <text fg={c.dim} selectable>
+              Allowed within denied: {fsRead.allowWithinDeny.join(', ')}
+            </text>
+          )}
+        </Section>
+      )}
+
+      {fsWrite.allowOnly.length > 0 && (
+        <Section title="Filesystem Write Restrictions:" marginTop>
+          <text fg={c.dim} selectable>Allowed: {fsWrite.allowOnly.join(', ')}</text>
+          {fsWrite.denyWithinAllow.length > 0 && (
+            <text fg={c.dim} selectable>
+              Denied within allowed: {fsWrite.denyWithinAllow.join(', ')}
+            </text>
+          )}
+        </Section>
+      )}
+
+      {hasNetworkRules && (
+        <Section
+          title={`Network Restrictions${shouldAllowManagedSandboxDomainsOnly(settings) ? ' (Managed)' : ''}:`}
+          marginTop
+        >
+          {network.allowedHosts && network.allowedHosts.length > 0 && (
+            <text fg={c.dim} selectable>
+              Allowed: {network.allowedHosts.join(', ')}
+            </text>
+          )}
+          {network.deniedHosts && network.deniedHosts.length > 0 && (
+            <text fg={c.dim} selectable>
+              Denied: {network.deniedHosts.join(', ')}
+            </text>
+          )}
+        </Section>
+      )}
+
+      {settings.allowUnixSockets.length > 0 && (
+        <Section title="Allowed Unix Sockets:" marginTop>
+          <text fg={c.dim} selectable>
+            {settings.allowUnixSockets.join(', ')}
+          </text>
+        </Section>
+      )}
+
+      {settings.linuxGlobPatternWarnings.length > 0 && (
+        <box marginTop={1} flexDirection="column">
+          <text fg={c.warning}>
+            <strong>\u26A0 Warning: Glob patterns not fully supported on Linux</strong>
+          </text>
+          <text fg={c.dim} selectable>
+            The following patterns will be ignored:{' '}
+            {settings.linuxGlobPatternWarnings.slice(0, 3).join(', ')}
+            {settings.linuxGlobPatternWarnings.length > 3 &&
+              ` (${settings.linuxGlobPatternWarnings.length - 3} more)`}
+          </text>
+        </box>
+      )}
+
+      {warningsNote}
+    </box>
+  )
+}
+
+function Section({
+  title,
+  marginTop,
+  children,
+}: {
+  title: string
+  marginTop?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <box marginTop={marginTop ? 1 : 0} flexDirection="column">
+      <text fg={c.accent}>
+        <strong>{title}</strong>
+      </text>
+      {children}
+    </box>
+  )
+}

--- a/ui/src/components/sandbox/SandboxDependenciesTab.tsx
+++ b/ui/src/components/sandbox/SandboxDependenciesTab.tsx
@@ -1,0 +1,134 @@
+import React from 'react'
+import { c } from '../../theme.js'
+import type { SandboxDependencyCheck } from './sandbox-adapter.js'
+import { useSandboxAdapter } from './sandbox-adapter.js'
+
+/**
+ * Lite-native port of
+ * `ui/examples/upstream-patterns/src/components/sandbox/SandboxDependenciesTab.tsx`.
+ *
+ * Same breakdown upstream ships:
+ * - macOS: `seatbelt` (built-in) + ripgrep.
+ * - Linux / WSL: ripgrep + bwrap + socat + optional seccomp.
+ * - Anywhere else: whatever the backend reports as an error is printed
+ *   verbatim so new platform errors aren't silently swallowed.
+ *
+ * The platform string comes from the adapter rather than from the
+ * frontend's `process.platform` — the Lite frontend runs in the same
+ * process as Rust, but the sandbox semantics are decided there.
+ */
+
+type Props = {
+  /** Allow callers to override the adapter's check payload — used by
+   *  the Settings shell to pass a cached/fresh diag result without
+   *  re-running the full sandbox discovery. */
+  depCheck?: SandboxDependencyCheck
+}
+
+export function SandboxDependenciesTab({ depCheck }: Props = {}) {
+  const { settings } = useSandboxAdapter()
+  const check = depCheck ?? settings.dependencyCheck
+  const isMac = settings.platform === 'macos'
+
+  const rgMissing = check.errors.some(e => e.includes('ripgrep'))
+  const bwrapMissing = check.errors.some(e => e.includes('bwrap'))
+  const socatMissing = check.errors.some(e => e.includes('socat'))
+  const seccompMissing = check.warnings.length > 0
+
+  const otherErrors = check.errors.filter(
+    e => !e.includes('ripgrep') && !e.includes('bwrap') && !e.includes('socat'),
+  )
+
+  const rgInstallHint = isMac ? 'brew install ripgrep' : 'apt install ripgrep'
+
+  return (
+    <box flexDirection="column" paddingY={1} gap={1}>
+      {isMac && (
+        <box flexDirection="column">
+          <text>
+            seatbelt: <span fg={c.success}>built-in (macOS)</span>
+          </text>
+        </box>
+      )}
+
+      <box flexDirection="column">
+        <text>
+          ripgrep (rg):{' '}
+          {rgMissing ? (
+            <span fg={c.error}>not found</span>
+          ) : (
+            <span fg={c.success}>found</span>
+          )}
+        </text>
+        {rgMissing && (
+          <text fg={c.dim}>
+            {'  '}· {rgInstallHint}
+          </text>
+        )}
+      </box>
+
+      {!isMac && (
+        <>
+          <box flexDirection="column">
+            <text>
+              bubblewrap (bwrap):{' '}
+              {bwrapMissing ? (
+                <span fg={c.error}>not installed</span>
+              ) : (
+                <span fg={c.success}>installed</span>
+              )}
+            </text>
+            {bwrapMissing && (
+              <text fg={c.dim}>{'  '}· apt install bubblewrap</text>
+            )}
+          </box>
+
+          <box flexDirection="column">
+            <text>
+              socat:{' '}
+              {socatMissing ? (
+                <span fg={c.error}>not installed</span>
+              ) : (
+                <span fg={c.success}>installed</span>
+              )}
+            </text>
+            {socatMissing && <text fg={c.dim}>{'  '}· apt install socat</text>}
+          </box>
+
+          <box flexDirection="column">
+            <text>
+              seccomp filter:{' '}
+              {seccompMissing ? (
+                <span fg={c.warning}>not installed</span>
+              ) : (
+                <span fg={c.success}>installed</span>
+              )}
+              {seccompMissing && (
+                <span fg={c.dim}> (required to block unix domain sockets)</span>
+              )}
+            </text>
+            {seccompMissing && (
+              <box flexDirection="column">
+                <text fg={c.dim}>
+                  {'  '}· npm install -g @anthropic-ai/sandbox-runtime
+                </text>
+                <text fg={c.dim}>
+                  {'  '}· or copy vendor/seccomp/* from sandbox-runtime and set
+                </text>
+                <text fg={c.dim}>
+                  {'    '}sandbox.seccomp.bpfPath and applyPath in settings.json
+                </text>
+              </box>
+            )}
+          </box>
+        </>
+      )}
+
+      {otherErrors.map(err => (
+        <text key={err} fg={c.error} selectable>
+          {err}
+        </text>
+      ))}
+    </box>
+  )
+}

--- a/ui/src/components/sandbox/SandboxDoctorSection.tsx
+++ b/ui/src/components/sandbox/SandboxDoctorSection.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { c } from '../../theme.js'
+import { useSandboxAdapter } from './sandbox-adapter.js'
+
+/**
+ * Lite-native port of
+ * `ui/examples/upstream-patterns/src/components/sandbox/SandboxDoctorSection.tsx`.
+ *
+ * Summary card surfaced inside the `/status` / `/doctor` output. Same
+ * three short-circuits upstream uses:
+ *   - Unsupported platform → render nothing.
+ *   - Sandbox not enabled in settings → render nothing.
+ *   - No dep errors / warnings → render nothing.
+ */
+
+export function SandboxDoctorSection() {
+  const { settings } = useSandboxAdapter()
+  if (!settings.supportedPlatform) return null
+  if (!settings.enabledInSettings) return null
+
+  const { errors, warnings } = settings.dependencyCheck
+  if (errors.length === 0 && warnings.length === 0) return null
+
+  const hasErrors = errors.length > 0
+  const statusColor = hasErrors ? c.error : c.warning
+  const statusText = hasErrors ? 'Missing dependencies' : 'Available (with warnings)'
+
+  return (
+    <box flexDirection="column">
+      <text>
+        <strong>Sandbox</strong>
+      </text>
+      <text>
+        \u2514 Status: <span fg={statusColor}>{statusText}</span>
+      </text>
+      {errors.map((error, i) => (
+        <text key={`err-${i}`} fg={c.error} selectable>
+          \u2514 {error}
+        </text>
+      ))}
+      {warnings.map((warn, i) => (
+        <text key={`warn-${i}`} fg={c.warning} selectable>
+          \u2514 {warn}
+        </text>
+      ))}
+      {hasErrors && (
+        <text fg={c.dim}>\u2514 Run /sandbox for install instructions</text>
+      )}
+    </box>
+  )
+}

--- a/ui/src/components/sandbox/SandboxOverridesTab.tsx
+++ b/ui/src/components/sandbox/SandboxOverridesTab.tsx
@@ -1,0 +1,165 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../../theme.js'
+import { isSandboxingEnabled, useSandboxAdapter } from './sandbox-adapter.js'
+
+/**
+ * Lite-native port of
+ * `ui/examples/upstream-patterns/src/components/sandbox/SandboxOverridesTab.tsx`.
+ *
+ * Upstream binds a two-option `<Select>` to
+ * `SandboxManager.setSandboxSettings({ allowUnsandboxedCommands })`.
+ * cc-rust routes the write through the adapter's `updateSettings`
+ * hook and surfaces the completion message via `onComplete` — the
+ * same callback the Settings shell passes down, so existing command
+ * plumbing keeps working.
+ */
+
+type OverrideMode = 'open' | 'closed'
+
+type Props = {
+  onComplete: (
+    result?: string,
+    options?: { display?: 'skip' | 'system' },
+  ) => void
+}
+
+type Option = {
+  value: OverrideMode
+  label: string
+  hotkey: string
+}
+
+const OPTIONS: Option[] = [
+  { value: 'open', label: 'Allow unsandboxed fallback', hotkey: 'a' },
+  { value: 'closed', label: 'Strict sandbox mode', hotkey: 's' },
+]
+
+export function SandboxOverridesTab({ onComplete }: Props) {
+  const { settings, updateSettings } = useSandboxAdapter()
+  const enabled = isSandboxingEnabled(settings)
+  const locked = settings.lockedByPolicy
+  const currentMode: OverrideMode = settings.allowUnsandboxedCommands ? 'open' : 'closed'
+
+  if (!enabled) {
+    return (
+      <box flexDirection="column" paddingY={1}>
+        <text fg={c.dim}>
+          Sandbox is not enabled. Enable sandbox to configure override settings.
+        </text>
+      </box>
+    )
+  }
+
+  if (locked) {
+    return (
+      <box flexDirection="column" paddingY={1}>
+        <text fg={c.dim}>
+          Override settings are managed by a higher-priority configuration and
+          cannot be changed locally.
+        </text>
+        <box marginTop={1}>
+          <text fg={c.dim} selectable>
+            Current setting:{' '}
+            {currentMode === 'open' ? 'Allow unsandboxed fallback' : 'Strict sandbox mode'}
+          </text>
+        </box>
+      </box>
+    )
+  }
+
+  return (
+    <OverridesSelect
+      currentMode={currentMode}
+      onSelect={async value => {
+        await updateSettings({ allowUnsandboxedCommands: value === 'open' })
+        onComplete(
+          value === 'open'
+            ? '\u2713 Unsandboxed fallback allowed - commands can run outside sandbox when necessary'
+            : '\u2713 Strict sandbox mode - all commands must run in sandbox or be excluded via the `excludedCommands` option',
+        )
+      }}
+      onCancel={() => onComplete(undefined, { display: 'skip' })}
+    />
+  )
+}
+
+function OverridesSelect({
+  currentMode,
+  onSelect,
+  onCancel,
+}: {
+  currentMode: OverrideMode
+  onSelect: (value: OverrideMode) => void | Promise<void>
+  onCancel: () => void
+}) {
+  const [selected, setSelected] = useState(
+    OPTIONS.findIndex(opt => opt.value === currentMode),
+  )
+  const safeIndex = Math.max(0, Math.min(selected, OPTIONS.length - 1))
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const input = (event.sequence ?? (name?.length === 1 ? name : '') ?? '').toLowerCase()
+
+    if (input) {
+      const match = OPTIONS.findIndex(opt => opt.hotkey === input)
+      if (match >= 0) {
+        void onSelect(OPTIONS[match]!.value)
+        return
+      }
+    }
+    if (name === 'escape') {
+      onCancel()
+      return
+    }
+    if (name === 'up' || input === 'k') {
+      setSelected(Math.max(0, safeIndex - 1))
+      return
+    }
+    if (name === 'down' || input === 'j') {
+      setSelected(Math.min(OPTIONS.length - 1, safeIndex + 1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      void onSelect(OPTIONS[safeIndex]!.value)
+    }
+  })
+
+  return (
+    <box flexDirection="column" paddingY={1}>
+      <box marginBottom={1}>
+        <text>
+          <strong>Configure Overrides:</strong>
+        </text>
+      </box>
+      {OPTIONS.map((opt, i) => {
+        const isSelected = i === safeIndex
+        const isCurrent = opt.value === currentMode
+        return (
+          <box key={opt.value} flexDirection="row">
+            <text fg={isSelected ? c.bg : undefined} bg={isSelected ? c.textBright : undefined}>
+              <strong>{` ${opt.label} `}</strong>
+            </text>
+            <text fg={c.dim}> ({opt.hotkey})</text>
+            {isCurrent && <text fg={c.success}> (current)</text>}
+          </box>
+        )
+      })}
+      <box flexDirection="column" marginTop={1} gap={1}>
+        <text fg={c.dim} selectable>
+          <strong>Allow unsandboxed fallback:</strong> When a command fails due
+          to sandbox restrictions, Claude can retry with
+          dangerouslyDisableSandbox to run outside the sandbox (falling back
+          to default permissions).
+        </text>
+        <text fg={c.dim} selectable>
+          <strong>Strict sandbox mode:</strong> All bash commands invoked by
+          the model must run in the sandbox unless they are explicitly listed
+          in excludedCommands.
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/sandbox/SandboxSettings.tsx
+++ b/ui/src/components/sandbox/SandboxSettings.tsx
@@ -1,0 +1,237 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import { c } from '../../theme.js'
+import { SandboxConfigTab } from './SandboxConfigTab.js'
+import { SandboxDependenciesTab } from './SandboxDependenciesTab.js'
+import { SandboxOverridesTab } from './SandboxOverridesTab.js'
+import type { SandboxDependencyCheck } from './sandbox-adapter.js'
+import { useSandboxAdapter } from './sandbox-adapter.js'
+
+/**
+ * Lite-native port of
+ * `ui/examples/upstream-patterns/src/components/sandbox/SandboxSettings.tsx`.
+ *
+ * Upstream wraps the sandbox views in a `Pane` + `Tabs` pair from the
+ * upstream Ink UI kit. cc-rust has no tabs primitive; we roll our own
+ * tab header (left/right or number keys switch) and render the active
+ * tab body below. Tab visibility matches upstream rules:
+ *   - deps have errors → only "Dependencies" tab.
+ *   - deps have warnings → Mode + Dependencies + Overrides + Config.
+ *   - otherwise → Mode + Overrides + Config.
+ */
+
+type SandboxMode = 'auto-allow' | 'regular' | 'disabled'
+
+type Props = {
+  onComplete: (
+    result?: string,
+    options?: { display?: 'skip' | 'system' },
+  ) => void
+  depCheck?: SandboxDependencyCheck
+}
+
+type TabKey = 'mode' | 'overrides' | 'config' | 'dependencies'
+
+const MODE_OPTIONS: Array<{ value: SandboxMode; label: string; hotkey: string }> = [
+  { value: 'auto-allow', label: 'Sandbox BashTool, with auto-allow', hotkey: 'a' },
+  { value: 'regular', label: 'Sandbox BashTool, with regular permissions', hotkey: 'r' },
+  { value: 'disabled', label: 'No Sandbox', hotkey: 'd' },
+]
+
+export function SandboxSettings({ onComplete, depCheck }: Props) {
+  const { settings, updateSettings } = useSandboxAdapter()
+  const check = depCheck ?? settings.dependencyCheck
+  const hasErrors = check.errors.length > 0
+  const hasWarnings = check.warnings.length > 0
+
+  const currentMode: SandboxMode = !settings.enabled
+    ? 'disabled'
+    : settings.autoAllowBashIfSandboxed
+      ? 'auto-allow'
+      : 'regular'
+
+  const tabs: TabKey[] = hasErrors
+    ? ['dependencies']
+    : hasWarnings
+      ? ['mode', 'dependencies', 'overrides', 'config']
+      : ['mode', 'overrides', 'config']
+
+  const [tabIndex, setTabIndex] = useState(0)
+  const safeTabIndex = Math.max(0, Math.min(tabIndex, tabs.length - 1))
+  const activeTab = tabs[safeTabIndex]!
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const input = (event.sequence ?? (name?.length === 1 ? name : '') ?? '').toLowerCase()
+
+    if (name === 'escape') {
+      onComplete(undefined, { display: 'skip' })
+      return
+    }
+    if (name === 'tab' || input === ']' || name === 'right') {
+      setTabIndex(prev => (prev + 1) % tabs.length)
+      return
+    }
+    if (input === '[' || name === 'left') {
+      setTabIndex(prev => (prev - 1 + tabs.length) % tabs.length)
+      return
+    }
+    // `1` / `2` / `3` / `4` jump directly to a tab by index.
+    const numeric = Number(input)
+    if (Number.isInteger(numeric) && numeric >= 1 && numeric <= tabs.length) {
+      setTabIndex(numeric - 1)
+    }
+  })
+
+  return (
+    <box
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.accent}
+      title="Sandbox:"
+      titleAlignment="left"
+      paddingX={2}
+      paddingY={1}
+      width="100%"
+    >
+      <box flexDirection="row" gap={2}>
+        {tabs.map((key, i) => (
+          <text
+            key={key}
+            fg={i === safeTabIndex ? c.bg : c.dim}
+            bg={i === safeTabIndex ? c.accent : undefined}
+          >
+            <strong>{` ${labelForTab(key)} `}</strong>
+          </text>
+        ))}
+      </box>
+      <box marginTop={1}>
+        {activeTab === 'mode' && (
+          <ModeTab
+            currentMode={currentMode}
+            showSocketWarning={
+              hasWarnings && !settings.network.allowAllUnixSockets
+            }
+            onSelect={async value => {
+              switch (value) {
+                case 'auto-allow':
+                  await updateSettings({ enabled: true, autoAllowBashIfSandboxed: true })
+                  onComplete('\u2713 Sandbox enabled with auto-allow for bash commands')
+                  break
+                case 'regular':
+                  await updateSettings({ enabled: true, autoAllowBashIfSandboxed: false })
+                  onComplete('\u2713 Sandbox enabled with regular bash permissions')
+                  break
+                case 'disabled':
+                  await updateSettings({ enabled: false, autoAllowBashIfSandboxed: false })
+                  onComplete('\u25CB Sandbox disabled')
+                  break
+              }
+            }}
+          />
+        )}
+        {activeTab === 'overrides' && <SandboxOverridesTab onComplete={onComplete} />}
+        {activeTab === 'config' && <SandboxConfigTab />}
+        {activeTab === 'dependencies' && <SandboxDependenciesTab depCheck={check} />}
+      </box>
+      <box marginTop={1}>
+        <text fg={c.dim}>
+          <em>
+            Tab / \u2190 \u2192 to switch tabs · 1-{tabs.length} jump · Esc to close
+          </em>
+        </text>
+      </box>
+    </box>
+  )
+}
+
+function labelForTab(key: TabKey): string {
+  switch (key) {
+    case 'mode':
+      return 'Mode'
+    case 'overrides':
+      return 'Overrides'
+    case 'config':
+      return 'Config'
+    case 'dependencies':
+      return 'Dependencies'
+  }
+}
+
+function ModeTab({
+  currentMode,
+  showSocketWarning,
+  onSelect,
+}: {
+  currentMode: SandboxMode
+  showSocketWarning: boolean
+  onSelect: (mode: SandboxMode) => void | Promise<void>
+}) {
+  const [selected, setSelected] = useState(
+    MODE_OPTIONS.findIndex(opt => opt.value === currentMode),
+  )
+  const safeIndex = Math.max(0, Math.min(selected, MODE_OPTIONS.length - 1))
+
+  useKeyboard(event => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const input = (event.sequence ?? (name?.length === 1 ? name : '') ?? '').toLowerCase()
+    if (input) {
+      const match = MODE_OPTIONS.findIndex(opt => opt.hotkey === input)
+      if (match >= 0) {
+        void onSelect(MODE_OPTIONS[match]!.value)
+        return
+      }
+    }
+    if (name === 'up' || input === 'k') {
+      setSelected(Math.max(0, safeIndex - 1))
+      return
+    }
+    if (name === 'down' || input === 'j') {
+      setSelected(Math.min(MODE_OPTIONS.length - 1, safeIndex + 1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      void onSelect(MODE_OPTIONS[safeIndex]!.value)
+    }
+  })
+
+  return (
+    <box flexDirection="column" paddingY={1}>
+      {showSocketWarning && (
+        <box marginBottom={1}>
+          <text fg={c.warning}>
+            Cannot block unix domain sockets (see Dependencies tab)
+          </text>
+        </box>
+      )}
+      <box marginBottom={1}>
+        <text>
+          <strong>Configure Mode:</strong>
+        </text>
+      </box>
+      {MODE_OPTIONS.map((opt, i) => {
+        const isSelected = i === safeIndex
+        const isCurrent = opt.value === currentMode
+        return (
+          <box key={opt.value} flexDirection="row">
+            <text fg={isSelected ? c.bg : undefined} bg={isSelected ? c.textBright : undefined}>
+              <strong>{` ${opt.label} `}</strong>
+            </text>
+            <text fg={c.dim}> ({opt.hotkey})</text>
+            {isCurrent && <text fg={c.success}> (current)</text>}
+          </box>
+        )
+      })}
+      <box flexDirection="column" marginTop={1}>
+        <text fg={c.dim} selectable>
+          <strong>Auto-allow mode:</strong> Commands will try to run in the
+          sandbox automatically, and attempts to run outside of the sandbox
+          fallback to regular permissions. Explicit ask/deny rules are always
+          respected.
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/sandbox/sandbox-adapter.ts
+++ b/ui/src/components/sandbox/sandbox-adapter.ts
@@ -1,0 +1,144 @@
+import { createContext, useContext } from 'react'
+
+/**
+ * Lite-native replacement for upstream's
+ * `utils/sandbox/sandbox-adapter.js`.
+ *
+ * Upstream keeps a singleton `SandboxManager` that reads/writes the
+ * settings file + platform binaries directly. cc-rust's frontend has
+ * no FS access, so the sandbox UI is driven by a data-only snapshot
+ * the backend ships over IPC (or a local stub used by the config
+ * preview). Hosts provide the snapshot through `SandboxAdapterContext`;
+ * the individual tabs consume `useSandboxAdapter()` to read + mutate
+ * via the supplied callbacks.
+ */
+
+export type Platform = 'macos' | 'linux' | 'wsl' | 'windows' | 'unknown'
+
+/** Dependency check result. Mirrors upstream
+ *  `SandboxDependencyCheck`. */
+export interface SandboxDependencyCheck {
+  errors: string[]
+  warnings: string[]
+}
+
+export interface SandboxFsReadConfig {
+  denyOnly: string[]
+  /** Paths that escape `denyOnly` — matches upstream
+   *  `filesystem.read.allowWithinDeny`. */
+  allowWithinDeny?: string[]
+}
+
+export interface SandboxFsWriteConfig {
+  allowOnly: string[]
+  /** Paths that, despite being under `allowOnly`, remain denied. */
+  denyWithinAllow: string[]
+}
+
+export interface SandboxNetworkConfig {
+  allowedHosts?: string[]
+  deniedHosts?: string[]
+  /** Upstream flag surfaced in the config tab. */
+  allowAllUnixSockets?: boolean
+}
+
+export interface SandboxSettings {
+  enabled: boolean
+  autoAllowBashIfSandboxed: boolean
+  allowUnsandboxedCommands: boolean
+  /** `true` when the local settings are pinned by a managed / policy
+   *  source. UI renders a read-only view in that case. */
+  lockedByPolicy: boolean
+  /** Platform string used by `SandboxDependenciesTab` to choose the
+   *  install-hint wording. */
+  platform: Platform
+  /** Running on a platform where sandboxing can work at all. */
+  supportedPlatform: boolean
+  /** `true` when settings have sandbox enabled — even when deps are
+   *  missing. */
+  enabledInSettings: boolean
+  excludedCommands: string[]
+  fsRead: SandboxFsReadConfig
+  fsWrite: SandboxFsWriteConfig
+  network: SandboxNetworkConfig
+  allowUnixSockets: string[]
+  allowManagedSandboxDomainsOnly: boolean
+  /** Glob patterns the backend detected it can't enforce on Linux. */
+  linuxGlobPatternWarnings: string[]
+  dependencyCheck: SandboxDependencyCheck
+}
+
+export type SandboxSettingsPatch = Partial<
+  Pick<
+    SandboxSettings,
+    'enabled' | 'autoAllowBashIfSandboxed' | 'allowUnsandboxedCommands'
+  >
+>
+
+export interface SandboxAdapter {
+  settings: SandboxSettings
+  /** Persist one or more fields. Adapters forward to the backend's
+   *  `/sandbox` command or the Rust side's write-settings IPC. */
+  updateSettings: (patch: SandboxSettingsPatch) => Promise<void> | void
+}
+
+const DEFAULT_PLATFORM: Platform =
+  (globalThis as unknown as { process?: { platform?: string } }).process?.platform === 'darwin'
+    ? 'macos'
+    : (globalThis as unknown as { process?: { platform?: string } }).process?.platform === 'linux'
+      ? 'linux'
+      : (globalThis as unknown as { process?: { platform?: string } }).process?.platform === 'win32'
+        ? 'windows'
+        : 'unknown'
+
+/** Sensible empty snapshot — used by `useSandboxAdapter()` when no
+ *  provider is mounted so tabs can still render "Sandbox is not
+ *  enabled" without throwing. */
+export const EMPTY_SANDBOX_SETTINGS: SandboxSettings = {
+  enabled: false,
+  autoAllowBashIfSandboxed: false,
+  allowUnsandboxedCommands: false,
+  lockedByPolicy: false,
+  platform: DEFAULT_PLATFORM,
+  supportedPlatform: DEFAULT_PLATFORM === 'macos' || DEFAULT_PLATFORM === 'linux',
+  enabledInSettings: false,
+  excludedCommands: [],
+  fsRead: { denyOnly: [] },
+  fsWrite: { allowOnly: [], denyWithinAllow: [] },
+  network: {},
+  allowUnixSockets: [],
+  allowManagedSandboxDomainsOnly: false,
+  linuxGlobPatternWarnings: [],
+  dependencyCheck: { errors: [], warnings: [] },
+}
+
+const DEFAULT_ADAPTER: SandboxAdapter = {
+  settings: EMPTY_SANDBOX_SETTINGS,
+  updateSettings: () => {},
+}
+
+export const SandboxAdapterContext = createContext<SandboxAdapter>(DEFAULT_ADAPTER)
+
+export function useSandboxAdapter(): SandboxAdapter {
+  return useContext(SandboxAdapterContext)
+}
+
+/** Convenience — does the current settings snapshot indicate the
+ *  sandbox is fully wired up? Mirrors upstream
+ *  `SandboxManager.isSandboxingEnabled()`. */
+export function isSandboxingEnabled(settings: SandboxSettings): boolean {
+  return (
+    settings.enabled &&
+    settings.supportedPlatform &&
+    settings.dependencyCheck.errors.length === 0
+  )
+}
+
+/** Pure helper for the config tab — returns `true` when the network
+ *  block should be annotated "(Managed)". Mirrors upstream
+ *  `shouldAllowManagedSandboxDomainsOnly()`. */
+export function shouldAllowManagedSandboxDomainsOnly(
+  settings: SandboxSettings,
+): boolean {
+  return settings.allowManagedSandboxDomainsOnly
+}


### PR DESCRIPTION
## Summary

Ports the next batch of upstream-pattern folders into the active Lite
tree — follows PR #114's approach (OpenTUI primitives only, host-supplied
state where the backend IPC isn't wired yet).

**Folders (5, 15 files, ~2 500 LoC):**

- **`LspRecommendation/LspRecommendationMenu.tsx`** — presentational
  install-plugin menu. Same four decisions + 30 s auto-dismiss as
  upstream; the existing wired `LspRecommendationDialog.tsx` can reuse
  this once we decide to decouple the chrome.
- **`memory/`** — `MemoryUpdateNotification` (prints the relative
  path against cwd / $HOME) + `MemoryFileSelector` (entry list with
  @-import indent + optional auto-memory / auto-dream toggle rows). The
  memory list and toggle handlers stay host-supplied so we don't touch
  the FS from the frontend.
- **`ManagedSettingsSecurityDialog/`** — `utils.ts` mirrors the
  authoritative `DANGEROUS_SHELL_SETTINGS` / `SAFE_ENV_VARS` tables
  (comment flags them for lockstep updates). The dialog is
  keyboard-driven and shows the flagged setting names only — values
  intentionally omitted.
- **`sandbox/`** — new `sandbox-adapter.ts` introduces
  `SandboxAdapterContext` carrying a `SandboxSettings` snapshot +
  `updateSettings` patch callback. Five view/control tabs
  (`SandboxConfigTab`, `SandboxDependenciesTab`, `SandboxDoctorSection`,
  `SandboxOverridesTab`) render from the context. The
  `SandboxSettings` shell rolls its own tab strip (Tab / ←→ / 1-N
  jump) since OpenTUI has no Pane/Tabs primitive. Tab visibility
  tracks upstream: errors → Dependencies-only; warnings → all four.
- **`Settings/`** — tabs shell with Status / Config / Usage:
  - `Status` pulls cwd, model, session id, vim, view mode, subsystems,
    ide state from the store; callers pass in extra property
    sections + diagnostics.
  - `Config` is a searchable option list with built-ins for vim,
    view mode, editor mode, model, session id, cwd, IDE. Hosts
    extend via `extraOptions`. Managed rows render in gray.
  - `Usage` keeps upstream's layout (progress bars + extra-usage)
    behind a pluggable `loadUtilization` prop; default returns
    `null` to render the "only on subscription plans" hint.
  - `Settings.tsx` shell wires all three behind Tab / ←→ / 1-3 keys.

## Why

Follows CLAUDE.md §Full Build — upstream components classified as
Class B/C are now expected to be ported rather than left in the
sample tree. Keeping the components purely view-oriented (with
adapter / loader / options props) means each piece becomes usable
the moment the matching backend IPC lands.

## Deliberate trade-offs

- **Settings/Config.tsx**: upstream is 2 368 lines and depends on
  fast-mode, bridge, channels, agent-swarms, teammate-mode, and a
  dozen pickers cc-rust doesn't ship. The port is a Lite *scaffold*
  that covers the store-backed toggles today and exposes
  `extraOptions` so hosts extend it without touching this file. Not a
  verbatim copy; marked explicitly in the file's JSDoc.
- **Sandbox**: the adapter abstraction means the renderers compile
  and render against `EMPTY_SANDBOX_SETTINGS` out of the box — once
  the backend surfaces a `sandbox_status` IPC event, a provider at
  the app root is the only thing needed.
- **Memory / Managed dialog**: both keep their data sources as
  props — no FS reads, no direct config writes. The
  `DANGEROUS_SHELL_SETTINGS` / `SAFE_ENV_VARS` constants are
  duplicated locally with a comment noting they must stay in lockstep
  with upstream.

## Test plan

- [x] `npx tsc --noEmit` — 0 new errors in any of the 15 files. Same
      `App.tsx` CliRenderer / ResizeRenderer mismatches as before are
      pre-existing.
- [ ] `cargo check` — no backend changes in this PR, so unaffected
      (PR #114 already shipped the backend adds this branch needs).
- [ ] Manual smoke: mount `<Settings>` with a stub `loadUtilization`,
      tab through Status / Config / Usage. Confirm Config search +
      vim toggle + view-mode toggle.
- [ ] Manual smoke: mount `<SandboxSettings>` inside a
      `SandboxAdapterContext.Provider` with a fixture snapshot; flip
      modes / overrides and observe `updateSettings` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)