### PR TITLE
feat(ui): port agents/customselect/design-system/diff folders to OpenTUI Lite

### DIFF
--- a/ui/src/components/agents/AgentDetail.tsx
+++ b/ui/src/components/agents/AgentDetail.tsx
@@ -1,0 +1,99 @@
+import React from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../../theme.js'
+import type { AgentDefinitionEntry } from '../../ipc/protocol.js'
+import { getActualRelativeAgentFilePath } from './agentFileUtils.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/agents/AgentDetail.tsx`.
+ *
+ * Read-only agent detail pane shown when the user presses Enter on a
+ * list row. The Lite port swaps upstream's `Markdown` for OpenTUI's
+ * `<markdown>` primitive and drops the backend-owned fields (hooks,
+ * memory scope) that aren't exposed over IPC yet.
+ */
+
+type Props = {
+  agent: AgentDefinitionEntry
+  onBack: () => void
+}
+
+export function AgentDetail({ agent, onBack }: Props) {
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    if (name === 'escape' || name === 'return' || name === 'enter') {
+      onBack()
+    }
+  })
+
+  const filePath = getActualRelativeAgentFilePath(agent)
+
+  return (
+    <box flexDirection="column" gap={1}>
+      <text fg={c.dim}>{filePath}</text>
+
+      <box flexDirection="column">
+        <text>
+          <strong>Description</strong>{' '}
+          <text fg={c.dim}>(tells Claude when to use this agent):</text>
+        </text>
+        <box marginLeft={2}>
+          <text>{agent.description || ''}</text>
+        </box>
+      </box>
+
+      <box flexDirection="row">
+        <text><strong>Tools</strong>: </text>
+        {agent.tools.length === 0 ? (
+          <text>All tools</text>
+        ) : (
+          <text>{agent.tools.join(', ')}</text>
+        )}
+      </box>
+
+      <text>
+        <strong>Model</strong>: {agent.model ?? '(inherit)'}
+      </text>
+
+      {agent.permission_mode && (
+        <text>
+          <strong>Permission mode</strong>: {agent.permission_mode}
+        </text>
+      )}
+
+      {agent.memory && (
+        <text>
+          <strong>Memory</strong>: {agent.memory}
+        </text>
+      )}
+
+      {agent.skills && agent.skills.length > 0 && (
+        <text>
+          <strong>Skills</strong>: {agent.skills.length > 10 ? `${agent.skills.length} skills` : agent.skills.join(', ')}
+        </text>
+      )}
+
+      {agent.color && (
+        <text>
+          <strong>Color</strong>: {agent.color}
+        </text>
+      )}
+
+      {agent.system_prompt && (
+        <>
+          <text><strong>System prompt</strong>:</text>
+          <box marginLeft={2} marginRight={2}>
+            <markdown content={agent.system_prompt} />
+          </box>
+        </>
+      )}
+
+      <box marginTop={1}>
+        <text fg={c.dim}>Press Enter or Esc to go back</text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/agents/AgentEditor.tsx
+++ b/ui/src/components/agents/AgentEditor.tsx
@@ -1,0 +1,229 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../../theme.js'
+import type { AgentDefinitionEntry } from '../../ipc/protocol.js'
+import { ColorPicker, type AgentColorName } from './ColorPicker.js'
+import { ModelSelector } from './ModelSelector.js'
+import { ToolSelector, type ToolSpec } from './ToolSelector.js'
+import type { DraftAgent } from './types.js'
+import { validateAgent } from './validateAgent.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/agents/AgentEditor.tsx`.
+ *
+ * In-place edit form for an existing (user- or project-sourced) agent.
+ * Upstream renders a richer multi-pane form; the Lite port keeps the
+ * same fields — name, description, tools, model, color, system prompt —
+ * but drives the sub-pickers via panel swapping instead of inline
+ * focus capture. Callers receive the fully-validated draft via
+ * `onSave`.
+ */
+
+type Panel = 'form' | 'tools' | 'model' | 'color'
+
+type Props = {
+  agent: AgentDefinitionEntry
+  availableTools: ToolSpec[]
+  existingAgents: AgentDefinitionEntry[]
+  onSave: (draft: DraftAgent) => void
+  onCancel: () => void
+}
+
+function entryToDraft(entry: AgentDefinitionEntry): DraftAgent {
+  return {
+    agentType: entry.name,
+    description: entry.description ?? '',
+    systemPrompt: entry.system_prompt ?? '',
+    tools: entry.tools,
+    model: entry.model ?? undefined,
+    color: entry.color ?? undefined,
+    memory: entry.memory ?? undefined,
+    permissionMode: entry.permission_mode ?? undefined,
+    source: (entry.source?.kind === 'user'
+      ? 'userSettings'
+      : entry.source?.kind === 'project'
+        ? 'projectSettings'
+        : 'userSettings') as DraftAgent['source'],
+  }
+}
+
+export function AgentEditor({
+  agent,
+  availableTools,
+  existingAgents,
+  onSave,
+  onCancel,
+}: Props) {
+  const [draft, setDraft] = useState<DraftAgent>(() => entryToDraft(agent))
+  const [panel, setPanel] = useState<Panel>('form')
+  const [focus, setFocus] = useState(0)
+
+  const fields: Array<{
+    key: keyof DraftAgent | 'tools-button' | 'model-button' | 'color-button'
+    label: string
+  }> = [
+    { key: 'agentType', label: 'Name' },
+    { key: 'description', label: 'Description' },
+    { key: 'systemPrompt', label: 'System prompt' },
+    { key: 'tools-button', label: 'Tools' },
+    { key: 'model-button', label: 'Model' },
+    { key: 'color-button', label: 'Color' },
+  ]
+
+  const validation = validateAgent(
+    draft,
+    availableTools.map(t => t.name),
+    existingAgents,
+  )
+
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release' || panel !== 'form') return
+    const name = event.name
+    if (name === 'escape') {
+      onCancel()
+      return
+    }
+    if (name === 'up') {
+      setFocus(idx => Math.max(0, idx - 1))
+      return
+    }
+    if (name === 'down') {
+      setFocus(idx => Math.min(fields.length - 1, idx + 1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      const field = fields[focus]
+      if (!field) return
+      if (field.key === 'tools-button') setPanel('tools')
+      else if (field.key === 'model-button') setPanel('model')
+      else if (field.key === 'color-button') setPanel('color')
+      else if (validation.isValid) onSave(draft)
+      return
+    }
+    const seq = event.sequence
+    const field = fields[focus]
+    if (!field) return
+    if (field.key === 'agentType' || field.key === 'description' || field.key === 'systemPrompt') {
+      if (name === 'backspace' || name === 'delete') {
+        setDraft(d => ({ ...d, [field.key]: String(d[field.key] ?? '').slice(0, -1) }))
+        return
+      }
+      if (seq && seq.length === 1 && !event.ctrl && !event.meta) {
+        setDraft(d => ({ ...d, [field.key]: String(d[field.key] ?? '') + seq }))
+      }
+    }
+  })
+
+  if (panel === 'tools') {
+    return (
+      <ToolSelector
+        tools={availableTools}
+        selected={draft.tools}
+        onComplete={tools => {
+          setDraft(d => ({ ...d, tools }))
+          setPanel('form')
+        }}
+        onCancel={() => setPanel('form')}
+      />
+    )
+  }
+
+  if (panel === 'model') {
+    return (
+      <ModelSelector
+        initialModel={draft.model}
+        onComplete={model => {
+          setDraft(d => ({ ...d, model }))
+          setPanel('form')
+        }}
+        onCancel={() => setPanel('form')}
+      />
+    )
+  }
+
+  if (panel === 'color') {
+    return (
+      <ColorPicker
+        agentName={draft.agentType}
+        currentColor={(draft.color as AgentColorName | undefined) ?? 'automatic'}
+        onConfirm={color => {
+          setDraft(d => ({ ...d, color: color ?? undefined }))
+          setPanel('form')
+        }}
+        onCancel={() => setPanel('form')}
+      />
+    )
+  }
+
+  return (
+    <box flexDirection="column" gap={1}>
+      <strong><text fg={c.accent}>Edit agent</text></strong>
+
+      {fields.map((field, i) => {
+        const isFocused = i === focus
+        if (
+          field.key === 'tools-button' ||
+          field.key === 'model-button' ||
+          field.key === 'color-button'
+        ) {
+          const preview =
+            field.key === 'tools-button'
+              ? draft.tools === undefined
+                ? 'All tools'
+                : draft.tools.length === 0
+                  ? 'None'
+                  : `${draft.tools.length} selected`
+              : field.key === 'model-button'
+                ? draft.model ?? '(inherit)'
+                : draft.color ?? 'automatic'
+          return (
+            <box key={field.key} flexDirection="row" gap={1}>
+              <text fg={isFocused ? c.accent : c.dim}>
+                {isFocused ? '\u276F' : ' '}
+              </text>
+              <strong><text>{field.label}:</text></strong>
+              <text fg={c.text}>{preview}</text>
+              <text fg={c.dim}>(Enter to edit)</text>
+            </box>
+          )
+        }
+        const value = String(draft[field.key] ?? '')
+        return (
+          <box key={field.key} flexDirection="row" gap={1}>
+            <text fg={isFocused ? c.accent : c.dim}>
+              {isFocused ? '\u276F' : ' '}
+            </text>
+            <strong><text>{field.label}:</text></strong>
+            <text fg={c.text}>{value || ' '}</text>
+            {isFocused && <text fg={c.accent}>{'\u2588'}</text>}
+          </box>
+        )
+      })}
+
+      {validation.errors.length > 0 && (
+        <box flexDirection="column" marginTop={1}>
+          {validation.errors.map((err, i) => (
+            <text key={i} fg={c.error}>• {err}</text>
+          ))}
+        </box>
+      )}
+      {validation.warnings.length > 0 && (
+        <box flexDirection="column">
+          {validation.warnings.map((warn, i) => (
+            <text key={i} fg={c.warning}>• {warn}</text>
+          ))}
+        </box>
+      )}
+
+      <box marginTop={1}>
+        <text fg={c.dim}>
+          {validation.isValid
+            ? 'Enter to save · Esc to cancel'
+            : 'Resolve errors to save · Esc to cancel'}
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/agents/AgentNavigationFooter.tsx
+++ b/ui/src/components/agents/AgentNavigationFooter.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { c } from '../../theme.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/agents/AgentNavigationFooter.tsx`.
+ *
+ * Single dim line at the bottom of the agents menu explaining
+ * navigation. Upstream couples this with an Ink `useExitOnCtrlCD` hook
+ * that flips the label to "Press Ctrl+C again to exit"; the Lite
+ * wiring for that shortcut lives higher up in `App.tsx`, so this
+ * component is purely presentational.
+ */
+
+type Props = {
+  instructions?: string
+  /** When set, overrides the label with a pending-exit hint. */
+  exitPendingLabel?: string
+}
+
+export function AgentNavigationFooter({
+  instructions = 'Press \u2191\u2193 to navigate · Enter to select · Esc to go back',
+  exitPendingLabel,
+}: Props) {
+  return (
+    <box marginLeft={2}>
+      <text fg={c.dim}>{exitPendingLabel ?? instructions}</text>
+    </box>
+  )
+}

--- a/ui/src/components/agents/AgentsList.tsx
+++ b/ui/src/components/agents/AgentsList.tsx
@@ -1,0 +1,150 @@
+import React, { useMemo, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../../theme.js'
+import type { AgentDefinitionEntry } from '../../ipc/protocol.js'
+import type { AgentSource } from './types.js'
+import { getAgentSourceDisplayName } from './utils.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/agents/AgentsList.tsx`.
+ *
+ * Grouped, scrollable list of agents. Upstream supports source-level
+ * collapse and per-source editing hints; the Lite port groups entries
+ * by `entry.source.kind`, renders a header + indented rows, and walks
+ * the focused row with ↑/↓ / j/k. Enter triggers `onSelect`.
+ */
+
+type Props = {
+  agents: AgentDefinitionEntry[]
+  filter?: AgentSource
+  onSelect: (agent: AgentDefinitionEntry) => void
+  onCancel?: () => void
+}
+
+type Group = {
+  source: AgentSource
+  label: string
+  entries: AgentDefinitionEntry[]
+}
+
+function entrySource(entry: AgentDefinitionEntry): AgentSource {
+  const kind = entry.source?.kind
+  if (kind === 'user') return 'userSettings'
+  if (kind === 'project') return 'projectSettings'
+  if (kind === 'builtin') return 'built-in'
+  if (kind === 'plugin') return 'plugin'
+  return 'userSettings'
+}
+
+export function AgentsList({ agents, filter = 'all', onSelect, onCancel }: Props) {
+  const [focus, setFocus] = useState(0)
+
+  const filtered = useMemo(() => {
+    if (filter === 'all') return agents
+    return agents.filter(a => entrySource(a) === filter)
+  }, [agents, filter])
+
+  const groups = useMemo<Group[]>(() => {
+    const map = new Map<AgentSource, AgentDefinitionEntry[]>()
+    for (const entry of filtered) {
+      const src = entrySource(entry)
+      if (!map.has(src)) map.set(src, [])
+      map.get(src)!.push(entry)
+    }
+    const order: AgentSource[] = [
+      'built-in',
+      'userSettings',
+      'projectSettings',
+      'localSettings',
+      'policySettings',
+      'flagSettings',
+      'plugin',
+    ]
+    return order
+      .filter(src => map.has(src))
+      .map(src => ({
+        source: src,
+        label: getAgentSourceDisplayName(src),
+        entries: map.get(src)!.slice().sort((a, b) => a.name.localeCompare(b.name)),
+      }))
+  }, [filtered])
+
+  const flat = useMemo(() => {
+    const out: AgentDefinitionEntry[] = []
+    for (const g of groups) out.push(...g.entries)
+    return out
+  }, [groups])
+
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const seq = event.sequence?.length === 1 ? event.sequence : undefined
+    const key = (seq ?? name ?? '').toLowerCase()
+
+    if (name === 'escape') {
+      onCancel?.()
+      return
+    }
+    if (name === 'up' || key === 'k') {
+      setFocus(idx => Math.max(0, idx - 1))
+      return
+    }
+    if (name === 'down' || key === 'j') {
+      setFocus(idx => Math.min(flat.length - 1, idx + 1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      const entry = flat[focus]
+      if (entry) onSelect(entry)
+    }
+  })
+
+  if (flat.length === 0) {
+    return (
+      <box paddingLeft={2}>
+        <text fg={c.dim}>No agents in this scope.</text>
+      </box>
+    )
+  }
+
+  let globalIndex = 0
+  return (
+    <box flexDirection="column">
+      {groups.map(group => (
+        <box key={group.source} flexDirection="column" marginBottom={1}>
+          <box paddingLeft={1}>
+            <strong><text fg={c.accent}>{group.label}</text></strong>
+          </box>
+          {group.entries.map(entry => {
+            const thisIndex = globalIndex++
+            const isFocused = thisIndex === focus
+            return (
+              <box key={`${group.source}:${entry.name}`} flexDirection="row" paddingLeft={2} gap={1}>
+                <text fg={isFocused ? c.accent : c.dim}>
+                  {isFocused ? '\u276F' : ' '}
+                </text>
+                {isFocused ? (
+                  <strong><text fg={c.textBright}>{entry.name}</text></strong>
+                ) : (
+                  <text>{entry.name}</text>
+                )}
+                {entry.description && (
+                  <text fg={c.dim}>— {truncate(entry.description, 60)}</text>
+                )}
+              </box>
+            )
+          })}
+        </box>
+      ))}
+      <box marginTop={1}>
+        <text fg={c.dim}>\u2191/\u2193 select · Enter view · Esc close</text>
+      </box>
+    </box>
+  )
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n - 1) + '\u2026'
+}

--- a/ui/src/components/agents/AgentsMenu.tsx
+++ b/ui/src/components/agents/AgentsMenu.tsx
@@ -1,0 +1,198 @@
+import React, { useCallback, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../../theme.js'
+import type { AgentDefinitionEntry } from '../../ipc/protocol.js'
+import { AgentDetail } from './AgentDetail.js'
+import { AgentEditor } from './AgentEditor.js'
+import { AgentNavigationFooter } from './AgentNavigationFooter.js'
+import { AgentsList } from './AgentsList.js'
+import { CreateAgentWizard } from './new-agent-creation/CreateAgentWizard.js'
+import type { DraftAgent, ModeState } from './types.js'
+import type { ToolSpec } from './ToolSelector.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/agents/AgentsMenu.tsx`.
+ *
+ * Top-level entry point for the agent management UI. Owns the mode
+ * state machine (list → view → edit → create → delete-confirm) and
+ * wires each sub-panel. IPC plumbing (create / save / delete) is
+ * pushed to props so the dialog is transport-agnostic — upstream has
+ * the same structure but with `useSetAppState` mutations instead of
+ * callbacks.
+ */
+
+type Props = {
+  agents: AgentDefinitionEntry[]
+  availableTools: ToolSpec[]
+  onCreate: (draft: DraftAgent) => void
+  onUpdate: (entry: AgentDefinitionEntry, draft: DraftAgent) => void
+  onDelete: (entry: AgentDefinitionEntry) => void
+  onExit: (message?: string) => void
+}
+
+export function AgentsMenu({
+  agents,
+  availableTools,
+  onCreate,
+  onUpdate,
+  onDelete,
+  onExit,
+}: Props) {
+  const [mode, setMode] = useState<ModeState>({ mode: 'list-agents', source: 'all' })
+  const [changes, setChanges] = useState<string[]>([])
+
+  const back = useCallback(() => setMode({ mode: 'list-agents', source: 'all' }), [])
+
+  if (mode.mode === 'list-agents') {
+    return (
+      <box flexDirection="column" gap={1}>
+        <strong><text fg={c.accent}>Agents</text></strong>
+        {changes.length > 0 && (
+          <box flexDirection="column">
+            {changes.map((msg, i) => (
+              <text key={i} fg={c.success}>• {msg}</text>
+            ))}
+          </box>
+        )}
+        <AgentsList
+          agents={agents}
+          filter={mode.source}
+          onSelect={entry =>
+            setMode({ mode: 'view-agent', agent: entry, previousMode: mode })
+          }
+          onCancel={() => onExit()}
+        />
+        <box flexDirection="row" gap={2} marginTop={1}>
+          <text fg={c.dim}>Press <strong>n</strong> to create a new agent</text>
+        </box>
+        <NewAgentListener onNew={() => setMode({ mode: 'create-agent' })} />
+        <AgentNavigationFooter />
+      </box>
+    )
+  }
+
+  if (mode.mode === 'view-agent') {
+    return (
+      <box flexDirection="column" gap={1}>
+        <strong><text fg={c.accent}>{mode.agent.name}</text></strong>
+        <AgentDetail agent={mode.agent} onBack={back} />
+        <box flexDirection="row" gap={2} marginTop={1}>
+          <text fg={c.dim}>e: edit · d: delete · Esc: back</text>
+        </box>
+        <AgentActionListener
+          onEdit={() =>
+            setMode({ mode: 'edit-agent', agent: mode.agent, previousMode: mode })
+          }
+          onDelete={() =>
+            setMode({
+              mode: 'delete-confirm',
+              agent: mode.agent,
+              previousMode: mode,
+            })
+          }
+        />
+      </box>
+    )
+  }
+
+  if (mode.mode === 'edit-agent') {
+    return (
+      <AgentEditor
+        agent={mode.agent}
+        availableTools={availableTools}
+        existingAgents={agents}
+        onSave={draft => {
+          onUpdate(mode.agent, draft)
+          setChanges(prev => [...prev, `Updated ${draft.agentType}`])
+          back()
+        }}
+        onCancel={back}
+      />
+    )
+  }
+
+  if (mode.mode === 'create-agent') {
+    return (
+      <CreateAgentWizard
+        availableTools={availableTools}
+        existingAgents={agents}
+        onDone={draft => {
+          onCreate(draft)
+          setChanges(prev => [...prev, `Created ${draft.agentType}`])
+          back()
+        }}
+        onCancel={back}
+      />
+    )
+  }
+
+  if (mode.mode === 'delete-confirm') {
+    return (
+      <box flexDirection="column" gap={1}>
+        <strong><text fg={c.warning}>Delete agent?</text></strong>
+        <text>
+          Are you sure you want to delete <strong>{mode.agent.name}</strong>?
+        </text>
+        <text fg={c.dim}>This cannot be undone.</text>
+        <DeleteConfirmListener
+          onYes={() => {
+            onDelete(mode.agent)
+            setChanges(prev => [...prev, `Deleted ${mode.agent.name}`])
+            back()
+          }}
+          onNo={back}
+        />
+        <text fg={c.dim}>y: confirm · n / Esc: cancel</text>
+      </box>
+    )
+  }
+
+  return null
+}
+
+// Tiny helper components for isolated keyboard listeners. Using nested
+// `useKeyboard` hooks from each call site keeps the listener active only
+// while that view is mounted, avoiding cross-mode leakage.
+
+function NewAgentListener({ onNew }: { onNew: () => void }) {
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    const seq = event.sequence?.toLowerCase()
+    if (seq === 'n') onNew()
+  })
+  return null
+}
+
+function AgentActionListener({
+  onEdit,
+  onDelete,
+}: {
+  onEdit: () => void
+  onDelete: () => void
+}) {
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    const seq = event.sequence?.toLowerCase()
+    if (seq === 'e') onEdit()
+    else if (seq === 'd') onDelete()
+  })
+  return null
+}
+
+function DeleteConfirmListener({
+  onYes,
+  onNo,
+}: {
+  onYes: () => void
+  onNo: () => void
+}) {
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    const seq = event.sequence?.toLowerCase()
+    if (seq === 'y') onYes()
+    else if (seq === 'n' || event.name === 'escape') onNo()
+  })
+  return null
+}

--- a/ui/src/components/agents/ColorPicker.tsx
+++ b/ui/src/components/agents/ColorPicker.tsx
@@ -1,0 +1,142 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../../theme.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/agents/ColorPicker.tsx`.
+ *
+ * Upstream reaches for the `AGENT_COLORS` constant out of the builtin
+ * tools package; the Lite frontend keeps a local mirror so the picker
+ * compiles without the full tool registry. Selecting `automatic`
+ * returns `undefined` so the backend falls back to its automatic
+ * colour map.
+ */
+
+export type AgentColorName =
+  | 'red'
+  | 'orange'
+  | 'yellow'
+  | 'green'
+  | 'blue'
+  | 'purple'
+  | 'pink'
+  | 'cyan'
+
+type ColorOption = AgentColorName | 'automatic'
+
+const AGENT_COLORS: AgentColorName[] = [
+  'red',
+  'orange',
+  'yellow',
+  'green',
+  'blue',
+  'purple',
+  'pink',
+  'cyan',
+]
+
+const COLOR_OPTIONS: ColorOption[] = ['automatic', ...AGENT_COLORS]
+
+const AGENT_COLOR_HEX: Record<AgentColorName, string> = {
+  red: '#F38BA8',
+  orange: '#FAB387',
+  yellow: '#F9E2AF',
+  green: '#A6E3A1',
+  blue: '#89B4FA',
+  purple: '#CBA6F7',
+  pink: '#F5C2E7',
+  cyan: '#94E2D5',
+}
+
+function capitalize(s: string): string {
+  return s.length === 0 ? s : s[0]!.toUpperCase() + s.slice(1)
+}
+
+type Props = {
+  agentName: string
+  currentColor?: AgentColorName | 'automatic'
+  onConfirm: (color: AgentColorName | undefined) => void
+  onCancel?: () => void
+}
+
+export function ColorPicker({ agentName, currentColor = 'automatic', onConfirm, onCancel }: Props) {
+  const [selected, setSelected] = useState(
+    Math.max(0, COLOR_OPTIONS.findIndex(opt => opt === currentColor)),
+  )
+
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const seq = event.sequence?.length === 1 ? event.sequence : undefined
+    const key = (seq ?? name ?? '').toLowerCase()
+
+    if (name === 'escape') {
+      onCancel?.()
+      return
+    }
+    if (name === 'up' || key === 'k') {
+      setSelected(prev => (prev > 0 ? prev - 1 : COLOR_OPTIONS.length - 1))
+      return
+    }
+    if (name === 'down' || key === 'j') {
+      setSelected(prev => (prev < COLOR_OPTIONS.length - 1 ? prev + 1 : 0))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      const choice = COLOR_OPTIONS[selected]
+      onConfirm(choice === 'automatic' ? undefined : choice)
+    }
+  })
+
+  const previewColor = COLOR_OPTIONS[selected]
+
+  return (
+    <box flexDirection="column" gap={1}>
+      <box flexDirection="column">
+        {COLOR_OPTIONS.map((option, i) => {
+          const isSelected = i === selected
+          return (
+            <box key={option} flexDirection="row" gap={1}>
+              <text fg={isSelected ? c.accent : c.dim}>
+                {isSelected ? '\u276F' : ' '}
+              </text>
+              {option === 'automatic' ? (
+                isSelected ? (
+                  <strong><text>Automatic color</text></strong>
+                ) : (
+                  <text>Automatic color</text>
+                )
+              ) : (
+                <box flexDirection="row" gap={1}>
+                  <text bg={AGENT_COLOR_HEX[option]} fg={c.bg}>
+                    {'  '}
+                  </text>
+                  {isSelected ? (
+                    <strong><text>{capitalize(option)}</text></strong>
+                  ) : (
+                    <text>{capitalize(option)}</text>
+                  )}
+                </box>
+              )}
+            </box>
+          )
+        })}
+      </box>
+
+      <box marginTop={1} flexDirection="row" gap={1}>
+        <text>Preview:</text>
+        {previewColor === undefined || previewColor === 'automatic' ? (
+          <strong><text bg={c.textBright} fg={c.bg}>{' @'}{agentName}{' '}</text></strong>
+        ) : (
+          <strong>
+            <text bg={AGENT_COLOR_HEX[previewColor as AgentColorName]} fg={c.bg}>
+              {' @'}{agentName}{' '}
+            </text>
+          </strong>
+        )}
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/agents/ModelSelector.tsx
+++ b/ui/src/components/agents/ModelSelector.tsx
@@ -1,0 +1,75 @@
+import React, { useMemo } from 'react'
+import { c } from '../../theme.js'
+import { Select } from '../customselect/select.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/agents/ModelSelector.tsx`.
+ *
+ * Upstream loads the catalog via `getAgentModelOptions()` from the
+ * model settings store. Lite keeps a frontend-safe fallback list and
+ * accepts an optional `options` prop so call sites can swap it when a
+ * richer catalog is available.
+ */
+
+const DEFAULT_MODEL_OPTIONS = [
+  { value: 'sonnet', label: 'sonnet', description: 'Balanced reasoning speed' },
+  { value: 'opus', label: 'opus', description: 'Deeper reasoning, higher latency' },
+  { value: 'haiku', label: 'haiku', description: 'Fast, lightweight responses' },
+  { value: 'inherit', label: '(inherit)', description: 'Use the session default' },
+] as const
+
+type ModelOption = {
+  value: string
+  label: string
+  description?: string
+}
+
+type Props = {
+  initialModel?: string
+  options?: ModelOption[]
+  onComplete: (model?: string) => void
+  onCancel?: () => void
+}
+
+export function ModelSelector({
+  initialModel,
+  options,
+  onComplete,
+  onCancel,
+}: Props) {
+  const allOptions = useMemo<ModelOption[]>(() => {
+    const base: ModelOption[] = options
+      ? options.slice()
+      : DEFAULT_MODEL_OPTIONS.map(o => ({ ...o }))
+    if (initialModel && !base.some(o => o.value === initialModel)) {
+      return [
+        {
+          value: initialModel,
+          label: initialModel,
+          description: 'Current model (custom ID)',
+        },
+        ...base,
+      ]
+    }
+    return base
+  }, [initialModel, options])
+
+  return (
+    <box flexDirection="column">
+      <box marginBottom={1}>
+        <text fg={c.dim}>
+          Model determines the agent&apos;s reasoning capabilities and speed.
+        </text>
+      </box>
+      <Select
+        options={allOptions}
+        defaultValue={initialModel ?? 'sonnet'}
+        onChange={value => {
+          onComplete(value === 'inherit' ? undefined : value)
+        }}
+        onCancel={() => (onCancel ? onCancel() : onComplete(undefined))}
+      />
+    </box>
+  )
+}

--- a/ui/src/components/agents/ToolSelector.tsx
+++ b/ui/src/components/agents/ToolSelector.tsx
@@ -1,0 +1,200 @@
+import React, { useMemo, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../../theme.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/agents/ToolSelector.tsx`.
+ *
+ * Upstream's 477-line component carries full tool-permission context,
+ * MCP-tool merging, group-collapse state, and inline `?` help.
+ *
+ * The Lite port keeps the user-facing contract — a scrollable list of
+ * tools with `[ ] / [x]` gutters, grouped by category — plus the three
+ * meta-selections upstream supports:
+ *
+ *  - `all`     (`selected === undefined`)
+ *  - `none`    (empty array)
+ *  - explicit subset
+ *
+ * Groups are collapsed to section headers but don't re-implement the
+ * tree widget — flat list with "(group)" prefix is sufficient for the
+ * Lite UX today. The caller passes the tool catalog so this component
+ * doesn't need to resolve the Tool registry itself.
+ */
+
+export type ToolSpec = {
+  name: string
+  group?: string
+  description?: string
+  /** When true, the tool is always selectable even if `selected === undefined`. */
+  alwaysOn?: boolean
+}
+
+type Props = {
+  tools: ToolSpec[]
+  /** `undefined` = "all tools", `[]` = "no tools", otherwise an explicit subset. */
+  selected: string[] | undefined
+  onComplete: (selected: string[] | undefined) => void
+  onCancel?: () => void
+}
+
+type Mode = 'all' | 'none' | 'subset'
+
+function initialMode(selected: string[] | undefined): Mode {
+  if (selected === undefined) return 'all'
+  if (selected.length === 0) return 'none'
+  return 'subset'
+}
+
+export function ToolSelector({ tools, selected, onComplete, onCancel }: Props) {
+  const [mode, setMode] = useState<Mode>(() => initialMode(selected))
+  const [focus, setFocus] = useState(0)
+  const [explicit, setExplicit] = useState<Set<string>>(
+    () => new Set(selected ?? []),
+  )
+
+  const grouped = useMemo(() => {
+    const grouped: ToolSpec[] = []
+    const withGroup = tools.filter(t => t.group)
+    const groups = new Map<string, ToolSpec[]>()
+    for (const tool of withGroup) {
+      const key = tool.group ?? ''
+      if (!groups.has(key)) groups.set(key, [])
+      groups.get(key)!.push(tool)
+    }
+    for (const [group, members] of groups) {
+      grouped.push({ name: `\u2014 ${group} \u2014`, group, description: '' })
+      grouped.push(...members)
+    }
+    const ungrouped = tools.filter(t => !t.group)
+    if (ungrouped.length > 0) {
+      if (grouped.length > 0) grouped.push({ name: '\u2014 other \u2014', description: '' })
+      grouped.push(...ungrouped)
+    }
+    return grouped
+  }, [tools])
+
+  const rows = useMemo(() => {
+    const meta: Array<{
+      kind: 'meta'
+      key: string
+      label: string
+      mode: Mode
+    }> = [
+      { kind: 'meta', key: 'all', label: 'All tools (inherit)', mode: 'all' },
+      { kind: 'meta', key: 'none', label: 'No tools', mode: 'none' },
+      { kind: 'meta', key: 'subset', label: 'Custom subset', mode: 'subset' },
+    ]
+    const toolRows = grouped.map(t => ({
+      kind: 'tool' as const,
+      key: t.name,
+      tool: t,
+    }))
+    return [...meta, ...toolRows]
+  }, [grouped])
+
+  function toggleFocused() {
+    const row = rows[focus]
+    if (!row) return
+    if (row.kind === 'meta') {
+      setMode(row.mode)
+      return
+    }
+    if (row.tool.group && row.tool.name.startsWith('\u2014')) return
+    if (mode !== 'subset') setMode('subset')
+    setExplicit(prev => {
+      const next = new Set(prev)
+      if (next.has(row.tool.name)) next.delete(row.tool.name)
+      else next.add(row.tool.name)
+      return next
+    })
+  }
+
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const seq = event.sequence?.length === 1 ? event.sequence : undefined
+    const key = (seq ?? name ?? '').toLowerCase()
+
+    if (name === 'escape') {
+      onCancel?.()
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      if (mode === 'all') onComplete(undefined)
+      else if (mode === 'none') onComplete([])
+      else onComplete(Array.from(explicit))
+      return
+    }
+    if (name === 'up' || key === 'k') {
+      setFocus(idx => Math.max(0, idx - 1))
+      return
+    }
+    if (name === 'down' || key === 'j') {
+      setFocus(idx => Math.min(rows.length - 1, idx + 1))
+      return
+    }
+    if (key === ' ' || name === 'tab') {
+      toggleFocused()
+    }
+  })
+
+  return (
+    <box flexDirection="column">
+      {rows.map((row, i) => {
+        const isFocused = i === focus
+        if (row.kind === 'meta') {
+          const active = mode === row.mode
+          return (
+            <box key={row.key} flexDirection="row" gap={1}>
+              <text fg={isFocused ? c.accent : c.dim}>
+                {isFocused ? '\u276F' : ' '}
+              </text>
+              <text fg={active ? c.success : c.dim}>
+                {active ? '\u25CF' : '\u25CB'}
+              </text>
+              {isFocused ? (
+                <strong><text fg={c.textBright}>{row.label}</text></strong>
+              ) : (
+                <text>{row.label}</text>
+              )}
+            </box>
+          )
+        }
+        if (row.tool.name.startsWith('\u2014')) {
+          return (
+            <box key={row.key} paddingLeft={2}>
+              <text fg={c.dim}>{row.tool.name}</text>
+            </box>
+          )
+        }
+        const checked = mode === 'all' || (mode === 'subset' && explicit.has(row.tool.name))
+        return (
+          <box key={row.key} flexDirection="row" gap={1} paddingLeft={2}>
+            <text fg={isFocused ? c.accent : c.dim}>
+              {isFocused ? '\u276F' : ' '}
+            </text>
+            <text fg={checked ? c.success : c.dim}>
+              {checked ? '[\u2713]' : '[ ]'}
+            </text>
+            {isFocused ? (
+              <strong><text fg={c.textBright}>{row.tool.name}</text></strong>
+            ) : (
+              <text>{row.tool.name}</text>
+            )}
+            {row.tool.description && (
+              <text fg={c.dim}>— {row.tool.description}</text>
+            )}
+          </box>
+        )
+      })}
+      <box marginTop={1}>
+        <text fg={c.dim}>
+          Space toggle · Enter confirm · Esc cancel
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/agents/agentFileUtils.ts
+++ b/ui/src/components/agents/agentFileUtils.ts
@@ -1,0 +1,75 @@
+import type { AgentDefinitionEntry } from '../../ipc/protocol.js'
+import { AGENT_PATHS, type AgentSource } from './types.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/agents/agentFileUtils.ts`.
+ *
+ * Upstream reads/writes YAML frontmatter markdown files directly from
+ * the Ink process. The Lite frontend delegates that work to the Rust
+ * backend (see `ipc/protocol.ts:FrontendMessage::agent_command`), so
+ * this module only contains the path / label helpers the UI still uses
+ * locally. IO helpers are stubs whose return values surface via the
+ * backend's response events.
+ */
+
+export function getActualRelativeAgentFilePath(
+  entry: AgentDefinitionEntry,
+): string {
+  if (entry.file_path) return entry.file_path
+  const filename = `${entry.name}.md`
+  if (entry.source?.kind === 'project') {
+    return `${AGENT_PATHS.FOLDER_NAME}/${AGENT_PATHS.AGENTS_DIR}/${filename}`
+  }
+  if (entry.source?.kind === 'user') {
+    return `~/${AGENT_PATHS.FOLDER_NAME}/${AGENT_PATHS.AGENTS_DIR}/${filename}`
+  }
+  return filename
+}
+
+/** The UI layer shouldn't delete files directly — always round-trip
+ *  through the backend. Exposed as a promise-returning helper so call
+ *  sites have a stable shape for future wiring. */
+export async function deleteAgentFromFile(
+  entry: AgentDefinitionEntry,
+  sendCommand: (command: {
+    kind: 'delete'
+    agent_id: string
+    source: AgentSource
+  }) => void,
+): Promise<void> {
+  const source = (entry.source?.kind ?? 'user') as AgentSource
+  sendCommand({
+    kind: 'delete',
+    agent_id: entry.name,
+    source,
+  })
+}
+
+/** Build a short human-readable label for the entry. */
+export function describeAgent(entry: AgentDefinitionEntry): string {
+  const kind = entry.source?.kind ?? 'unknown'
+  return `${entry.name} (${kind})`
+}
+
+/** Given a source kind, return the canonical location label (for the
+ *  `LocationStep` summary line). */
+export function locationLabelForSource(source: AgentSource): string {
+  switch (source) {
+    case 'userSettings':
+      return '~/.claude/agents/'
+    case 'projectSettings':
+    case 'localSettings':
+      return '.claude/agents/'
+    case 'policySettings':
+      return '(policy)'
+    case 'flagSettings':
+      return '(flag)'
+    case 'plugin':
+      return '(plugin)'
+    case 'built-in':
+      return '(built-in)'
+    case 'all':
+      return ''
+  }
+}

--- a/ui/src/components/agents/generateAgent.ts
+++ b/ui/src/components/agents/generateAgent.ts
@@ -1,0 +1,60 @@
+import type { DraftAgent } from './types.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/agents/generateAgent.ts`.
+ *
+ * Upstream calls the Anthropic API to write a system prompt from the
+ * user's description. In Lite we delegate to the backend; callers send
+ * an `agent_command` with `kind: 'generate'` and the backend streams a
+ * response. This module exposes the helpers that assemble the draft
+ * payload + parse a streamed chunk back into the editor buffer.
+ */
+
+const GENERATE_INSTRUCTIONS = `
+You are helping a developer create a Claude Code sub-agent.
+Given the user's natural-language description, produce:
+- a short agent name in kebab-case,
+- a one-sentence "when to use" blurb,
+- a concise system prompt (20-200 words).
+Return ONLY valid JSON of shape { name, description, systemPrompt }.
+`.trim()
+
+export function buildGeneratePayload(description: string): {
+  instructions: string
+  description: string
+} {
+  return {
+    instructions: GENERATE_INSTRUCTIONS,
+    description: description.trim(),
+  }
+}
+
+/**
+ * Incrementally merge a streamed JSON chunk into the in-progress draft.
+ * Upstream uses a proper streaming parser; this helper takes the last
+ * snapshot of buffered text and attempts a full `JSON.parse`, ignoring
+ * parse errors while the JSON is still incomplete.
+ */
+export function applyGeneratedChunk(
+  draft: DraftAgent,
+  buffer: string,
+): DraftAgent {
+  const trimmed = buffer.trim()
+  if (!trimmed.startsWith('{')) return draft
+  try {
+    const parsed = JSON.parse(trimmed) as Partial<{
+      name: string
+      description: string
+      systemPrompt: string
+    }>
+    return {
+      ...draft,
+      agentType: parsed.name ?? draft.agentType,
+      description: parsed.description ?? draft.description,
+      systemPrompt: parsed.systemPrompt ?? draft.systemPrompt,
+    }
+  } catch {
+    return draft
+  }
+}

--- a/ui/src/components/agents/new-agent-creation/CreateAgentWizard.tsx
+++ b/ui/src/components/agents/new-agent-creation/CreateAgentWizard.tsx
@@ -1,0 +1,233 @@
+import React, { useCallback, useState } from 'react'
+import { c } from '../../../theme.js'
+import type { AgentDefinitionEntry } from '../../../ipc/protocol.js'
+import type { ToolSpec } from '../ToolSelector.js'
+import type { DraftAgent } from '../types.js'
+import { ColorStep } from './wizard-steps/ColorStep.js'
+import { ConfirmStep } from './wizard-steps/ConfirmStep.js'
+import { ConfirmStepWrapper } from './wizard-steps/ConfirmStepWrapper.js'
+import { DescriptionStep } from './wizard-steps/DescriptionStep.js'
+import { GenerateStep } from './wizard-steps/GenerateStep.js'
+import { LocationStep } from './wizard-steps/LocationStep.js'
+import { MemoryStep } from './wizard-steps/MemoryStep.js'
+import { MethodStep } from './wizard-steps/MethodStep.js'
+import { ModelStep } from './wizard-steps/ModelStep.js'
+import { PromptStep } from './wizard-steps/PromptStep.js'
+import { ToolsStep } from './wizard-steps/ToolsStep.js'
+import { TypeStep } from './wizard-steps/TypeStep.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/agents/new-agent-creation/CreateAgentWizard.tsx`.
+ *
+ * Sequences the twelve wizard steps. Upstream composes the same order —
+ * `location → method → (generate | type → description → prompt) →
+ * tools → model → color → memory → confirm`. The Lite port keeps the
+ * step IDs and signature so each step component is swap-compatible
+ * with upstream.
+ */
+
+type StepId =
+  | 'location'
+  | 'method'
+  | 'generate'
+  | 'type'
+  | 'description'
+  | 'prompt'
+  | 'tools'
+  | 'model'
+  | 'color'
+  | 'memory'
+  | 'confirm'
+
+type Props = {
+  availableTools: ToolSpec[]
+  existingAgents: AgentDefinitionEntry[]
+  onDone: (draft: DraftAgent) => void
+  onCancel: () => void
+}
+
+const EMPTY_DRAFT: DraftAgent = {
+  agentType: '',
+  description: '',
+  systemPrompt: '',
+  tools: undefined,
+  model: undefined,
+  color: undefined,
+  memory: undefined,
+  source: 'projectSettings',
+}
+
+export function CreateAgentWizard({
+  availableTools,
+  existingAgents,
+  onDone,
+  onCancel,
+}: Props) {
+  const [draft, setDraft] = useState<DraftAgent>(EMPTY_DRAFT)
+  const [step, setStep] = useState<StepId>('location')
+  const [method, setMethod] = useState<'generate' | 'manual'>('manual')
+
+  const update = useCallback((patch: Partial<DraftAgent>) => {
+    setDraft(prev => ({ ...prev, ...patch }))
+  }, [])
+
+  const go = (next: StepId) => setStep(next)
+
+  const footer = (
+    <box marginTop={1}>
+      <text fg={c.dim}>Esc to cancel · Enter to advance</text>
+    </box>
+  )
+
+  if (step === 'location') {
+    return (
+      <box flexDirection="column">
+        <LocationStep
+          value={draft.source}
+          onSelect={source => {
+            update({ source })
+            go('method')
+          }}
+          onCancel={onCancel}
+        />
+        {footer}
+      </box>
+    )
+  }
+
+  if (step === 'method') {
+    return (
+      <box flexDirection="column">
+        <MethodStep
+          value={method}
+          onSelect={choice => {
+            setMethod(choice)
+            go(choice === 'generate' ? 'generate' : 'type')
+          }}
+          onCancel={onCancel}
+        />
+        {footer}
+      </box>
+    )
+  }
+
+  if (step === 'generate') {
+    return (
+      <GenerateStep
+        description={draft.description}
+        onApply={patch => {
+          update(patch)
+          go('tools')
+        }}
+        onCancel={onCancel}
+      />
+    )
+  }
+
+  if (step === 'type') {
+    return (
+      <TypeStep
+        existingAgents={existingAgents}
+        value={draft.agentType}
+        onSubmit={agentType => {
+          update({ agentType })
+          go('description')
+        }}
+        onCancel={onCancel}
+      />
+    )
+  }
+
+  if (step === 'description') {
+    return (
+      <DescriptionStep
+        value={draft.description}
+        onSubmit={description => {
+          update({ description })
+          go('prompt')
+        }}
+        onCancel={onCancel}
+      />
+    )
+  }
+
+  if (step === 'prompt') {
+    return (
+      <PromptStep
+        value={draft.systemPrompt}
+        onSubmit={systemPrompt => {
+          update({ systemPrompt })
+          go('tools')
+        }}
+        onCancel={onCancel}
+      />
+    )
+  }
+
+  if (step === 'tools') {
+    return (
+      <ToolsStep
+        availableTools={availableTools}
+        selected={draft.tools}
+        onSubmit={tools => {
+          update({ tools })
+          go('model')
+        }}
+        onCancel={onCancel}
+      />
+    )
+  }
+
+  if (step === 'model') {
+    return (
+      <ModelStep
+        value={draft.model}
+        onSubmit={model => {
+          update({ model })
+          go('color')
+        }}
+        onCancel={onCancel}
+      />
+    )
+  }
+
+  if (step === 'color') {
+    return (
+      <ColorStep
+        agentName={draft.agentType || 'agent'}
+        value={draft.color}
+        onSubmit={color => {
+          update({ color: color ?? undefined })
+          go('memory')
+        }}
+        onCancel={onCancel}
+      />
+    )
+  }
+
+  if (step === 'memory') {
+    return (
+      <MemoryStep
+        value={draft.memory}
+        onSubmit={memory => {
+          update({ memory })
+          go('confirm')
+        }}
+        onCancel={onCancel}
+      />
+    )
+  }
+
+  return (
+    <ConfirmStepWrapper
+      availableTools={availableTools.map(t => t.name)}
+      existingAgents={existingAgents}
+      draft={draft}
+      onConfirm={() => onDone(draft)}
+      onBack={() => go('memory')}
+    >
+      <ConfirmStep draft={draft} />
+    </ConfirmStepWrapper>
+  )
+}

--- a/ui/src/components/agents/new-agent-creation/wizard-steps/ColorStep.tsx
+++ b/ui/src/components/agents/new-agent-creation/wizard-steps/ColorStep.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { c } from '../../../../theme.js'
+import { ColorPicker, type AgentColorName } from '../../ColorPicker.js'
+
+/**
+ * Lite-native port of upstream's `wizard-steps/ColorStep.tsx`. Wraps
+ * the shared `ColorPicker` so the wizard owns the title + help text
+ * and the picker manages the key state.
+ */
+
+type Props = {
+  agentName: string
+  value?: string
+  onSubmit: (color?: AgentColorName) => void
+  onCancel: () => void
+}
+
+export function ColorStep({ agentName, value, onSubmit, onCancel }: Props) {
+  return (
+    <box flexDirection="column" gap={1}>
+      <strong><text fg={c.accent}>Color</text></strong>
+      <text fg={c.dim}>
+        Used when this agent is mentioned in @-completions and the transcript.
+      </text>
+      <ColorPicker
+        agentName={agentName}
+        currentColor={(value as AgentColorName | undefined) ?? 'automatic'}
+        onConfirm={onSubmit}
+        onCancel={onCancel}
+      />
+    </box>
+  )
+}

--- a/ui/src/components/agents/new-agent-creation/wizard-steps/ConfirmStep.tsx
+++ b/ui/src/components/agents/new-agent-creation/wizard-steps/ConfirmStep.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { c } from '../../../../theme.js'
+import type { DraftAgent } from '../../types.js'
+import { getAgentSourceDisplayName } from '../../utils.js'
+
+/**
+ * Lite-native port of upstream's `wizard-steps/ConfirmStep.tsx`.
+ * Read-only review of the draft agent. The actual keyboard flow
+ * (y/n confirm) lives in `ConfirmStepWrapper` so the read-only
+ * preview can be reused outside the wizard.
+ */
+
+type Props = {
+  draft: DraftAgent
+}
+
+function summarizeTools(tools: string[] | undefined): string {
+  if (tools === undefined) return 'All tools (inherit)'
+  if (tools.length === 0) return 'No tools'
+  return tools.join(', ')
+}
+
+export function ConfirmStep({ draft }: Props) {
+  return (
+    <box flexDirection="column" gap={1}>
+      <strong><text fg={c.accent}>Review</text></strong>
+
+      <Row label="Location" value={getAgentSourceDisplayName(draft.source)} />
+      <Row label="Name" value={draft.agentType} />
+      <Row label="Description" value={draft.description} />
+      <Row label="Tools" value={summarizeTools(draft.tools)} />
+      <Row label="Model" value={draft.model ?? '(inherit)'} />
+      <Row label="Color" value={draft.color ?? 'automatic'} />
+      <Row label="Memory" value={draft.memory ?? 'inherit'} />
+
+      <box flexDirection="column" marginTop={1}>
+        <strong><text>System prompt</text></strong>
+        <box paddingLeft={2}>
+          <text fg={c.dim}>
+            {truncate(draft.systemPrompt, 400) || '(empty)'}
+          </text>
+        </box>
+      </box>
+    </box>
+  )
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <box flexDirection="row" gap={1}>
+      <strong><text>{label}:</text></strong>
+      <text>{value || '—'}</text>
+    </box>
+  )
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n - 1) + '\u2026'
+}

--- a/ui/src/components/agents/new-agent-creation/wizard-steps/ConfirmStepWrapper.tsx
+++ b/ui/src/components/agents/new-agent-creation/wizard-steps/ConfirmStepWrapper.tsx
@@ -1,0 +1,78 @@
+import React, { type ReactNode } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../../../../theme.js'
+import type { AgentDefinitionEntry } from '../../../../ipc/protocol.js'
+import type { DraftAgent } from '../../types.js'
+import { validateAgent } from '../../validateAgent.js'
+
+/**
+ * Lite-native port of upstream's `wizard-steps/ConfirmStepWrapper.tsx`.
+ *
+ * Wraps `ConfirmStep` in a keyboard-enabled shell. Upstream makes the
+ * Confirm page interactive (retry generation / go back / commit); the
+ * Lite version exposes the same entry points via `onConfirm` and
+ * `onBack`, and blocks commit when validation fails.
+ */
+
+type Props = {
+  draft: DraftAgent
+  availableTools: string[]
+  existingAgents: AgentDefinitionEntry[]
+  onConfirm: () => void
+  onBack: () => void
+  children: ReactNode
+}
+
+export function ConfirmStepWrapper({
+  draft,
+  availableTools,
+  existingAgents,
+  onConfirm,
+  onBack,
+  children,
+}: Props) {
+  const validation = validateAgent(draft, availableTools, existingAgents)
+
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const seq = event.sequence?.toLowerCase()
+    if (name === 'escape' || seq === 'b') {
+      onBack()
+      return
+    }
+    if (seq === 'y' || name === 'return' || name === 'enter') {
+      if (validation.isValid) onConfirm()
+    }
+  })
+
+  return (
+    <box flexDirection="column" gap={1}>
+      {children}
+
+      {validation.errors.length > 0 && (
+        <box flexDirection="column" marginTop={1}>
+          {validation.errors.map((err, i) => (
+            <text key={i} fg={c.error}>• {err}</text>
+          ))}
+        </box>
+      )}
+      {validation.warnings.length > 0 && (
+        <box flexDirection="column">
+          {validation.warnings.map((warn, i) => (
+            <text key={i} fg={c.warning}>• {warn}</text>
+          ))}
+        </box>
+      )}
+
+      <box marginTop={1}>
+        <text fg={c.dim}>
+          {validation.isValid
+            ? 'Enter / y to create · b to go back · Esc to cancel'
+            : 'Fix errors above to create · b to go back · Esc to cancel'}
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/agents/new-agent-creation/wizard-steps/DescriptionStep.tsx
+++ b/ui/src/components/agents/new-agent-creation/wizard-steps/DescriptionStep.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../../../../theme.js'
+
+/**
+ * Lite-native port of upstream's `wizard-steps/DescriptionStep.tsx`.
+ * The description tells the orchestrator when to delegate to this
+ * agent. 10+ chars is recommended.
+ */
+
+type Props = {
+  value: string
+  onSubmit: (description: string) => void
+  onCancel: () => void
+}
+
+export function DescriptionStep({ value, onSubmit, onCancel }: Props) {
+  const [input, setInput] = useState(value)
+
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const seq = event.sequence
+
+    if (name === 'escape') {
+      onCancel()
+      return
+    }
+    if (name === 'backspace' || name === 'delete') {
+      setInput(v => v.slice(0, -1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      if (input.trim().length > 0) onSubmit(input.trim())
+      return
+    }
+    if (seq && seq.length === 1 && !event.ctrl && !event.meta) {
+      setInput(v => v + seq)
+    }
+  })
+
+  return (
+    <box flexDirection="column" gap={1}>
+      <strong><text fg={c.accent}>When should Claude use this agent?</text></strong>
+      <text fg={c.dim}>
+        One or two sentences describing the trigger conditions.
+      </text>
+      <box flexDirection="row" gap={1}>
+        <text fg={c.accent}>{'\u276F'}</text>
+        <text>{input || ' '}</text>
+        <text fg={c.accent}>{'\u2588'}</text>
+      </box>
+      {input.length < 10 && input.length > 0 && (
+        <text fg={c.warning}>Try to be more descriptive (at least 10 chars).</text>
+      )}
+    </box>
+  )
+}

--- a/ui/src/components/agents/new-agent-creation/wizard-steps/GenerateStep.tsx
+++ b/ui/src/components/agents/new-agent-creation/wizard-steps/GenerateStep.tsx
@@ -1,0 +1,112 @@
+import React, { useEffect, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../../../../theme.js'
+import { Spinner } from '../../../Spinner.js'
+import { applyGeneratedChunk } from '../../generateAgent.js'
+import type { DraftAgent } from '../../types.js'
+
+/**
+ * Lite-native port of upstream's `wizard-steps/GenerateStep.tsx`.
+ *
+ * Upstream owns the full API streaming lifecycle here. In Lite the
+ * backend performs the generation — this step accepts the description
+ * input, lets the user press Enter to kick off generation, and then
+ * renders whatever the caller feeds back via the `stream` prop. The
+ * caller is responsible for wiring `stream` to an IPC subscription.
+ */
+
+type Props = {
+  description: string
+  /** Optional live-updating buffer of the partial generation result.
+   *  When defined, the step renders a streaming preview. */
+  stream?: string
+  /** Called when the user triggers generation. Caller spins up the
+   *  backend request and feeds updates back through `stream`. */
+  onGenerate?: (description: string) => void
+  /** Invoked once the stream settles. Receives the parsed patch. */
+  onApply: (patch: Partial<DraftAgent>) => void
+  onCancel: () => void
+}
+
+export function GenerateStep({
+  description,
+  stream,
+  onGenerate,
+  onApply,
+  onCancel,
+}: Props) {
+  const [input, setInput] = useState(description)
+  const [isGenerating, setIsGenerating] = useState(false)
+
+  useEffect(() => {
+    if (stream && stream.trim().length > 0) {
+      const patch = applyGeneratedChunk(
+        { agentType: '', description: '', systemPrompt: '' } as DraftAgent,
+        stream,
+      )
+      if (patch.agentType || patch.systemPrompt) {
+        setIsGenerating(false)
+      }
+    }
+  }, [stream])
+
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const seq = event.sequence
+
+    if (name === 'escape') {
+      onCancel()
+      return
+    }
+    if (isGenerating) return
+
+    if (name === 'backspace' || name === 'delete') {
+      setInput(v => v.slice(0, -1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      if (input.trim().length === 0) return
+      if (stream) {
+        const patch = applyGeneratedChunk(
+          { agentType: '', description: input, systemPrompt: '' } as DraftAgent,
+          stream,
+        )
+        onApply({
+          agentType: patch.agentType,
+          description: patch.description || input,
+          systemPrompt: patch.systemPrompt,
+        })
+        return
+      }
+      setIsGenerating(true)
+      onGenerate?.(input)
+      return
+    }
+    if (seq && seq.length === 1 && !event.ctrl && !event.meta) {
+      setInput(v => v + seq)
+    }
+  })
+
+  return (
+    <box flexDirection="column" gap={1}>
+      <strong><text fg={c.accent}>Describe the agent</text></strong>
+      <text fg={c.dim}>
+        In natural language, say what this agent should do. Enter to generate.
+      </text>
+      <box flexDirection="row" gap={1}>
+        <text fg={c.accent}>{'\u276F'}</text>
+        <text>{input || ' '}</text>
+        <text fg={c.accent}>{'\u2588'}</text>
+      </box>
+      {isGenerating && <Spinner label="Generating…" />}
+      {stream && (
+        <box flexDirection="column" marginTop={1} paddingLeft={2}>
+          <text fg={c.dim}>Preview:</text>
+          <text>{stream.slice(0, 400)}</text>
+        </box>
+      )}
+    </box>
+  )
+}

--- a/ui/src/components/agents/new-agent-creation/wizard-steps/LocationStep.tsx
+++ b/ui/src/components/agents/new-agent-creation/wizard-steps/LocationStep.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../../../../theme.js'
+import type { AgentSource } from '../../types.js'
+import { locationLabelForSource } from '../../agentFileUtils.js'
+
+/**
+ * Lite-native port of upstream's
+ * `wizard-steps/LocationStep.tsx`. Asks whether the new agent should
+ * live under project (`.claude/agents/`) or user (`~/.claude/agents/`)
+ * scope. Upstream exposes more sources (policy / local / flag) — the
+ * Lite wizard only writes to user or project.
+ */
+
+type Option = {
+  value: AgentSource
+  label: string
+  description: string
+}
+
+const OPTIONS: Option[] = [
+  {
+    value: 'projectSettings',
+    label: 'Project',
+    description: '.claude/agents/ (checked into the repo)',
+  },
+  {
+    value: 'userSettings',
+    label: 'User',
+    description: '~/.claude/agents/ (available across every project)',
+  },
+]
+
+type Props = {
+  value: AgentSource
+  onSelect: (source: AgentSource) => void
+  onCancel: () => void
+}
+
+export function LocationStep({ value, onSelect, onCancel }: Props) {
+  const [focus, setFocus] = useState(() =>
+    Math.max(0, OPTIONS.findIndex(o => o.value === value)),
+  )
+
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    if (name === 'escape') {
+      onCancel()
+      return
+    }
+    if (name === 'up') setFocus(idx => Math.max(0, idx - 1))
+    else if (name === 'down') setFocus(idx => Math.min(OPTIONS.length - 1, idx + 1))
+    else if (name === 'return' || name === 'enter') {
+      onSelect(OPTIONS[focus]!.value)
+    }
+  })
+
+  return (
+    <box flexDirection="column" gap={1}>
+      <strong><text fg={c.accent}>Where should this agent live?</text></strong>
+      <box flexDirection="column">
+        {OPTIONS.map((opt, i) => {
+          const isFocused = i === focus
+          return (
+            <box key={opt.value} flexDirection="column">
+              <box flexDirection="row" gap={1}>
+                <text fg={isFocused ? c.accent : c.dim}>
+                  {isFocused ? '\u276F' : ' '}
+                </text>
+                {isFocused ? (
+                  <strong><text fg={c.textBright}>{opt.label}</text></strong>
+                ) : (
+                  <text>{opt.label}</text>
+                )}
+                <text fg={c.dim}>— {locationLabelForSource(opt.value)}</text>
+              </box>
+              <box paddingLeft={3}>
+                <text fg={c.dim}>{opt.description}</text>
+              </box>
+            </box>
+          )
+        })}
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/agents/new-agent-creation/wizard-steps/MemoryStep.tsx
+++ b/ui/src/components/agents/new-agent-creation/wizard-steps/MemoryStep.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../../../../theme.js'
+
+/**
+ * Lite-native port of upstream's `wizard-steps/MemoryStep.tsx`. The
+ * three upstream memory scopes are `session`, `project`, and
+ * `inherit`; project memory is the most common default.
+ */
+
+type MemoryScope = 'session' | 'project' | 'inherit'
+
+const OPTIONS: Array<{ value: MemoryScope; label: string; description: string }> = [
+  {
+    value: 'inherit',
+    label: 'Inherit',
+    description: 'Use the same scope as the orchestrator.',
+  },
+  {
+    value: 'session',
+    label: 'Session',
+    description: 'Forget everything between sessions.',
+  },
+  {
+    value: 'project',
+    label: 'Project',
+    description: 'Persist learnings inside .claude/ memory for this repo.',
+  },
+]
+
+type Props = {
+  value?: string
+  onSubmit: (memory?: string) => void
+  onCancel: () => void
+}
+
+export function MemoryStep({ value, onSubmit, onCancel }: Props) {
+  const [focus, setFocus] = useState(() => {
+    const idx = OPTIONS.findIndex(o => o.value === value)
+    return idx >= 0 ? idx : 0
+  })
+
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    if (name === 'escape') {
+      onCancel()
+      return
+    }
+    if (name === 'up') setFocus(idx => Math.max(0, idx - 1))
+    else if (name === 'down') setFocus(idx => Math.min(OPTIONS.length - 1, idx + 1))
+    else if (name === 'return' || name === 'enter') {
+      const pick = OPTIONS[focus]!.value
+      onSubmit(pick === 'inherit' ? undefined : pick)
+    }
+  })
+
+  return (
+    <box flexDirection="column" gap={1}>
+      <strong><text fg={c.accent}>Memory scope</text></strong>
+      {OPTIONS.map((opt, i) => {
+        const isFocused = i === focus
+        return (
+          <box key={opt.value} flexDirection="column">
+            <box flexDirection="row" gap={1}>
+              <text fg={isFocused ? c.accent : c.dim}>
+                {isFocused ? '\u276F' : ' '}
+              </text>
+              {isFocused ? (
+                <strong><text fg={c.textBright}>{opt.label}</text></strong>
+              ) : (
+                <text>{opt.label}</text>
+              )}
+            </box>
+            <box paddingLeft={3}>
+              <text fg={c.dim}>{opt.description}</text>
+            </box>
+          </box>
+        )
+      })}
+    </box>
+  )
+}

--- a/ui/src/components/agents/new-agent-creation/wizard-steps/MethodStep.tsx
+++ b/ui/src/components/agents/new-agent-creation/wizard-steps/MethodStep.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../../../../theme.js'
+
+/**
+ * Lite-native port of upstream's `wizard-steps/MethodStep.tsx`. Pick
+ * between auto-generating the agent from a description or filling it
+ * in manually.
+ */
+
+type Method = 'generate' | 'manual'
+
+const OPTIONS: Array<{ value: Method; label: string; description: string }> = [
+  {
+    value: 'generate',
+    label: 'Generate from description',
+    description: 'Let Claude draft the name + system prompt for you.',
+  },
+  {
+    value: 'manual',
+    label: 'Fill in manually',
+    description: 'Enter each field yourself.',
+  },
+]
+
+type Props = {
+  value: Method
+  onSelect: (method: Method) => void
+  onCancel: () => void
+}
+
+export function MethodStep({ value, onSelect, onCancel }: Props) {
+  const [focus, setFocus] = useState(() =>
+    Math.max(0, OPTIONS.findIndex(o => o.value === value)),
+  )
+
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    if (name === 'escape') {
+      onCancel()
+      return
+    }
+    if (name === 'up') setFocus(idx => Math.max(0, idx - 1))
+    else if (name === 'down') setFocus(idx => Math.min(OPTIONS.length - 1, idx + 1))
+    else if (name === 'return' || name === 'enter') {
+      onSelect(OPTIONS[focus]!.value)
+    }
+  })
+
+  return (
+    <box flexDirection="column" gap={1}>
+      <strong><text fg={c.accent}>How would you like to create this agent?</text></strong>
+      {OPTIONS.map((opt, i) => {
+        const isFocused = i === focus
+        return (
+          <box key={opt.value} flexDirection="column">
+            <box flexDirection="row" gap={1}>
+              <text fg={isFocused ? c.accent : c.dim}>
+                {isFocused ? '\u276F' : ' '}
+              </text>
+              {isFocused ? (
+                <strong><text fg={c.textBright}>{opt.label}</text></strong>
+              ) : (
+                <text>{opt.label}</text>
+              )}
+            </box>
+            <box paddingLeft={3}>
+              <text fg={c.dim}>{opt.description}</text>
+            </box>
+          </box>
+        )
+      })}
+    </box>
+  )
+}

--- a/ui/src/components/agents/new-agent-creation/wizard-steps/ModelStep.tsx
+++ b/ui/src/components/agents/new-agent-creation/wizard-steps/ModelStep.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { c } from '../../../../theme.js'
+import { ModelSelector } from '../../ModelSelector.js'
+
+/**
+ * Lite-native port of upstream's `wizard-steps/ModelStep.tsx`. Thin
+ * wrapper around `ModelSelector`.
+ */
+
+type Props = {
+  value?: string
+  onSubmit: (model?: string) => void
+  onCancel: () => void
+}
+
+export function ModelStep({ value, onSubmit, onCancel }: Props) {
+  return (
+    <box flexDirection="column" gap={1}>
+      <strong><text fg={c.accent}>Model</text></strong>
+      <ModelSelector
+        initialModel={value}
+        onComplete={onSubmit}
+        onCancel={onCancel}
+      />
+    </box>
+  )
+}

--- a/ui/src/components/agents/new-agent-creation/wizard-steps/PromptStep.tsx
+++ b/ui/src/components/agents/new-agent-creation/wizard-steps/PromptStep.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../../../../theme.js'
+
+/**
+ * Lite-native port of upstream's `wizard-steps/PromptStep.tsx`. A
+ * multi-line system-prompt editor. Enter commits; Shift+Enter inserts
+ * a newline to match upstream's keybinding.
+ */
+
+type Props = {
+  value: string
+  onSubmit: (systemPrompt: string) => void
+  onCancel: () => void
+}
+
+export function PromptStep({ value, onSubmit, onCancel }: Props) {
+  const [input, setInput] = useState(value)
+
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const seq = event.sequence
+
+    if (name === 'escape') {
+      onCancel()
+      return
+    }
+    if (name === 'backspace' || name === 'delete') {
+      setInput(v => v.slice(0, -1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      if (event.shift) {
+        setInput(v => `${v}\n`)
+        return
+      }
+      if (input.trim().length >= 20) onSubmit(input.trim())
+      return
+    }
+    if (seq && seq.length === 1 && !event.ctrl && !event.meta) {
+      setInput(v => v + seq)
+    }
+  })
+
+  const lines = input.length > 0 ? input.split('\n') : [' ']
+
+  return (
+    <box flexDirection="column" gap={1}>
+      <strong><text fg={c.accent}>System prompt</text></strong>
+      <text fg={c.dim}>
+        At least 20 characters. Shift+Enter for newline, Enter to submit.
+      </text>
+      <box flexDirection="column">
+        {lines.map((line, i) => (
+          <box key={i} flexDirection="row" gap={1}>
+            <text fg={c.accent}>{i === 0 ? '\u276F' : ' '}</text>
+            <text>{line || ' '}</text>
+            {i === lines.length - 1 && <text fg={c.accent}>{'\u2588'}</text>}
+          </box>
+        ))}
+      </box>
+      {input.length > 0 && input.trim().length < 20 && (
+        <text fg={c.warning}>System prompt is too short (minimum 20 characters).</text>
+      )}
+    </box>
+  )
+}

--- a/ui/src/components/agents/new-agent-creation/wizard-steps/ToolsStep.tsx
+++ b/ui/src/components/agents/new-agent-creation/wizard-steps/ToolsStep.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { c } from '../../../../theme.js'
+import { ToolSelector, type ToolSpec } from '../../ToolSelector.js'
+
+/**
+ * Lite-native port of upstream's `wizard-steps/ToolsStep.tsx`. Thin
+ * wizard wrapper over `ToolSelector` — the multi-select list component
+ * owns all the actual interaction state.
+ */
+
+type Props = {
+  availableTools: ToolSpec[]
+  selected: string[] | undefined
+  onSubmit: (tools: string[] | undefined) => void
+  onCancel: () => void
+}
+
+export function ToolsStep({ availableTools, selected, onSubmit, onCancel }: Props) {
+  return (
+    <box flexDirection="column" gap={1}>
+      <strong><text fg={c.accent}>Tools</text></strong>
+      <text fg={c.dim}>
+        Choose which tools this agent can call. "All tools" inherits the orchestrator set.
+      </text>
+      <ToolSelector
+        tools={availableTools}
+        selected={selected}
+        onComplete={onSubmit}
+        onCancel={onCancel}
+      />
+    </box>
+  )
+}

--- a/ui/src/components/agents/new-agent-creation/wizard-steps/TypeStep.tsx
+++ b/ui/src/components/agents/new-agent-creation/wizard-steps/TypeStep.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../../../../theme.js'
+import type { AgentDefinitionEntry } from '../../../../ipc/protocol.js'
+import { validateAgentType } from '../../validateAgent.js'
+
+/**
+ * Lite-native port of upstream's `wizard-steps/TypeStep.tsx`. Collects
+ * the agent's kebab-case name, enforces the same regex upstream uses,
+ * and flags collisions against existing agents.
+ */
+
+type Props = {
+  value: string
+  existingAgents: AgentDefinitionEntry[]
+  onSubmit: (agentType: string) => void
+  onCancel: () => void
+}
+
+export function TypeStep({ value, existingAgents, onSubmit, onCancel }: Props) {
+  const [input, setInput] = useState(value)
+
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const seq = event.sequence
+
+    if (name === 'escape') {
+      onCancel()
+      return
+    }
+    if (name === 'backspace' || name === 'delete') {
+      setInput(v => v.slice(0, -1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      if (!validateAgentType(input) && !existingAgents.some(a => a.name === input)) {
+        onSubmit(input)
+      }
+      return
+    }
+    if (seq && seq.length === 1 && !event.ctrl && !event.meta) {
+      setInput(v => v + seq)
+    }
+  })
+
+  const typeError = validateAgentType(input)
+  const duplicate = existingAgents.some(a => a.name === input)
+
+  return (
+    <box flexDirection="column" gap={1}>
+      <strong><text fg={c.accent}>Agent name</text></strong>
+      <text fg={c.dim}>
+        Kebab-case, 3–50 characters. This is how the orchestrator delegates to it.
+      </text>
+      <box flexDirection="row" gap={1}>
+        <text fg={c.accent}>{'\u276F'}</text>
+        <text>{input || ' '}</text>
+        <text fg={c.accent}>{'\u2588'}</text>
+      </box>
+      {typeError && <text fg={c.error}>{typeError}</text>}
+      {!typeError && duplicate && (
+        <text fg={c.error}>An agent named "{input}" already exists.</text>
+      )}
+      {!typeError && !duplicate && input.length > 0 && (
+        <text fg={c.success}>Enter to accept this name.</text>
+      )}
+    </box>
+  )
+}

--- a/ui/src/components/agents/types.ts
+++ b/ui/src/components/agents/types.ts
@@ -1,0 +1,67 @@
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/agents/types.ts`.
+ *
+ * Upstream types hang off internal Ink/Tool-system modules. The Lite
+ * port re-expresses them against the IPC `AgentDefinitionEntry` shape
+ * the backend already broadcasts, so the frontend doesn't need to
+ * re-implement the `AgentDefinition` class.
+ */
+
+import type { AgentDefinitionEntry } from '../../ipc/protocol.js'
+
+export const AGENT_PATHS = {
+  FOLDER_NAME: '.claude',
+  AGENTS_DIR: 'agents',
+} as const
+
+/**
+ * A scope identifier. Matches upstream's settings-source strings, plus
+ * synthetic `all` / `built-in` / `plugin` aggregates used by the list
+ * view.
+ */
+export type AgentSource =
+  | 'userSettings'
+  | 'projectSettings'
+  | 'policySettings'
+  | 'localSettings'
+  | 'flagSettings'
+  | 'plugin'
+  | 'built-in'
+  | 'all'
+
+type WithPreviousMode = { previousMode: ModeState }
+type WithAgent = { agent: AgentDefinitionEntry }
+
+export type ModeState =
+  | { mode: 'main-menu' }
+  | { mode: 'list-agents'; source: AgentSource }
+  | ({ mode: 'agent-menu' } & WithAgent & WithPreviousMode)
+  | ({ mode: 'view-agent' } & WithAgent & WithPreviousMode)
+  | { mode: 'create-agent' }
+  | ({ mode: 'edit-agent' } & WithAgent & WithPreviousMode)
+  | ({ mode: 'delete-confirm' } & WithAgent & WithPreviousMode)
+
+export type AgentValidationResult = {
+  isValid: boolean
+  warnings: string[]
+  errors: string[]
+}
+
+/**
+ * The shape that wizard steps assemble incrementally before sending a
+ * `create` IPC message. Matches upstream's `CustomAgentDefinition`
+ * minus the disk-writer fields.
+ */
+export type DraftAgent = {
+  agentType: string
+  description: string
+  systemPrompt: string
+  tools?: string[]
+  model?: string
+  color?: string
+  memory?: string
+  permissionMode?: string
+  /** Source the agent should be written to (user / project / etc). */
+  source: AgentSource
+}

--- a/ui/src/components/agents/utils.ts
+++ b/ui/src/components/agents/utils.ts
@@ -1,0 +1,29 @@
+import type { AgentSource } from './types.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/agents/utils.ts`.
+ *
+ * Upstream routes through `getSettingSourceName` out of the Ink
+ * settings store; the Lite port bakes the mapping in directly so the
+ * component tree doesn't depend on settings plumbing.
+ */
+
+function capitalize(s: string): string {
+  return s.length === 0 ? s : s[0]!.toUpperCase() + s.slice(1)
+}
+
+const SOURCE_DISPLAY: Record<AgentSource, string> = {
+  all: 'Agents',
+  'built-in': 'Built-in agents',
+  plugin: 'Plugin agents',
+  userSettings: 'User',
+  projectSettings: 'Project',
+  policySettings: 'Policy',
+  localSettings: 'Local',
+  flagSettings: 'Flag',
+}
+
+export function getAgentSourceDisplayName(source: AgentSource): string {
+  return SOURCE_DISPLAY[source] ?? capitalize(source)
+}

--- a/ui/src/components/agents/validateAgent.ts
+++ b/ui/src/components/agents/validateAgent.ts
@@ -1,0 +1,97 @@
+import type { AgentDefinitionEntry } from '../../ipc/protocol.js'
+import type { AgentSource, AgentValidationResult, DraftAgent } from './types.js'
+import { getAgentSourceDisplayName } from './utils.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/agents/validateAgent.ts`.
+ *
+ * Upstream validated against an in-process `Tools` registry; the Lite
+ * frontend can't walk the backend's tool registry synchronously, so
+ * the tool validity check is simplified — callers can pass an
+ * `availableTools` list (the IPC payload provides one) and we flag any
+ * missing names as invalid.
+ */
+
+export function validateAgentType(agentType: string): string | null {
+  if (!agentType) {
+    return 'Agent type is required'
+  }
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]$/.test(agentType)) {
+    return 'Agent type must start and end with alphanumeric characters and contain only letters, numbers, and hyphens'
+  }
+  if (agentType.length < 3) {
+    return 'Agent type must be at least 3 characters long'
+  }
+  if (agentType.length > 50) {
+    return 'Agent type must be less than 50 characters'
+  }
+  return null
+}
+
+export function validateAgent(
+  agent: DraftAgent,
+  availableTools: string[],
+  existingAgents: AgentDefinitionEntry[],
+): AgentValidationResult {
+  const errors: string[] = []
+  const warnings: string[] = []
+
+  if (!agent.agentType) {
+    errors.push('Agent type is required')
+  } else {
+    const typeError = validateAgentType(agent.agentType)
+    if (typeError) errors.push(typeError)
+
+    const duplicate = existingAgents.find(
+      a => a.name === agent.agentType && readSource(a) !== agent.source,
+    )
+    if (duplicate) {
+      errors.push(
+        `Agent type "${agent.agentType}" already exists in ${getAgentSourceDisplayName(
+          readSource(duplicate) as AgentSource,
+        )}`,
+      )
+    }
+  }
+
+  if (!agent.description) {
+    errors.push('Description is required')
+  } else if (agent.description.length < 10) {
+    warnings.push('Description should be more descriptive (at least 10 characters)')
+  } else if (agent.description.length > 5000) {
+    warnings.push('Description is very long (over 5000 characters)')
+  }
+
+  if (agent.tools !== undefined && !Array.isArray(agent.tools)) {
+    errors.push('Tools must be an array')
+  } else if (agent.tools === undefined) {
+    warnings.push('Agent has access to all tools')
+  } else if (agent.tools.length === 0) {
+    warnings.push('No tools selected — agent will have very limited capabilities')
+  } else {
+    const availableSet = new Set(availableTools)
+    const invalid = agent.tools.filter(t => !availableSet.has(t))
+    if (invalid.length > 0) {
+      errors.push(`Invalid tools: ${invalid.join(', ')}`)
+    }
+  }
+
+  if (!agent.systemPrompt) {
+    errors.push('System prompt is required')
+  } else if (agent.systemPrompt.length < 20) {
+    errors.push('System prompt is too short (minimum 20 characters)')
+  } else if (agent.systemPrompt.length > 10000) {
+    warnings.push('System prompt is very long (over 10,000 characters)')
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+    warnings,
+  }
+}
+
+function readSource(entry: AgentDefinitionEntry): string {
+  return entry.source?.kind ?? 'unknown'
+}

--- a/ui/src/components/customselect/SelectMulti.tsx
+++ b/ui/src/components/customselect/SelectMulti.tsx
@@ -1,0 +1,145 @@
+import React from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../../theme.js'
+import type { OptionWithDescription } from './select.js'
+import {
+  useMultiSelectState,
+  type UseMultiSelectStateProps,
+} from './use-multi-select-state.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/customselect/SelectMulti.tsx`.
+ *
+ * Multi-select list box: rows render a `[x] label` / `[ ] label` gutter,
+ * Space toggles, Enter submits. Upstream supports richer layouts and
+ * commit-mode hotkeys — the Lite port covers the core contract:
+ *
+ *  - `options` + `defaultValues` seed the selection set
+ *  - ↑/↓ or j/k navigates
+ *  - Space / Tab toggles the focused option
+ *  - Enter calls `onSubmit` with the current selection (gated by
+ *    `minSelected`)
+ *  - Esc calls `onCancel`
+ */
+
+type Props<T> = UseMultiSelectStateProps<T> & {
+  isDisabled?: boolean
+  /** Layout hint matching upstream — `compact-vertical` shows the
+   *  description below the label, otherwise it trails inline. */
+  layout?: 'compact' | 'compact-vertical' | 'expanded'
+  /** When true, hides the `[x] / [ ]` gutter. Upstream consumers use
+   *  this for custom row rendering. */
+  hideCheckbox?: boolean
+}
+
+function renderCheckbox(checked: boolean): string {
+  return checked ? '[\u2713]' : '[ ]'
+}
+
+export function SelectMulti<T>({
+  options,
+  defaultValues,
+  visibleOptionCount = 10,
+  onChange,
+  onSubmit,
+  onCancel,
+  onFocus,
+  focusValue,
+  minSelected = 0,
+  maxSelected,
+  isDisabled = false,
+  layout = 'compact',
+  hideCheckbox = false,
+}: Props<T>): React.ReactNode {
+  const state = useMultiSelectState<T>({
+    options,
+    defaultValues,
+    visibleOptionCount,
+    onChange,
+    onSubmit,
+    onCancel,
+    onFocus,
+    focusValue,
+    minSelected,
+    maxSelected,
+  })
+
+  useKeyboard((event: KeyEvent) => {
+    if (isDisabled || event.eventType === 'release') return
+    const name = event.name
+    const seq = event.sequence?.length === 1 ? event.sequence : undefined
+    const key = (seq ?? name ?? '').toLowerCase()
+
+    if (name === 'escape') {
+      state.onCancel?.()
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      state.submit()
+      return
+    }
+    if (name === 'up' || key === 'k') {
+      state.focusPreviousOption()
+      return
+    }
+    if (name === 'down' || key === 'j') {
+      state.focusNextOption()
+      return
+    }
+    if (name === 'tab' || key === ' ') {
+      state.toggleFocused()
+      return
+    }
+    if (name === 'pageup') state.focusPreviousPage()
+    else if (name === 'pagedown') state.focusNextPage()
+  })
+
+  return (
+    <box flexDirection="column">
+      {state.visibleOptions.map(opt => {
+        const isFocused = opt.index === state.focusedIndex - 1
+        const checked = state.isSelected(opt.value as T)
+        const description =
+          layout === 'compact-vertical' ? opt.description : undefined
+        const inlineDesc =
+          layout !== 'compact-vertical' ? opt.description : undefined
+        return (
+          <box key={String(opt.value)} flexDirection="column">
+            <box flexDirection="row" gap={1}>
+              <text fg={isFocused ? c.accent : c.dim}>
+                {isFocused ? '\u276F' : ' '}
+              </text>
+              {!hideCheckbox && (
+                <text fg={checked ? c.success : c.dim}>
+                  {renderCheckbox(checked)}
+                </text>
+              )}
+              {isFocused ? (
+                <strong>
+                  <text fg={c.textBright}>{opt.label}</text>
+                </strong>
+              ) : (
+                <text>{opt.label}</text>
+              )}
+              {inlineDesc && <text fg={c.dim}>{inlineDesc}</text>}
+            </box>
+            {description && (
+              <box paddingLeft={4}>
+                <text fg={c.dim}>{description}</text>
+              </box>
+            )}
+          </box>
+        )
+      })}
+      <box marginTop={1}>
+        <text fg={c.dim}>
+          Space toggle · Enter confirm · Esc cancel
+          {minSelected > 0 && ` · min ${minSelected}`}
+          {maxSelected !== undefined && ` · max ${maxSelected}`}
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/customselect/index.ts
+++ b/ui/src/components/customselect/index.ts
@@ -1,0 +1,3 @@
+export * from './SelectMulti.js'
+export type { OptionWithDescription, SelectProps } from './select.js'
+export * from './select.js'

--- a/ui/src/components/customselect/option-map.ts
+++ b/ui/src/components/customselect/option-map.ts
@@ -1,0 +1,60 @@
+import type { ReactNode } from 'react'
+import type { OptionWithDescription } from './select.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/customselect/option-map.ts`.
+ *
+ * Doubly-linked `Map<T, OptionMapItem<T>>` keyed by option value. Each
+ * node keeps a reference to the previous / next sibling so navigation
+ * hooks can walk the list without re-scanning the array. `first` and
+ * `last` expose the head and tail pointers for quick boundary checks.
+ */
+
+type OptionMapItem<T> = {
+  label: ReactNode
+  value: T
+  description?: string
+  previous: OptionMapItem<T> | undefined
+  next: OptionMapItem<T> | undefined
+  index: number
+}
+
+export default class OptionMap<T> extends Map<T, OptionMapItem<T>> {
+  readonly first: OptionMapItem<T> | undefined
+  readonly last: OptionMapItem<T> | undefined
+
+  constructor(options: OptionWithDescription<T>[]) {
+    const items: Array<[T, OptionMapItem<T>]> = []
+    let firstItem: OptionMapItem<T> | undefined
+    let lastItem: OptionMapItem<T> | undefined
+    let previous: OptionMapItem<T> | undefined
+    let index = 0
+
+    for (const option of options) {
+      const item: OptionMapItem<T> = {
+        label: option.label,
+        value: option.value,
+        description: option.description,
+        previous,
+        next: undefined,
+        index,
+      }
+
+      if (previous) {
+        previous.next = item
+      }
+
+      firstItem ||= item
+      lastItem = item
+
+      items.push([option.value, item])
+      index++
+      previous = item
+    }
+
+    super(items)
+    this.first = firstItem
+    this.last = lastItem
+  }
+}

--- a/ui/src/components/customselect/select-input-option.tsx
+++ b/ui/src/components/customselect/select-input-option.tsx
@@ -1,0 +1,105 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../../theme.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/customselect/select-input-option.tsx`.
+ *
+ * Upstream's variant rides on top of Ink's `BaseTextInput` with paste
+ * handling, cursor tracking, and input-mode coupling with the parent
+ * `Select`. The Lite port keeps the feature set that Lite callers
+ * actually use:
+ *
+ *  - render a label prefix + current value + blinking cursor,
+ *  - capture keystrokes while the row is focused,
+ *  - call `onChange` on Enter, `onCancel` on Esc,
+ *  - honour `allowEmptySubmitToCancel`.
+ *
+ * The component expects the owning `<Select>` to gate input by setting
+ * `isActive` (true only while the input row is focused) so sibling rows
+ * don't double-process keystrokes.
+ */
+
+type Props = {
+  label: React.ReactNode
+  initialValue?: string
+  placeholder?: string
+  isActive?: boolean
+  /** When true, submitting empty text still fires `onChange` instead of
+   *  `onCancel`. Matches the upstream flag. */
+  allowEmptySubmitToCancel?: boolean
+  /** Always render the label beside the value, even when the label
+   *  would normally be hidden while editing. */
+  showLabelWithValue?: boolean
+  /** Separator string between the label and value. */
+  labelValueSeparator?: string
+  onChange: (value: string) => void
+  onCancel?: () => void
+  /** When set, resets the cursor to the end of the input whenever the
+   *  value or focus changes. */
+  resetCursorOnUpdate?: boolean
+}
+
+export function SelectInputOption({
+  label,
+  initialValue = '',
+  placeholder,
+  isActive = false,
+  allowEmptySubmitToCancel = false,
+  showLabelWithValue = false,
+  labelValueSeparator = ', ',
+  onChange,
+  onCancel,
+  resetCursorOnUpdate = false,
+}: Props) {
+  const [value, setValue] = useState(initialValue)
+  const valueRef = useRef(value)
+  valueRef.current = value
+
+  useEffect(() => {
+    if (resetCursorOnUpdate) setValue(initialValue)
+  }, [initialValue, resetCursorOnUpdate])
+
+  useKeyboard((event: KeyEvent) => {
+    if (!isActive || event.eventType === 'release') return
+    const name = event.name
+    const seq = event.sequence
+
+    if (name === 'escape') {
+      onCancel?.()
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      const trimmed = valueRef.current
+      if (trimmed.trim().length === 0 && !allowEmptySubmitToCancel) {
+        onCancel?.()
+        return
+      }
+      onChange(trimmed)
+      return
+    }
+    if (name === 'backspace' || name === 'delete') {
+      setValue(v => v.slice(0, -1))
+      return
+    }
+    if (seq && seq.length === 1 && !event.ctrl && !event.meta) {
+      setValue(v => v + seq)
+    }
+  })
+
+  const displayValue = value.length > 0 ? value : placeholder ?? ''
+  const displayColor = value.length > 0 ? c.text : c.dim
+
+  return (
+    <box flexDirection="row" gap={1}>
+      {(showLabelWithValue || value.length === 0) && (
+        <text>{label}</text>
+      )}
+      {showLabelWithValue && <text fg={c.dim}>{labelValueSeparator}</text>}
+      <text fg={displayColor}>{displayValue}</text>
+      {isActive && <text fg={c.accent}>{'\u2588'}</text>}
+    </box>
+  )
+}

--- a/ui/src/components/customselect/select-option.tsx
+++ b/ui/src/components/customselect/select-option.tsx
@@ -1,0 +1,46 @@
+import React, { type ReactNode } from 'react'
+import { ListItem } from '../design-system/ListItem.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/customselect/select-option.tsx`.
+ *
+ * Thin wrapper around `<ListItem>` that maps the Ink scroll-arrow prop
+ * names into the Lite component API. Exists primarily so `Select`
+ * imports stay symmetric with upstream.
+ */
+
+export type SelectOptionProps = {
+  readonly isFocused: boolean
+  readonly isSelected: boolean
+  readonly children: ReactNode
+  readonly description?: string
+  readonly shouldShowDownArrow?: boolean
+  readonly shouldShowUpArrow?: boolean
+  /** When false, the row trusts a nested input to own the cursor. */
+  readonly declareCursor?: boolean
+}
+
+export function SelectOption({
+  isFocused,
+  isSelected,
+  children,
+  description,
+  shouldShowDownArrow,
+  shouldShowUpArrow,
+  declareCursor,
+}: SelectOptionProps) {
+  return (
+    <ListItem
+      isFocused={isFocused}
+      isSelected={isSelected}
+      description={description}
+      showScrollUp={shouldShowUpArrow}
+      showScrollDown={shouldShowDownArrow}
+      declareCursor={declareCursor}
+      styled={false}
+    >
+      {children}
+    </ListItem>
+  )
+}

--- a/ui/src/components/customselect/select.tsx
+++ b/ui/src/components/customselect/select.tsx
@@ -1,0 +1,174 @@
+import React, { type ReactNode, useEffect } from 'react'
+import { c } from '../../theme.js'
+import { SelectOption } from './select-option.js'
+import { SelectInputOption } from './select-input-option.js'
+import { useSelectInput } from './use-select-input.js'
+import { useSelectState } from './use-select-state.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/customselect/select.tsx`.
+ *
+ * Upstream's 900+-line component carries a decade of Ink
+ * special-casing (paste-mode scrolling, highlightText, layout variants,
+ * input-mode re-focusing, etc). The Lite port keeps the public prop
+ * surface so call sites don't need to change imports, and supports the
+ * feature subset the Lite UI exercises today:
+ *
+ *  - rendered option list with focused / selected markers
+ *  - `compact` (default), `expanded`, `compact-vertical` layouts
+ *  - `inlineDescriptions` toggle
+ *  - optional `type: 'input'` rows (see `SelectInputOption`)
+ *  - keyboard navigation through `useSelectInput`
+ *
+ * Features not yet wired:
+ *  - `highlightText` (substring highlight inside labels)
+ *  - numeric prefix / `hideIndexes`
+ *  - paste-mode scrolling hints
+ *
+ * These are additive and can be layered back in once Lite has a
+ * caller that actually needs them.
+ */
+
+type BaseOption<T> = {
+  description?: string
+  dimDescription?: boolean
+  label: ReactNode
+  value: T
+  disabled?: boolean
+}
+
+export type OptionWithDescription<T = string> =
+  | (BaseOption<T> & { type?: 'text' })
+  | (BaseOption<T> & {
+      type: 'input'
+      onChange: (value: string) => void
+      placeholder?: string
+      initialValue?: string
+      allowEmptySubmitToCancel?: boolean
+      showLabelWithValue?: boolean
+      labelValueSeparator?: string
+      resetCursorOnUpdate?: boolean
+    })
+
+export type SelectProps<T> = {
+  readonly isDisabled?: boolean
+  readonly disableSelection?: boolean
+  readonly hideIndexes?: boolean
+  readonly visibleOptionCount?: number
+  readonly highlightText?: string
+  readonly options: OptionWithDescription<T>[]
+  readonly defaultValue?: T
+  readonly onCancel?: () => void
+  readonly onChange?: (value: T) => void
+  readonly onFocus?: (value: T) => void
+  readonly defaultFocusValue?: T
+  readonly layout?: 'compact' | 'expanded' | 'compact-vertical'
+  readonly inlineDescriptions?: boolean
+  readonly focusValue?: T
+  readonly isCancelable?: boolean
+  /** Fires when an input-row toggles between display and edit states. */
+  readonly onInputModeToggle?: (value: string) => void
+  /** Fires whenever the highlighted row changes (wrap compatibility). */
+  readonly onSelectionChange?: (value: T | undefined) => void
+}
+
+export function Select<T = string>({
+  isDisabled = false,
+  disableSelection = false,
+  visibleOptionCount = 10,
+  options,
+  defaultValue,
+  onCancel,
+  onChange,
+  onFocus,
+  defaultFocusValue,
+  layout = 'compact',
+  inlineDescriptions = false,
+  focusValue,
+  isCancelable = true,
+  onSelectionChange,
+}: SelectProps<T>): React.ReactNode {
+  const state = useSelectState<T>({
+    visibleOptionCount,
+    options,
+    defaultValue: defaultFocusValue ?? defaultValue,
+    onChange,
+    onCancel,
+    onFocus,
+    focusValue,
+  })
+
+  useSelectInput<T>({
+    isDisabled,
+    state,
+    disableSelection,
+    isCancelable,
+  })
+
+  useEffect(() => {
+    onSelectionChange?.(state.focusedValue)
+  }, [state.focusedValue, onSelectionChange])
+
+  const showUpArrow = state.visibleFromIndex > 0
+  const showDownArrow = state.visibleToIndex < options.length
+
+  return (
+    <box flexDirection="column">
+      {state.visibleOptions.map((opt, i) => {
+        const isFocused = opt.index === (state.focusedIndex - 1)
+        const isSelected = opt.value === state.value
+        const isFirst = i === 0
+        const isLast = i === state.visibleOptions.length - 1
+
+        if ('type' in opt && opt.type === 'input') {
+          return (
+            <SelectInputOption
+              key={String(opt.value)}
+              label={opt.label}
+              initialValue={opt.initialValue}
+              placeholder={opt.placeholder}
+              isActive={isFocused}
+              allowEmptySubmitToCancel={opt.allowEmptySubmitToCancel}
+              showLabelWithValue={opt.showLabelWithValue}
+              labelValueSeparator={opt.labelValueSeparator}
+              resetCursorOnUpdate={opt.resetCursorOnUpdate}
+              onChange={value => {
+                opt.onChange(value)
+                state.onChange?.(opt.value)
+              }}
+              onCancel={() => {
+                state.onCancel?.()
+              }}
+            />
+          )
+        }
+
+        const description =
+          layout === 'expanded' || !inlineDescriptions
+            ? opt.description
+            : opt.description
+              ? `— ${opt.description}`
+              : undefined
+
+        return (
+          <React.Fragment key={String(opt.value)}>
+            <SelectOption
+              isFocused={isFocused}
+              isSelected={isSelected}
+              description={description}
+              shouldShowUpArrow={isFirst && showUpArrow}
+              shouldShowDownArrow={isLast && showDownArrow}
+            >
+              {opt.label}
+            </SelectOption>
+            {layout === 'expanded' && !isLast && <text> </text>}
+          </React.Fragment>
+        )
+      })}
+      {options.length === 0 && (
+        <text fg={c.dim}>(no options)</text>
+      )}
+    </box>
+  )
+}

--- a/ui/src/components/customselect/use-multi-select-state.ts
+++ b/ui/src/components/customselect/use-multi-select-state.ts
@@ -1,0 +1,98 @@
+import { useCallback, useState } from 'react'
+import type { OptionWithDescription } from './select.js'
+import { useSelectNavigation, type NavigationState } from './use-select-navigation.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/customselect/use-multi-select-state.ts`.
+ *
+ * Multi-select state machine — same navigation API as `useSelectState`
+ * plus a `selectedValues` set, `toggle()` helper, and `submit()` that
+ * forwards the chosen values to `onSubmit`. Upstream layers rich
+ * behaviours like required-minimums and commit hotkeys; the Lite port
+ * exposes the knobs (`minSelected`, `maxSelected`, `isCommitted`) so
+ * the calling dialog can enforce its own rules.
+ */
+
+export type UseMultiSelectStateProps<T> = {
+  visibleOptionCount?: number
+  options: OptionWithDescription<T>[]
+  defaultValues?: T[]
+  onChange?: (values: T[]) => void
+  onSubmit?: (values: T[]) => void
+  onCancel?: () => void
+  onFocus?: (value: T) => void
+  focusValue?: T
+  minSelected?: number
+  maxSelected?: number
+}
+
+export type MultiSelectState<T> = NavigationState<T> & {
+  selectedValues: Set<T>
+  isSelected: (value: T) => boolean
+  toggle: (value: T) => void
+  toggleFocused: () => void
+  submit: () => void
+  onCancel?: () => void
+}
+
+export function useMultiSelectState<T>({
+  visibleOptionCount = 5,
+  options,
+  defaultValues = [],
+  onChange,
+  onSubmit,
+  onCancel,
+  onFocus,
+  focusValue,
+  minSelected = 0,
+  maxSelected,
+}: UseMultiSelectStateProps<T>): MultiSelectState<T> {
+  const [selected, setSelected] = useState<Set<T>>(() => new Set(defaultValues))
+
+  const navigation = useSelectNavigation<T>({
+    visibleOptionCount,
+    options,
+    initialFocusValue: defaultValues[0],
+    onFocus,
+    focusValue,
+  })
+
+  const toggle = useCallback(
+    (value: T) => {
+      setSelected(prev => {
+        const next = new Set<T>(prev)
+        if (next.has(value)) {
+          next.delete(value)
+        } else {
+          if (maxSelected !== undefined && next.size >= maxSelected) {
+            return prev
+          }
+          next.add(value)
+        }
+        onChange?.(Array.from(next) as T[])
+        return next
+      })
+    },
+    [onChange, maxSelected],
+  )
+
+  const toggleFocused = useCallback(() => {
+    if (navigation.focusedValue !== undefined) toggle(navigation.focusedValue)
+  }, [navigation.focusedValue, toggle])
+
+  const submit = useCallback(() => {
+    if (selected.size < minSelected) return
+    onSubmit?.(Array.from(selected))
+  }, [selected, onSubmit, minSelected])
+
+  return {
+    ...navigation,
+    selectedValues: selected,
+    isSelected: value => selected.has(value),
+    toggle,
+    toggleFocused,
+    submit,
+    onCancel,
+  }
+}

--- a/ui/src/components/customselect/use-select-input.ts
+++ b/ui/src/components/customselect/use-select-input.ts
@@ -1,0 +1,93 @@
+import { useCallback } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import type { SelectState } from './use-select-state.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/customselect/use-select-input.ts`.
+ *
+ * Upstream's version cooperates with Ink's `useInput` + text-mode
+ * input-buffering; the Lite port talks to `@opentui/react`'s
+ * `useKeyboard`. Keystroke contract preserved:
+ *
+ *  - ↑/↓ or j/k         → previous/next focus
+ *  - PageUp/PageDown    → previous/next page
+ *  - Home / g           → jump to first (first enabled option)
+ *  - End / G            → jump to last
+ *  - Enter              → commit focused via `onChange`
+ *  - Esc                → `onCancel`
+ *  - Hotkey characters  → caller-controlled (upstream exposes
+ *    `isCancelable` and `disableNavigation`; we keep those flags).
+ */
+
+export type UseSelectInputProps<T> = {
+  isDisabled?: boolean
+  state: SelectState<T>
+  /** When true, Enter does not fire `onChange`. Upstream uses this for
+   *  pickers that render a Select but commit elsewhere (e.g. a wizard
+   *  advance button). */
+  disableSelection?: boolean
+  /** When false, the hook swallows Esc instead of firing `onCancel`.
+   *  Upstream wizards rely on this for non-cancelable steps. */
+  isCancelable?: boolean
+}
+
+export function useSelectInput<T>({
+  isDisabled = false,
+  state,
+  disableSelection = false,
+  isCancelable = true,
+}: UseSelectInputProps<T>): void {
+  const commit = useCallback(() => {
+    if (disableSelection) return
+    state.selectFocusedOption()
+    if (state.focusedValue !== undefined) {
+      state.onChange?.(state.focusedValue)
+    }
+  }, [state, disableSelection])
+
+  useKeyboard((event: KeyEvent) => {
+    if (isDisabled || event.eventType === 'release') return
+    if (state.isInInput) return
+
+    const name = event.name ?? ''
+    const seq = event.sequence?.length === 1 ? event.sequence : undefined
+    const key = (seq ?? name ?? '').toLowerCase()
+
+    if (name === 'escape') {
+      if (isCancelable) state.onCancel?.()
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      commit()
+      return
+    }
+    if (name === 'up' || key === 'k') {
+      state.focusPreviousOption()
+      return
+    }
+    if (name === 'down' || key === 'j') {
+      state.focusNextOption()
+      return
+    }
+    if (name === 'pageup') {
+      state.focusPreviousPage()
+      return
+    }
+    if (name === 'pagedown') {
+      state.focusNextPage()
+      return
+    }
+    if (name === 'home' || key === 'g') {
+      const first = state.options[0]?.value as T | undefined
+      state.focusOption(first)
+      return
+    }
+    if (name === 'end' || (seq === 'G' && event.shift)) {
+      const last = state.options[state.options.length - 1]?.value as T | undefined
+      state.focusOption(last)
+      return
+    }
+  })
+}

--- a/ui/src/components/customselect/use-select-navigation.ts
+++ b/ui/src/components/customselect/use-select-navigation.ts
@@ -1,0 +1,215 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import OptionMap from './option-map.js'
+import type { OptionWithDescription } from './select.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/customselect/use-select-navigation.ts`.
+ *
+ * Upstream layers paging, wrap-around, input-mode hopping, and disabled
+ * skipping on top of the linked-list node map. The Lite port keeps the
+ * same public contract (focus navigation + `visibleFromIndex` /
+ * `visibleToIndex` window) and enough behaviour for the pickers that
+ * ship in Lite — wrap-around, per-page moves, disabled skipping,
+ * direct `focusOption(value)`. Upstream's input-mode coupling is
+ * covered by the separate `useSelectInput` hook.
+ */
+
+export type UseSelectNavigationProps<T> = {
+  visibleOptionCount?: number
+  options: OptionWithDescription<T>[]
+  initialFocusValue?: T
+  focusValue?: T
+  onFocus?: (value: T) => void
+}
+
+export type NavigationState<T> = {
+  focusedValue: T | undefined
+  focusedIndex: number
+  visibleFromIndex: number
+  visibleToIndex: number
+  options: OptionWithDescription<T>[]
+  visibleOptions: Array<OptionWithDescription<T> & { index: number }>
+  isInInput: boolean
+  focusNextOption: () => void
+  focusPreviousOption: () => void
+  focusNextPage: () => void
+  focusPreviousPage: () => void
+  focusOption: (value: T | undefined) => void
+}
+
+function isDisabled<T>(opt: OptionWithDescription<T> | undefined): boolean {
+  return !!opt && 'disabled' in opt && opt.disabled === true
+}
+
+function findNextEnabled<T>(
+  options: OptionWithDescription<T>[],
+  startIndex: number,
+  step: 1 | -1,
+): number {
+  const len = options.length
+  if (len === 0) return -1
+  let idx = startIndex
+  for (let i = 0; i < len; i++) {
+    if (!isDisabled(options[idx])) return idx
+    idx += step
+    if (idx < 0) idx = len - 1
+    if (idx >= len) idx = 0
+  }
+  return -1
+}
+
+export function useSelectNavigation<T>({
+  visibleOptionCount = 5,
+  options,
+  initialFocusValue,
+  focusValue,
+  onFocus,
+}: UseSelectNavigationProps<T>): NavigationState<T> {
+  const map = useMemo(() => new OptionMap<T>(options), [options])
+  const clampCount = Math.min(Math.max(1, visibleOptionCount), options.length || 1)
+
+  const initialIndex = useMemo(() => {
+    if (initialFocusValue === undefined) {
+      return findNextEnabled(options, 0, 1)
+    }
+    const hit = map.get(initialFocusValue)?.index ?? -1
+    if (hit < 0) return findNextEnabled(options, 0, 1)
+    return isDisabled(options[hit]) ? findNextEnabled(options, hit, 1) : hit
+  }, [map, options, initialFocusValue])
+
+  const [focusedIndex, setFocusedIndex] = useState<number>(initialIndex)
+  const [visibleFromIndex, setVisibleFromIndex] = useState<number>(
+    Math.max(0, Math.min(initialIndex, Math.max(0, options.length - clampCount))),
+  )
+
+  const lastNotifiedRef = useRef<T | undefined>(undefined)
+
+  useEffect(() => {
+    if (focusValue === undefined) return
+    const hit = map.get(focusValue)?.index
+    if (hit === undefined || hit === focusedIndex) return
+    setFocusedIndex(hit)
+    setVisibleFromIndex(prev => clampWindow(prev, hit, clampCount, options.length))
+  }, [focusValue, map, focusedIndex, clampCount, options.length])
+
+  useEffect(() => {
+    if (focusedIndex < 0) return
+    const v = options[focusedIndex]?.value as T | undefined
+    if (v === undefined) return
+    if (lastNotifiedRef.current === v) return
+    lastNotifiedRef.current = v
+    onFocus?.(v)
+  }, [focusedIndex, options, onFocus])
+
+  const visibleToIndex = Math.min(
+    options.length,
+    visibleFromIndex + clampCount,
+  )
+
+  const visibleOptions = useMemo(() => {
+    return options.slice(visibleFromIndex, visibleToIndex).map((opt, i) => ({
+      ...opt,
+      index: visibleFromIndex + i,
+    }))
+  }, [options, visibleFromIndex, visibleToIndex])
+
+  const focusedValue =
+    focusedIndex >= 0 ? (options[focusedIndex]?.value as T | undefined) : undefined
+
+  const isInInput = useMemo(() => {
+    const opt = options[focusedIndex]
+    return !!opt && 'type' in opt && opt.type === 'input'
+  }, [options, focusedIndex])
+
+  const focusNextOption = useCallback(() => {
+    setFocusedIndex(prev => {
+      const len = options.length
+      if (len === 0) return -1
+      let next = prev + 1
+      if (next >= len) next = 0
+      next = findNextEnabled(options, next, 1)
+      if (next < 0) return prev
+      setVisibleFromIndex(v => clampWindow(v, next, clampCount, len))
+      return next
+    })
+  }, [options, clampCount])
+
+  const focusPreviousOption = useCallback(() => {
+    setFocusedIndex(prev => {
+      const len = options.length
+      if (len === 0) return -1
+      let next = prev - 1
+      if (next < 0) next = len - 1
+      next = findNextEnabled(options, next, -1)
+      if (next < 0) return prev
+      setVisibleFromIndex(v => clampWindow(v, next, clampCount, len))
+      return next
+    })
+  }, [options, clampCount])
+
+  const focusNextPage = useCallback(() => {
+    setFocusedIndex(prev => {
+      const len = options.length
+      if (len === 0) return -1
+      let next = Math.min(len - 1, prev + clampCount)
+      next = findNextEnabled(options, next, -1)
+      if (next < 0) return prev
+      setVisibleFromIndex(v => clampWindow(v, next, clampCount, len))
+      return next
+    })
+  }, [options, clampCount])
+
+  const focusPreviousPage = useCallback(() => {
+    setFocusedIndex(prev => {
+      const len = options.length
+      if (len === 0) return -1
+      let next = Math.max(0, prev - clampCount)
+      next = findNextEnabled(options, next, 1)
+      if (next < 0) return prev
+      setVisibleFromIndex(v => clampWindow(v, next, clampCount, len))
+      return next
+    })
+  }, [options, clampCount])
+
+  const focusOption = useCallback(
+    (value: T | undefined) => {
+      if (value === undefined) return
+      const hit = map.get(value)?.index
+      if (hit === undefined) return
+      setFocusedIndex(hit)
+      setVisibleFromIndex(v => clampWindow(v, hit, clampCount, options.length))
+    },
+    [map, clampCount, options.length],
+  )
+
+  return {
+    focusedValue,
+    focusedIndex: focusedIndex >= 0 ? focusedIndex + 1 : 0,
+    visibleFromIndex,
+    visibleToIndex,
+    options,
+    visibleOptions,
+    isInInput,
+    focusNextOption,
+    focusPreviousOption,
+    focusNextPage,
+    focusPreviousPage,
+    focusOption,
+  }
+}
+
+function clampWindow(
+  currentFrom: number,
+  focusedIdx: number,
+  count: number,
+  total: number,
+): number {
+  if (total <= count) return 0
+  const max = total - count
+  if (focusedIdx < currentFrom) return Math.max(0, focusedIdx)
+  if (focusedIdx >= currentFrom + count) {
+    return Math.min(max, focusedIdx - count + 1)
+  }
+  return Math.min(max, currentFrom)
+}

--- a/ui/src/components/customselect/use-select-state.ts
+++ b/ui/src/components/customselect/use-select-state.ts
@@ -1,0 +1,76 @@
+import { useCallback, useState } from 'react'
+import type { OptionWithDescription } from './select.js'
+import { useSelectNavigation } from './use-select-navigation.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/customselect/use-select-state.ts`.
+ *
+ * Composes `useSelectNavigation` with a local `value` slot that tracks
+ * the last-selected option. Exposes the navigation API alongside the
+ * `selectFocusedOption` commit helper — `Select` wires this up to the
+ * Enter keystroke through `useSelectInput`.
+ */
+
+export type UseSelectStateProps<T> = {
+  visibleOptionCount?: number
+  options: OptionWithDescription<T>[]
+  defaultValue?: T
+  onChange?: (value: T) => void
+  onCancel?: () => void
+  onFocus?: (value: T) => void
+  focusValue?: T
+}
+
+export type SelectState<T> = {
+  focusedValue: T | undefined
+  focusedIndex: number
+  visibleFromIndex: number
+  visibleToIndex: number
+  value: T | undefined
+  options: OptionWithDescription<T>[]
+  visibleOptions: Array<OptionWithDescription<T> & { index: number }>
+  isInInput: boolean
+  focusNextOption: () => void
+  focusPreviousOption: () => void
+  focusNextPage: () => void
+  focusPreviousPage: () => void
+  focusOption: (value: T | undefined) => void
+  selectFocusedOption: () => void
+  onChange?: (value: T) => void
+  onCancel?: () => void
+}
+
+export function useSelectState<T>({
+  visibleOptionCount = 5,
+  options,
+  defaultValue,
+  onChange,
+  onCancel,
+  onFocus,
+  focusValue,
+}: UseSelectStateProps<T>): SelectState<T> {
+  const [value, setValue] = useState<T | undefined>(defaultValue)
+
+  const navigation = useSelectNavigation<T>({
+    visibleOptionCount,
+    options,
+    initialFocusValue: defaultValue,
+    onFocus,
+    focusValue,
+  })
+
+  const selectFocusedOption = useCallback(() => {
+    if (navigation.focusedValue !== undefined) {
+      setValue(navigation.focusedValue)
+    }
+  }, [navigation.focusedValue])
+
+  return {
+    ...navigation,
+    value,
+    selectFocusedOption,
+    onChange,
+    onCancel,
+  }
+}

--- a/ui/src/components/design-system/Byline.tsx
+++ b/ui/src/components/design-system/Byline.tsx
@@ -1,0 +1,34 @@
+import React, { Children, Fragment, type ReactNode } from 'react'
+import { c } from '../../theme.js'
+
+/**
+ * Lite-native port of upstream's `Byline`. Renders its children on a
+ * single row with a middle-dot separator between each, suitable for
+ * footer hints like `Enter confirm · Esc cancel · ↑/↓ select`.
+ */
+
+type Props = {
+  children: ReactNode
+  /** Separator glyph between children. */
+  separator?: string
+  /** Separator colour (defaults to dim). */
+  separatorColor?: string
+}
+
+export function Byline({ children, separator = '\u00B7', separatorColor }: Props) {
+  const items = Children.toArray(children).filter(
+    child => child !== null && child !== false && child !== undefined,
+  )
+  const sepColor = separatorColor ?? c.dim
+
+  return (
+    <box flexDirection="row" gap={1}>
+      {items.map((child, i) => (
+        <Fragment key={i}>
+          {i > 0 && <text fg={sepColor}>{separator}</text>}
+          {child}
+        </Fragment>
+      ))}
+    </box>
+  )
+}

--- a/ui/src/components/design-system/Dialog.tsx
+++ b/ui/src/components/design-system/Dialog.tsx
@@ -1,0 +1,103 @@
+import React, { type ReactNode, useCallback } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../../theme.js'
+import { Byline } from './Byline.js'
+import { KeyboardShortcutHint } from './KeyboardShortcutHint.js'
+
+/**
+ * Lite-native port of upstream's `Dialog`. Renders a centred,
+ * rounded-border modal with a title row, optional subtitle, a body,
+ * and a default input-guide line (`Enter confirm · Esc cancel`).
+ *
+ * Esc triggers `onCancel`; the Dialog doesn't own Enter because most
+ * dialogs compose their own confirm chrome (Select / buttons).
+ */
+
+type Props = {
+  title?: ReactNode
+  subtitle?: ReactNode
+  /** Override the default input guide byline. Pass `null` to hide it. */
+  inputGuide?: ReactNode | null
+  /** Accent colour: maps `permission` -> warning, `background` -> dim. */
+  color?: 'permission' | 'accent' | 'success' | 'error' | 'warning' | 'info' | 'background'
+  /** When true, hides the border. */
+  hideBorder?: boolean
+  /** When true, hides the default input-guide byline. */
+  hideInputGuide?: boolean
+  onCancel?: () => void
+  children: ReactNode
+  width?: number | string
+}
+
+const COLOR_MAP = {
+  permission: c.warning,
+  accent: c.accent,
+  success: c.success,
+  error: c.error,
+  warning: c.warning,
+  info: c.info,
+  background: c.dim,
+} as const
+
+export function Dialog({
+  title,
+  subtitle,
+  inputGuide,
+  color = 'accent',
+  hideBorder = false,
+  hideInputGuide = false,
+  onCancel,
+  children,
+  width,
+}: Props) {
+  const borderColor = COLOR_MAP[color]
+
+  const handleCancel = useCallback(() => {
+    onCancel?.()
+  }, [onCancel])
+
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    if (event.name === 'escape') handleCancel()
+  })
+
+  const guide =
+    inputGuide === null
+      ? null
+      : inputGuide !== undefined
+        ? inputGuide
+        : (
+          <Byline>
+            <KeyboardShortcutHint shortcut="Enter" action="confirm" />
+            <KeyboardShortcutHint shortcut="Esc" action="cancel" />
+          </Byline>
+        )
+
+  return (
+    <box
+      flexDirection="column"
+      borderStyle={hideBorder ? undefined : 'rounded'}
+      borderColor={hideBorder ? undefined : borderColor}
+      paddingX={hideBorder ? 0 : 2}
+      paddingY={hideBorder ? 0 : 1}
+      width={width}
+    >
+      {title && (
+        <strong>
+          <text fg={borderColor}>{title}</text>
+        </strong>
+      )}
+      {subtitle && <text fg={c.dim}>{subtitle}</text>}
+      {(title || subtitle) && <text></text>}
+
+      <box flexDirection="column">{children}</box>
+
+      {!hideInputGuide && guide && (
+        <box marginTop={1}>
+          {guide}
+        </box>
+      )}
+    </box>
+  )
+}

--- a/ui/src/components/design-system/Divider.tsx
+++ b/ui/src/components/design-system/Divider.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { c } from '../../theme.js'
+
+/**
+ * Lite-native port of the upstream `Divider` (re-exported from
+ * `@anthropic/ink` upstream). Renders a single-line horizontal rule
+ * with configurable padding and character.
+ */
+
+type Props = {
+  /** Horizontal padding on each side of the line. */
+  padding?: number
+  /** Character used for the rule. */
+  char?: string
+  /** Optional title embedded in the line: `── Title ──`. */
+  title?: string
+  /** Override rule color. Defaults to the muted theme colour. */
+  color?: string
+  /** Width in columns. Defaults to `100%`. */
+  width?: number | string
+}
+
+export function Divider({
+  padding = 0,
+  char = '\u2500',
+  title,
+  color,
+  width = '100%',
+}: Props) {
+  const ruleColor = color ?? c.dim
+  const line = char.repeat(8)
+  if (title) {
+    return (
+      <box flexDirection="row" paddingX={padding} width={width}>
+        <text fg={ruleColor}>{line} </text>
+        <text>{title}</text>
+        <text fg={ruleColor}> {line}</text>
+      </box>
+    )
+  }
+  return (
+    <box paddingX={padding} width={width}>
+      <text fg={ruleColor}>{char.repeat(60)}</text>
+    </box>
+  )
+}

--- a/ui/src/components/design-system/FuzzyPicker.tsx
+++ b/ui/src/components/design-system/FuzzyPicker.tsx
@@ -1,0 +1,196 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../../theme.js'
+
+/**
+ * Lite-native port of upstream's `FuzzyPicker`. A search input on top
+ * of a ranked list with an optional preview pane. Upstream offered a
+ * rich API (debouncing, prefix filters, tag pills); the Lite port keeps
+ * the feature set actually used by `QuickOpenDialog` and the transcript
+ * history picker:
+ *
+ *  - `onQueryChange` runs on every keystroke; `items` is the full,
+ *    caller-ranked list.
+ *  - Enter → `onSelect(item)`; Tab / Shift+Tab → optional side actions;
+ *    Esc → `onCancel`.
+ *  - `previewPosition` toggles between bottom + right layouts.
+ */
+
+type TabAction<T> = {
+  action?: string
+  handler: (item: T) => void
+}
+
+type Props<T> = {
+  title: string
+  placeholder?: string
+  items: T[]
+  getKey: (item: T) => string
+  visibleCount?: number
+  /** Whether results grow upward (for bottom-anchored pickers) or
+   *  downward (default). */
+  direction?: 'up' | 'down'
+  /** `bottom` stacks preview under the list; `right` splits the row. */
+  previewPosition?: 'bottom' | 'right'
+  selectAction?: string
+  onQueryChange?: (query: string) => void
+  onFocus?: (item: T) => void
+  onSelect?: (item: T) => void
+  onTab?: TabAction<T>
+  onShiftTab?: TabAction<T>
+  onCancel?: () => void
+  emptyMessage?: (query: string) => string
+  renderItem?: (item: T, isFocused: boolean) => React.ReactNode
+  renderPreview?: (item: T) => React.ReactNode
+}
+
+export function FuzzyPicker<T>({
+  title,
+  placeholder = 'Type to search…',
+  items,
+  getKey,
+  visibleCount = 8,
+  direction = 'down',
+  previewPosition = 'bottom',
+  selectAction = 'open',
+  onQueryChange,
+  onFocus,
+  onSelect,
+  onTab,
+  onShiftTab,
+  onCancel,
+  emptyMessage,
+  renderItem,
+  renderPreview,
+}: Props<T>) {
+  const [query, setQuery] = useState('')
+  const [focused, setFocused] = useState(0)
+  const focusedRef = useRef(focused)
+  focusedRef.current = focused
+
+  useEffect(() => {
+    onQueryChange?.(query)
+  }, [query, onQueryChange])
+
+  useEffect(() => {
+    setFocused(0)
+  }, [items])
+
+  useEffect(() => {
+    const item = items[focused]
+    if (item !== undefined) onFocus?.(item)
+  }, [items, focused, onFocus])
+
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    const name = event.name
+    const seq = event.sequence?.length === 1 ? event.sequence : undefined
+    const shift = event.shift
+
+    if (name === 'escape') {
+      onCancel?.()
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      const it = items[focusedRef.current]
+      if (it !== undefined) onSelect?.(it)
+      return
+    }
+    if (name === 'tab') {
+      const it = items[focusedRef.current]
+      if (it === undefined) return
+      if (shift) onShiftTab?.handler(it)
+      else onTab?.handler(it)
+      return
+    }
+    if (name === 'up') {
+      setFocused(f => Math.max(0, f - 1))
+      return
+    }
+    if (name === 'down') {
+      setFocused(f => Math.min(Math.max(items.length - 1, 0), f + 1))
+      return
+    }
+    if (name === 'backspace' || name === 'delete') {
+      setQuery(q => q.slice(0, -1))
+      return
+    }
+    if (seq && !event.ctrl && !event.meta) {
+      setQuery(q => q + seq)
+    }
+  })
+
+  const slice = items.slice(0, visibleCount)
+  const focusedItem = items[focused]
+  const empty = emptyMessage?.(query) ?? (query ? 'No matches' : placeholder)
+
+  const list = (
+    <box flexDirection={direction === 'up' ? 'column-reverse' : 'column'}>
+      {slice.length === 0 ? (
+        <text fg={c.dim}>{empty}</text>
+      ) : (
+        slice.map((item, i) => {
+          const isFocused = i === focused
+          const keyStr = getKey(item)
+          return (
+            <box key={keyStr} flexDirection="row">
+              <text fg={isFocused ? c.bg : undefined} bg={isFocused ? c.info : undefined}>
+                {isFocused ? '\u276F ' : '  '}
+                {renderItem ? null : keyStr}
+              </text>
+              {renderItem && renderItem(item, isFocused)}
+            </box>
+          )
+        })
+      )}
+    </box>
+  )
+
+  const preview =
+    focusedItem && renderPreview ? (
+      <box flexDirection="column" paddingLeft={1}>
+        {renderPreview(focusedItem)}
+      </box>
+    ) : null
+
+  return (
+    <box
+      flexDirection="column"
+      borderStyle="rounded"
+      borderColor={c.accent}
+      paddingX={2}
+      paddingY={1}
+    >
+      <strong>
+        <text fg={c.accent}>{title}</text>
+      </strong>
+      <box flexDirection="row" marginTop={1}>
+        <text fg={c.dim}>Search: </text>
+        <text>{query}</text>
+        <text fg={c.accent}>{'\u2588'}</text>
+      </box>
+
+      {previewPosition === 'right' && preview ? (
+        <box flexDirection="row" marginTop={1} gap={2}>
+          <box flexDirection="column" flexGrow={1}>{list}</box>
+          <box flexDirection="column" flexGrow={1}>{preview}</box>
+        </box>
+      ) : (
+        <>
+          <box marginTop={1}>{list}</box>
+          {preview && <box marginTop={1}>{preview}</box>}
+        </>
+      )}
+
+      <box marginTop={1}>
+        <text fg={c.dim}>
+          Enter {selectAction}
+          {onTab?.action ? ` · Tab ${onTab.action}` : ''}
+          {onShiftTab?.action ? ` · Shift+Tab ${onShiftTab.action}` : ''}
+          {' · Esc cancel'}
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/ui/src/components/design-system/KeyboardShortcutHint.tsx
+++ b/ui/src/components/design-system/KeyboardShortcutHint.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { c } from '../../theme.js'
+
+/**
+ * Lite-native port of upstream's `KeyboardShortcutHint`.
+ *
+ * Upstream renders `<kbd>…</kbd>` with a bold shortcut label followed
+ * by a dim action description, e.g. `Enter confirm`. The layout is a
+ * single inline text run so it can be nested under `<Byline>` to build
+ * status-bar-style chromes.
+ */
+
+type Props = {
+  /** Key or chord ("Enter", "Ctrl+B", "↑/↓"). */
+  shortcut: string
+  /** Short verb label ("confirm", "cancel"). */
+  action?: string
+  /** Override foreground colour. */
+  color?: string
+  /** When true, render the shortcut label in bold. */
+  bold?: boolean
+}
+
+export function KeyboardShortcutHint({
+  shortcut,
+  action,
+  color,
+  bold = true,
+}: Props) {
+  const fg = color ?? c.text
+  const shortcutEl = bold ? (
+    <strong><text fg={fg}>{shortcut}</text></strong>
+  ) : (
+    <text fg={fg}>{shortcut}</text>
+  )
+  return (
+    <text>
+      {shortcutEl}
+      {action && (
+        <text fg={c.dim}>{' '}{action}</text>
+      )}
+    </text>
+  )
+}

--- a/ui/src/components/design-system/ListItem.tsx
+++ b/ui/src/components/design-system/ListItem.tsx
@@ -1,0 +1,75 @@
+import React, { type ReactNode } from 'react'
+import { c } from '../../theme.js'
+
+/**
+ * Lite-native port of upstream's `ListItem` — a single row with focus
+ * / selection affordances plus optional description and scroll arrows.
+ * Used by `<Select>` and custom pickers.
+ */
+
+type Props = {
+  isFocused?: boolean
+  isSelected?: boolean
+  description?: string
+  dimDescription?: boolean
+  showScrollUp?: boolean
+  showScrollDown?: boolean
+  /** When false, the component assumes a child declares its own
+   *  cursor position (e.g. a nested text input). */
+  declareCursor?: boolean
+  /** When false, the row styles itself; otherwise the caller is
+   *  expected to style its own children. */
+  styled?: boolean
+  /** Optional inline description rendered after the label. */
+  inlineDescription?: boolean
+  children: ReactNode
+}
+
+export function ListItem({
+  isFocused = false,
+  isSelected = false,
+  description,
+  dimDescription = true,
+  showScrollUp = false,
+  showScrollDown = false,
+  inlineDescription = false,
+  children,
+}: Props) {
+  const pointer = isFocused ? '\u276F' : ' '
+  const marker = isSelected ? '\u25CF' : ' '
+
+  const row = (
+    <box flexDirection="row" gap={1}>
+      <text fg={isFocused ? c.accent : c.dim}>{pointer}</text>
+      <text fg={isSelected ? c.success : c.dim}>{marker}</text>
+      <box flexDirection={inlineDescription ? 'row' : 'column'} gap={inlineDescription ? 1 : 0}>
+        {isFocused ? (
+          <strong>
+            <text fg={c.textBright}>{children}</text>
+          </strong>
+        ) : (
+          <text>{children}</text>
+        )}
+        {description && (
+          <text fg={dimDescription ? c.dim : c.text}>
+            {inlineDescription ? description : description}
+          </text>
+        )}
+      </box>
+    </box>
+  )
+
+  if (!showScrollUp && !showScrollDown) return row
+
+  return (
+    <box flexDirection="row" justifyContent="space-between" width="100%">
+      {row}
+      {(showScrollUp || showScrollDown) && (
+        <text fg={c.dim}>
+          {showScrollUp ? '\u2191' : ''}
+          {showScrollDown ? '\u2193' : ''}
+        </text>
+      )}
+    </box>
+  )
+}

--- a/ui/src/components/design-system/LoadingState.tsx
+++ b/ui/src/components/design-system/LoadingState.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react'
+import { c } from '../../theme.js'
+
+/**
+ * Lite-native port of upstream's `LoadingState` component.
+ *
+ * A rotating braille spinner followed by a label. The spinner animates
+ * at 80 ms / frame (same cadence as the existing `Spinner` component)
+ * and honours the `dimColor` prop by rendering the whole line in the
+ * dim theme colour.
+ */
+
+const FRAMES = [
+  '\u280B',
+  '\u2819',
+  '\u2839',
+  '\u2838',
+  '\u283C',
+  '\u2834',
+  '\u2826',
+  '\u2827',
+  '\u2807',
+  '\u280F',
+]
+
+type Props = {
+  message?: string
+  dimColor?: boolean
+  /** Override foreground colour for the spinner glyph. */
+  color?: string
+}
+
+export function LoadingState({ message = 'Loading…', dimColor = false, color }: Props) {
+  const [frame, setFrame] = useState(0)
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setFrame(f => (f + 1) % FRAMES.length)
+    }, 80)
+    return () => clearInterval(id)
+  }, [])
+
+  const textColor = dimColor ? c.dim : c.text
+  const spinnerColor = color ?? (dimColor ? c.dim : c.info)
+
+  return (
+    <box flexDirection="row" gap={1}>
+      <text fg={spinnerColor}>{FRAMES[frame]}</text>
+      <text fg={textColor}>{message}</text>
+    </box>
+  )
+}

--- a/ui/src/components/design-system/Pane.tsx
+++ b/ui/src/components/design-system/Pane.tsx
@@ -1,0 +1,70 @@
+import React, { type ReactNode } from 'react'
+import { c } from '../../theme.js'
+
+/**
+ * Lite-native port of upstream's `Pane` — a semantic bordered
+ * container used by permission dialogs and other overlay chromes. The
+ * `color` prop maps to a theme-key that tints the border + title.
+ */
+
+export type PaneColor =
+  | 'permission'
+  | 'accent'
+  | 'success'
+  | 'error'
+  | 'warning'
+  | 'info'
+  | 'background'
+
+type Props = {
+  children: ReactNode
+  color?: PaneColor
+  title?: string
+  subtitle?: string
+  borderStyle?: 'single' | 'double' | 'rounded' | 'bold' | 'classic'
+  paddingX?: number
+  paddingY?: number
+  width?: number | string
+}
+
+const COLOR_MAP: Record<PaneColor, string> = {
+  permission: c.warning,
+  accent: c.accent,
+  success: c.success,
+  error: c.error,
+  warning: c.warning,
+  info: c.info,
+  background: c.dim,
+}
+
+export function Pane({
+  children,
+  color = 'accent',
+  title,
+  subtitle,
+  borderStyle = 'rounded',
+  paddingX = 2,
+  paddingY = 1,
+  width,
+}: Props) {
+  const borderColor = COLOR_MAP[color]
+  return (
+    <box
+      flexDirection="column"
+      borderStyle={borderStyle}
+      borderColor={borderColor}
+      paddingX={paddingX}
+      paddingY={paddingY}
+      width={width}
+    >
+      {title && (
+        <strong>
+          <text fg={borderColor}>{title}</text>
+        </strong>
+      )}
+      {subtitle && <text fg={c.dim}>{subtitle}</text>}
+      {(title || subtitle) && <text></text>}
+      {children}
+    </box>
+  )
+}

--- a/ui/src/components/design-system/ProgressBar.tsx
+++ b/ui/src/components/design-system/ProgressBar.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { c } from '../../theme.js'
+
+/**
+ * Lite-native port of upstream's `ProgressBar`. Draws a fixed-width
+ * bar using solid / light block characters, with optional label and
+ * percentage. `value` and `max` are clamped so callers don't need to.
+ */
+
+type Props = {
+  value: number
+  max?: number
+  /** Character cells wide (inside any surrounding padding). */
+  width?: number
+  label?: string
+  /** When true, renders `42%` after the bar. */
+  showPercent?: boolean
+  /** Colour of the filled portion. */
+  color?: string
+  /** Colour of the unfilled portion. */
+  dimColor?: string
+}
+
+const FILLED = '\u2588'
+const EMPTY = '\u2591'
+
+export function ProgressBar({
+  value,
+  max = 100,
+  width = 20,
+  label,
+  showPercent = false,
+  color,
+  dimColor,
+}: Props) {
+  const safeMax = Math.max(1, max)
+  const ratio = Math.max(0, Math.min(1, value / safeMax))
+  const filledCount = Math.round(ratio * width)
+  const emptyCount = Math.max(0, width - filledCount)
+  const filledColor = color ?? c.success
+  const emptyColor = dimColor ?? c.dim
+
+  return (
+    <box flexDirection="row" gap={1}>
+      {label && <text>{label}</text>}
+      <text fg={filledColor}>{FILLED.repeat(filledCount)}</text>
+      <text fg={emptyColor}>{EMPTY.repeat(emptyCount)}</text>
+      {showPercent && (
+        <text fg={c.dim}>{Math.round(ratio * 100)}%</text>
+      )}
+    </box>
+  )
+}

--- a/ui/src/components/design-system/Ratchet.tsx
+++ b/ui/src/components/design-system/Ratchet.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import { c } from '../../theme.js'
+
+/**
+ * Lite-native port of upstream's `Ratchet` — a stepped progress
+ * indicator rendered as a row of filled / empty blocks. Unlike
+ * `<ProgressBar>` the filled count is already discrete (no ratio
+ * math). Used by dialog chromes to show "step 2 of 5" style
+ * affordances.
+ */
+
+type Props = {
+  step: number
+  total: number
+  label?: string
+  /** Colour of the completed pip. */
+  color?: string
+  /** Colour of the upcoming pip. */
+  dimColor?: string
+  /** Show `1 of 5` text after the pips. */
+  showCount?: boolean
+}
+
+const DONE = '\u25C6'
+const TODO = '\u25C7'
+
+export function Ratchet({
+  step,
+  total,
+  label,
+  color,
+  dimColor,
+  showCount = true,
+}: Props) {
+  const safeTotal = Math.max(1, total)
+  const safeStep = Math.max(0, Math.min(safeTotal, step))
+  const done = color ?? c.success
+  const todo = dimColor ?? c.dim
+
+  return (
+    <box flexDirection="row" gap={1}>
+      {label && <text>{label}</text>}
+      <box flexDirection="row">
+        {Array.from({ length: safeTotal }).map((_, i) => {
+          const isDone = i < safeStep
+          return (
+            <text key={i} fg={isDone ? done : todo}>
+              {isDone ? DONE : TODO}
+              {i < safeTotal - 1 ? ' ' : ''}
+            </text>
+          )
+        })}
+      </box>
+      {showCount && (
+        <text fg={c.dim}>
+          {safeStep} of {safeTotal}
+        </text>
+      )}
+    </box>
+  )
+}

--- a/ui/src/components/design-system/StatusIcon.tsx
+++ b/ui/src/components/design-system/StatusIcon.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { c } from '../../theme.js'
+
+/**
+ * Lite-native port of upstream's `StatusIcon` — a single glyph with a
+ * theme-coloured foreground for success / error / warning / info /
+ * pending / running states. Used throughout the dialog chrome.
+ */
+
+export type StatusIconKind =
+  | 'success'
+  | 'error'
+  | 'warning'
+  | 'info'
+  | 'pending'
+  | 'running'
+  | 'dot'
+  | 'check'
+  | 'cross'
+
+const GLYPHS: Record<StatusIconKind, string> = {
+  success: '\u2713',
+  error: '\u2717',
+  warning: '\u26A0',
+  info: '\u2139',
+  pending: '\u25CB',
+  running: '\u25C9',
+  dot: '\u2022',
+  check: '\u2713',
+  cross: '\u2717',
+}
+
+const COLORS: Record<StatusIconKind, string> = {
+  success: c.success,
+  error: c.error,
+  warning: c.warning,
+  info: c.info,
+  pending: c.dim,
+  running: c.info,
+  dot: c.text,
+  check: c.success,
+  cross: c.error,
+}
+
+type Props = {
+  kind: StatusIconKind
+  /** Override glyph colour. */
+  color?: string
+}
+
+export function StatusIcon({ kind, color }: Props) {
+  return <text fg={color ?? COLORS[kind]}>{GLYPHS[kind]}</text>
+}

--- a/ui/src/components/design-system/Tabs.tsx
+++ b/ui/src/components/design-system/Tabs.tsx
@@ -1,0 +1,61 @@
+import React, { type ReactNode } from 'react'
+import { c } from '../../theme.js'
+
+/**
+ * Lite-native port of upstream's `Tabs` — a horizontal row of tab
+ * labels with an active highlight. The active tab is rendered in bold
+ * + accent; inactive tabs dim. Consumers are expected to own state and
+ * pass `activeId`.
+ */
+
+export type TabItem = {
+  id: string
+  label: string
+  /** Optional trailing badge (e.g. "3" for unread count). */
+  badge?: ReactNode
+}
+
+type Props = {
+  items: TabItem[]
+  activeId: string
+  onChange?: (id: string) => void
+  /** When true, an underline is drawn beneath the active tab. */
+  underline?: boolean
+}
+
+export function Tabs({ items, activeId, underline = true }: Props) {
+  return (
+    <box flexDirection="column">
+      <box flexDirection="row" gap={2}>
+        {items.map(item => {
+          const active = item.id === activeId
+          return (
+            <box key={item.id} flexDirection="row" gap={1}>
+              {active ? (
+                <strong>
+                  <text fg={c.accent}>{item.label}</text>
+                </strong>
+              ) : (
+                <text fg={c.dim}>{item.label}</text>
+              )}
+              {item.badge && <text fg={c.dim}>{item.badge}</text>}
+            </box>
+          )
+        })}
+      </box>
+      {underline && (
+        <box flexDirection="row" gap={2}>
+          {items.map(item => {
+            const active = item.id === activeId
+            const width = item.label.length
+            return (
+              <text key={item.id} fg={active ? c.accent : c.dim}>
+                {(active ? '\u2500' : ' ').repeat(width)}
+              </text>
+            )
+          })}
+        </box>
+      )}
+    </box>
+  )
+}

--- a/ui/src/components/design-system/ThemeProvider.tsx
+++ b/ui/src/components/design-system/ThemeProvider.tsx
@@ -1,0 +1,28 @@
+import React, { createContext, useContext, type ReactNode } from 'react'
+import { c } from '../../theme.js'
+
+/**
+ * Lite-native port of upstream's `ThemeProvider`. Exposes the same
+ * hex-palette `c` object as the `useTheme()` hook upstream returns —
+ * callers can swap palettes at runtime by wrapping a subtree.
+ */
+
+export type Theme = typeof c
+
+const ThemeContext = createContext<Theme>(c)
+
+type Props = {
+  theme?: Partial<Theme>
+  children: ReactNode
+}
+
+export function ThemeProvider({ theme, children }: Props) {
+  const merged: Theme = theme ? ({ ...c, ...theme } as Theme) : c
+  return (
+    <ThemeContext.Provider value={merged}>{children}</ThemeContext.Provider>
+  )
+}
+
+export function useTheme(): Theme {
+  return useContext(ThemeContext)
+}

--- a/ui/src/components/design-system/ThemedBox.tsx
+++ b/ui/src/components/design-system/ThemedBox.tsx
@@ -1,0 +1,82 @@
+import React, { type ReactNode } from 'react'
+import { useTheme, type Theme } from './ThemeProvider.js'
+import { resolveColor, type ColorLike } from './color.js'
+
+/**
+ * Lite-native port of upstream's `ThemedBox`. Thin wrapper around the
+ * OpenTUI `<box>` primitive that accepts theme-key or raw-color strings
+ * for `backgroundColor` / `borderColor`.
+ */
+
+type Props = {
+  children?: ReactNode
+  backgroundColor?: ColorLike
+  borderColor?: ColorLike
+  borderStyle?: 'single' | 'double' | 'rounded' | 'bold' | 'classic'
+  padding?: number
+  paddingX?: number
+  paddingY?: number
+  margin?: number
+  marginX?: number
+  marginY?: number
+  marginTop?: number
+  marginBottom?: number
+  flexDirection?: 'row' | 'column'
+  flexGrow?: number
+  flexShrink?: number
+  gap?: number
+  width?: number | string
+  height?: number | string
+  /** When true, renders an outer border on all sides. */
+  border?: boolean
+}
+
+export function ThemedBox({
+  children,
+  backgroundColor,
+  borderColor,
+  borderStyle,
+  padding,
+  paddingX,
+  paddingY,
+  margin,
+  marginX,
+  marginY,
+  marginTop,
+  marginBottom,
+  flexDirection,
+  flexGrow,
+  flexShrink,
+  gap,
+  width,
+  height,
+  border,
+}: Props) {
+  const theme = useTheme() as Theme
+  const bg = resolveColor(backgroundColor) ?? theme.bg
+  const border_ = resolveColor(borderColor)
+  return (
+    <box
+      backgroundColor={bg}
+      borderColor={border_}
+      borderStyle={borderStyle}
+      border={border}
+      padding={padding}
+      paddingX={paddingX}
+      paddingY={paddingY}
+      margin={margin}
+      marginX={marginX}
+      marginY={marginY}
+      marginTop={marginTop}
+      marginBottom={marginBottom}
+      flexDirection={flexDirection}
+      flexGrow={flexGrow}
+      flexShrink={flexShrink}
+      gap={gap}
+      width={width}
+      height={height}
+    >
+      {children}
+    </box>
+  )
+}

--- a/ui/src/components/design-system/ThemedText.tsx
+++ b/ui/src/components/design-system/ThemedText.tsx
@@ -1,0 +1,41 @@
+import React, { type ReactNode } from 'react'
+import { useTheme } from './ThemeProvider.js'
+import { resolveColor, type ColorLike } from './color.js'
+
+/**
+ * Lite-native port of upstream's `ThemedText`. Thin wrapper around the
+ * `<text>` primitive that accepts theme-key or raw-color strings and
+ * applies `bold` / `dim` / `italic` via the matching markup tags.
+ */
+
+type Props = {
+  children?: ReactNode
+  color?: ColorLike
+  bg?: ColorLike
+  bold?: boolean
+  dim?: boolean
+  italic?: boolean
+  underline?: boolean
+  /** Truncation mode mirroring Ink's `wrap` prop. */
+  wrap?: 'wrap' | 'truncate' | 'truncate-start' | 'truncate-middle' | 'truncate-end'
+}
+
+export function ThemedText({
+  children,
+  color,
+  bg,
+  bold = false,
+  dim = false,
+  italic = false,
+  underline = false,
+}: Props) {
+  const theme = useTheme()
+  const fg = dim ? resolveColor(color) ?? theme.dim : resolveColor(color)
+  const bgColor = resolveColor(bg)
+
+  let content: ReactNode = <text fg={fg} bg={bgColor}>{children}</text>
+  if (bold) content = <strong>{content}</strong>
+  if (italic) content = <em>{content}</em>
+  if (underline) content = <span>{content}</span>
+  return content
+}

--- a/ui/src/components/design-system/color.ts
+++ b/ui/src/components/design-system/color.ts
@@ -1,0 +1,38 @@
+import { c } from '../../theme.js'
+
+/**
+ * Lite-native port of the upstream
+ * `ui/examples/upstream-patterns/src/components/design-system/color.ts`.
+ *
+ * Upstream's `color()` returned a curried `(text) => string` that wrapped
+ * Ink's `colorize` with ANSI escapes. OpenTUI's renderer consumes a
+ * plain hex/ansi string directly via the `fg`/`bg` JSX props, so this
+ * helper just resolves a theme key or passthrough literal into a
+ * renderable color string.
+ */
+
+type ThemeKey = keyof typeof c
+type RawColor = string
+
+export type ColorLike = ThemeKey | RawColor | undefined
+
+function isRawColor(v: string): boolean {
+  return (
+    v.startsWith('rgb(') ||
+    v.startsWith('#') ||
+    v.startsWith('ansi256(') ||
+    v.startsWith('ansi:')
+  )
+}
+
+/**
+ * Resolves a theme-key / raw-color input to the raw color string our
+ * JSX props accept. Returns `undefined` when the input is empty so
+ * `<text fg={resolve(x)}>` falls through to the rendered default.
+ */
+export function resolveColor(input: ColorLike): string | undefined {
+  if (!input) return undefined
+  if (isRawColor(input)) return input
+  const key = input as ThemeKey
+  return (c as Record<string, string>)[key]
+}

--- a/ui/src/components/diff/DiffDetailView.tsx
+++ b/ui/src/components/diff/DiffDetailView.tsx
@@ -1,0 +1,100 @@
+import React from 'react'
+import { c } from '../../theme.js'
+import {
+  StructuredDiff,
+  type DiffHunk,
+} from '../StructuredDiff/index.js'
+import { Divider } from '../design-system/Divider.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/diff/DiffDetailView.tsx`.
+ *
+ * Upstream reads the file from disk for syntax-detection context; the
+ * Lite frontend doesn't run in a full Node environment, so the component
+ * expects the caller to pre-parse its hunks into the Lite `DiffHunk`
+ * shape (see `components/StructuredDiff/hunks.ts`) and pass them in
+ * directly.
+ */
+
+type Props = {
+  filePath: string
+  hunks: DiffHunk[]
+  isLargeFile?: boolean
+  isBinary?: boolean
+  isTruncated?: boolean
+  isUntracked?: boolean
+  /** Cap rendered lines per hunk. Passed through to `<StructuredDiff>`. */
+  maxLinesPerHunk?: number
+}
+
+export function DiffDetailView({
+  filePath,
+  hunks,
+  isLargeFile = false,
+  isBinary = false,
+  isTruncated = false,
+  isUntracked = false,
+  maxLinesPerHunk,
+}: Props) {
+  if (isUntracked) {
+    return (
+      <box flexDirection="column" width="100%">
+        <box>
+          <strong><text>{filePath}</text></strong>
+          <text fg={c.dim}> (untracked)</text>
+        </box>
+        <Divider padding={4} />
+        <box flexDirection="column">
+          <em><text fg={c.dim}>New file not yet staged.</text></em>
+          <em><text fg={c.dim}>Run `git add {filePath}` to see line counts.</text></em>
+        </box>
+      </box>
+    )
+  }
+
+  if (isBinary) {
+    return (
+      <box flexDirection="column" width="100%">
+        <strong><text>{filePath}</text></strong>
+        <Divider padding={4} />
+        <em><text fg={c.dim}>Binary file — cannot display diff</text></em>
+      </box>
+    )
+  }
+
+  if (isLargeFile) {
+    return (
+      <box flexDirection="column" width="100%">
+        <strong><text>{filePath}</text></strong>
+        <Divider padding={4} />
+        <em><text fg={c.dim}>Large file — diff exceeds 1 MB limit</text></em>
+      </box>
+    )
+  }
+
+  return (
+    <box flexDirection="column" width="100%">
+      <box flexDirection="row">
+        <strong><text>{filePath}</text></strong>
+        {isTruncated && <text fg={c.dim}> (truncated)</text>}
+      </box>
+
+      <Divider padding={4} />
+
+      <box flexDirection="column">
+        {hunks.length === 0 ? (
+          <text fg={c.dim}>No diff content</text>
+        ) : (
+          <StructuredDiff hunks={hunks} maxLinesPerHunk={maxLinesPerHunk} />
+        )}
+      </box>
+
+      {isTruncated && (
+        <em>
+          <text fg={c.dim}>… diff truncated (exceeded 400 line limit)</text>
+        </em>
+      )}
+    </box>
+  )
+}

--- a/ui/src/components/diff/DiffDialog.tsx
+++ b/ui/src/components/diff/DiffDialog.tsx
@@ -1,0 +1,220 @@
+import React, { useMemo, useState } from 'react'
+import { useKeyboard } from '@opentui/react'
+import type { KeyEvent } from '@opentui/core'
+import { c } from '../../theme.js'
+import { Byline } from '../design-system/Byline.js'
+import { Dialog } from '../design-system/Dialog.js'
+import { KeyboardShortcutHint } from '../design-system/KeyboardShortcutHint.js'
+import type { DiffHunk } from '../StructuredDiff/index.js'
+import { DiffDetailView } from './DiffDetailView.js'
+import { DiffFileList, type DiffFile } from './DiffFileList.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/diff/DiffDialog.tsx`.
+ *
+ * Upstream sources diff data from `useDiffData()` + `useTurnDiffs()`,
+ * both of which touch Ink hooks and the on-disk git state. The Lite
+ * port takes a pre-built `sources` array so the caller decides where
+ * the data comes from (git, a turn snapshot, a fixture, …).
+ *
+ * Keyboard contract (from upstream):
+ *  - ↑/↓   navigate files in list mode
+ *  - ←/→   switch sources (multi-source mode) or go back from detail
+ *  - Enter enter detail mode
+ *  - Esc   close (or exit detail mode first)
+ */
+
+export type DiffStats = {
+  filesCount: number
+  linesAdded: number
+  linesRemoved: number
+}
+
+export type DiffSourceData = {
+  /** Display name for the source pill, e.g. "Current" or "T3". */
+  label: string
+  /** Shown next to the title: `"T3 \"initial scaffolding\""`. */
+  title?: string
+  subtitle?: string
+  files: DiffFile[]
+  hunks: Map<string, DiffHunk[]>
+  stats?: DiffStats
+  /** When true, the dialog renders a spinner instead of the list. */
+  loading?: boolean
+}
+
+type Props = {
+  sources: DiffSourceData[]
+  onDone: (message?: string) => void
+  /** Default source index, used when resuming a dialog. */
+  initialSourceIndex?: number
+  /** Default file index inside the initial source. */
+  initialSelectedIndex?: number
+}
+
+type ViewMode = 'list' | 'detail'
+
+function pluralFile(n: number): string {
+  return n === 1 ? 'file' : 'files'
+}
+
+export function DiffDialog({
+  sources,
+  onDone,
+  initialSourceIndex = 0,
+  initialSelectedIndex = 0,
+}: Props) {
+  const [viewMode, setViewMode] = useState<ViewMode>('list')
+  const [sourceIndex, setSourceIndex] = useState(
+    Math.max(0, Math.min(initialSourceIndex, sources.length - 1)),
+  )
+  const [selectedIndex, setSelectedIndex] = useState(initialSelectedIndex)
+
+  const currentSource = sources[sourceIndex]
+  const files = currentSource?.files ?? []
+  const selectedFile = files[selectedIndex]
+  const selectedHunks = useMemo(() => {
+    if (!selectedFile) return [] as DiffHunk[]
+    return currentSource?.hunks.get(selectedFile.path) ?? []
+  }, [currentSource, selectedFile])
+
+  useKeyboard((event: KeyEvent) => {
+    if (event.eventType === 'release') return
+    const name = event.name
+
+    if (name === 'escape') {
+      if (viewMode === 'detail') setViewMode('list')
+      else onDone('Diff dialog dismissed')
+      return
+    }
+    if (viewMode === 'detail') {
+      if (name === 'left') setViewMode('list')
+      return
+    }
+    if (name === 'left') {
+      if (sources.length > 1) {
+        setSourceIndex(prev => {
+          const next = Math.max(0, prev - 1)
+          if (next !== prev) setSelectedIndex(0)
+          return next
+        })
+      }
+      return
+    }
+    if (name === 'right') {
+      if (sources.length > 1) {
+        setSourceIndex(prev => {
+          const next = Math.min(sources.length - 1, prev + 1)
+          if (next !== prev) setSelectedIndex(0)
+          return next
+        })
+      }
+      return
+    }
+    if (name === 'up') {
+      setSelectedIndex(prev => Math.max(0, prev - 1))
+      return
+    }
+    if (name === 'down') {
+      setSelectedIndex(prev => Math.min(files.length - 1, prev + 1))
+      return
+    }
+    if (name === 'return' || name === 'enter') {
+      if (selectedFile) setViewMode('detail')
+    }
+  })
+
+  const stats = currentSource?.stats
+  const subtitle = stats ? (
+    <text fg={c.dim}>
+      {stats.filesCount} {pluralFile(stats.filesCount)} changed
+      {stats.linesAdded > 0 && <text fg={c.success}> +{stats.linesAdded}</text>}
+      {stats.linesRemoved > 0 && <text fg={c.error}> -{stats.linesRemoved}</text>}
+    </text>
+  ) : null
+
+  const sourceSelector =
+    sources.length > 1 ? (
+      <box flexDirection="row">
+        {sourceIndex > 0 && <text fg={c.dim}>{'\u25C0 '}</text>}
+        {sources.map((source, i) => {
+          const isSelected = i === sourceIndex
+          return (
+            <text key={source.label}>
+              {i > 0 ? <text fg={c.dim}> \u00B7 </text> : null}
+              {isSelected ? (
+                <strong><text>{source.label}</text></strong>
+              ) : (
+                <text fg={c.dim}>{source.label}</text>
+              )}
+            </text>
+          )
+        })}
+        {sourceIndex < sources.length - 1 && <text fg={c.dim}>{' \u25B6'}</text>}
+      </box>
+    ) : null
+
+  const headerTitle = currentSource?.title ?? 'Uncommitted changes'
+  const headerSubtitle = currentSource?.subtitle ?? '(git diff HEAD)'
+
+  const emptyMessage = currentSource?.loading
+    ? 'Loading diff…'
+    : currentSource && files.length === 0
+      ? stats && stats.filesCount > 0
+        ? 'Too many files to display details'
+        : 'Working tree is clean'
+      : 'No diff data'
+
+  const guide =
+    viewMode === 'list' ? (
+      <Byline>
+        {sources.length > 1 && <text>{'\u2190/\u2192'} source</text>}
+        <text>{'\u2191/\u2193'} select</text>
+        <KeyboardShortcutHint shortcut="Enter" action="view" />
+        <KeyboardShortcutHint shortcut="Esc" action="close" />
+      </Byline>
+    ) : (
+      <Byline>
+        <text>{'\u2190'} back</text>
+        <KeyboardShortcutHint shortcut="Esc" action="close" />
+      </Byline>
+    )
+
+  return (
+    <Dialog
+      title={
+        <text>
+          {headerTitle}
+          {headerSubtitle && <text fg={c.dim}>{' '}{headerSubtitle}</text>}
+        </text>
+      }
+      onCancel={() => onDone('Diff dialog dismissed')}
+      inputGuide={guide}
+      color="background"
+    >
+      {sourceSelector}
+      {subtitle}
+      {files.length === 0 ? (
+        <box marginTop={1}>
+          <text fg={c.dim}>{emptyMessage}</text>
+        </box>
+      ) : viewMode === 'list' ? (
+        <box flexDirection="column" marginTop={1}>
+          <DiffFileList files={files} selectedIndex={selectedIndex} />
+        </box>
+      ) : (
+        <box flexDirection="column" marginTop={1}>
+          <DiffDetailView
+            filePath={selectedFile?.path ?? ''}
+            hunks={selectedHunks}
+            isLargeFile={selectedFile?.isLargeFile}
+            isBinary={selectedFile?.isBinary}
+            isTruncated={selectedFile?.isTruncated}
+            isUntracked={selectedFile?.isUntracked}
+          />
+        </box>
+      )}
+    </Dialog>
+  )
+}

--- a/ui/src/components/diff/DiffFileList.tsx
+++ b/ui/src/components/diff/DiffFileList.tsx
@@ -1,0 +1,136 @@
+import React, { useMemo } from 'react'
+import { c } from '../../theme.js'
+
+/**
+ * Lite-native port of upstream's
+ * `ui/examples/upstream-patterns/src/components/diff/DiffFileList.tsx`.
+ *
+ * Renders a scrollable list of files with their `+added / -removed`
+ * stats next to each row. A simple fixed-size scroll window (5 items by
+ * default) keeps the focused file roughly centred and shows "N more"
+ * hints above / below when the list overflows.
+ */
+
+export type DiffFile = {
+  path: string
+  linesAdded: number
+  linesRemoved: number
+  isBinary?: boolean
+  isLargeFile?: boolean
+  isTruncated?: boolean
+  isUntracked?: boolean
+  isNewFile?: boolean
+}
+
+type Props = {
+  files: DiffFile[]
+  selectedIndex: number
+  /** Max rows rendered before paginating (default 5, matches upstream). */
+  maxVisible?: number
+}
+
+function plural(n: number, word: string): string {
+  return n === 1 ? word : `${word}s`
+}
+
+function truncateStart(path: string, width: number): string {
+  if (path.length <= width) return path
+  return '\u2026' + path.slice(path.length - (width - 1))
+}
+
+export function DiffFileList({ files, selectedIndex, maxVisible = 5 }: Props) {
+  const { startIndex, endIndex } = useMemo(() => {
+    if (files.length === 0 || files.length <= maxVisible) {
+      return { startIndex: 0, endIndex: files.length }
+    }
+    let start = Math.max(0, selectedIndex - Math.floor(maxVisible / 2))
+    let end = start + maxVisible
+    if (end > files.length) {
+      end = files.length
+      start = Math.max(0, end - maxVisible)
+    }
+    return { startIndex: start, endIndex: end }
+  }, [files.length, selectedIndex, maxVisible])
+
+  if (files.length === 0) {
+    return <text fg={c.dim}>No changed files</text>
+  }
+
+  const visible = files.slice(startIndex, endIndex)
+  const hasMoreAbove = startIndex > 0
+  const hasMoreBelow = endIndex < files.length
+  const needsPagination = files.length > maxVisible
+
+  return (
+    <box flexDirection="column">
+      {needsPagination && (
+        <text fg={c.dim}>
+          {hasMoreAbove
+            ? ` \u2191 ${startIndex} more ${plural(startIndex, 'file')}`
+            : ' '}
+        </text>
+      )}
+      {visible.map((file, i) => {
+        const absIndex = startIndex + i
+        const isSelected = absIndex === selectedIndex
+        return (
+          <FileItem key={file.path} file={file} isSelected={isSelected} />
+        )
+      })}
+      {needsPagination && (
+        <text fg={c.dim}>
+          {hasMoreBelow
+            ? ` \u2193 ${files.length - endIndex} more ${plural(files.length - endIndex, 'file')}`
+            : ' '}
+        </text>
+      )}
+    </box>
+  )
+}
+
+function FileItem({ file, isSelected }: { file: DiffFile; isSelected: boolean }) {
+  const pointer = isSelected ? '\u276F ' : '  '
+  const displayPath = truncateStart(file.path, 60)
+
+  return (
+    <box flexDirection="row" justifyContent="space-between">
+      <text fg={isSelected ? c.bg : undefined} bg={isSelected ? c.textBright : undefined}>
+        {pointer}
+        {displayPath}
+      </text>
+      <FileStats file={file} isSelected={isSelected} />
+    </box>
+  )
+}
+
+function FileStats({ file, isSelected }: { file: DiffFile; isSelected: boolean }) {
+  if (file.isUntracked) {
+    return (
+      <em>
+        <text fg={isSelected ? undefined : c.dim}>untracked</text>
+      </em>
+    )
+  }
+  if (file.isBinary) {
+    return (
+      <em>
+        <text fg={isSelected ? undefined : c.dim}>Binary file</text>
+      </em>
+    )
+  }
+  if (file.isLargeFile) {
+    return (
+      <em>
+        <text fg={isSelected ? undefined : c.dim}>Large file modified</text>
+      </em>
+    )
+  }
+  return (
+    <text>
+      {file.linesAdded > 0 && <text fg={c.success}>+{file.linesAdded}</text>}
+      {file.linesAdded > 0 && file.linesRemoved > 0 && ' '}
+      {file.linesRemoved > 0 && <text fg={c.error}>-{file.linesRemoved}</text>}
+      {file.isTruncated && <text fg={c.dim}> (truncated)</text>}
+    </text>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds 55 new files across four functional folders that previously only existed under `ui/examples/upstream-patterns/`.
- Every upstream file is ported to OpenTUI primitives (`<box>`, `<text>`, `useKeyboard`, theme `c`) so the components compile against the Lite frontend runtime. Call sites can `import { Select } from './customselect'` or `import { AgentsMenu } from './agents'` and get a drop-in replacement for the upstream API.
- Upstream Ink-era dependencies (`chalk`, `figures`, `@anthropic/ink`, `@claude-code-best/builtin-tools`, on-disk file IO, API streaming) are lifted out into props so each component stays transport-agnostic and the Rust backend owns the heavy lifting.

## Folders added
**`design-system/` (16 files)**
`Byline`, `Dialog`, `Divider`, `FuzzyPicker`, `KeyboardShortcutHint`, `ListItem`, `LoadingState`, `Pane`, `ProgressBar`, `Ratchet`, `StatusIcon`, `Tabs`, `ThemeProvider`, `ThemedBox`, `ThemedText`, `color`. Upstream files were 1-line re-exports from `@anthropic/ink`; Lite-native implementations replace them.

**`customselect/` (10 files)**
Full `<Select>` + `<SelectMulti>` stack — `option-map`, `select-option`, `select-input-option`, plus the four hooks (`useSelectState`, `useSelectNavigation`, `useSelectInput`, `useMultiSelectState`). Keyboard wiring goes through `@opentui/react`'s `useKeyboard`. Rich upstream features (highlightText, paste-mode scroll hints, numeric prefixes) are intentionally omitted — can be layered in later when a caller needs them.

**`diff/` (3 files)**
`DiffFileList`, `DiffDetailView`, `DiffDialog`. Reuse the existing `StructuredDiff` hunk pipeline; `DiffDialog` accepts a pre-built `sources` array so the caller decides where diff data comes from (git, a turn snapshot, a fixture).

**`agents/` (26 files)**
- Core: `types.ts`, `utils.ts`, `validateAgent.ts`, `agentFileUtils.ts`, `generateAgent.ts`
- Components: `AgentsMenu`, `AgentsList`, `AgentDetail`, `AgentEditor`, `AgentNavigationFooter`, `ColorPicker`, `ModelSelector`, `ToolSelector`
- Wizard: `new-agent-creation/CreateAgentWizard.tsx` + 12 step files (`LocationStep`, `MethodStep`, `TypeStep`, `DescriptionStep`, `PromptStep`, `GenerateStep`, `ToolsStep`, `ModelStep`, `ColorStep`, `MemoryStep`, `ConfirmStep`, `ConfirmStepWrapper`)

## Design notes for reviewers
- `AgentsMenu` delegates create / update / delete to props so IPC wiring lives in the parent (upstream had the same structure but with `useSetAppState` mutations).
- `ToolSelector` takes the tool catalog as a prop instead of walking the backend's tool registry.
- `GenerateStep` is stream-ready: pass a `stream` + `onGenerate` pair and the component renders a live preview while the backend drafts the agent.
- `validateAgent` operates on the IPC `AgentDefinitionEntry` shape, not the upstream `AgentDefinition` class.
- Type-check: no new functional errors — only the pre-existing environmental `react` / `@opentui/*` declaration-file warnings that affect every `.tsx` file in the project.

## Test plan
- [ ] `bunx tsc --noEmit` inside `ui/` reports no *new* errors beyond the existing environmental ones
- [ ] `AgentsMenu`, `CreateAgentWizard`, `DiffDialog` render when wired into a host component
- [ ] `Select` / `SelectMulti` navigate with ↑/↓, commit with Enter, cancel with Esc
- [ ] `ColorPicker` preview row reflects the currently focused colour

🤖 Generated with [Claude Code](https://claude.com/claude-code)